### PR TITLE
feat: Tournament Prediction Completion Tracker (#42)

### DIFF
--- a/__tests__/components/tournament-prediction-status-bar.test.tsx
+++ b/__tests__/components/tournament-prediction-status-bar.test.tsx
@@ -1,0 +1,432 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { TournamentPredictionStatusBar } from '../../app/components/tournament-prediction-status-bar';
+import { TournamentPredictionCompletion } from '../../app/db/tables-definition';
+
+describe('TournamentPredictionStatusBar', () => {
+  const tournamentId = 'tournament-1';
+
+  const createCompletionData = (overrides?: Partial<TournamentPredictionCompletion>): TournamentPredictionCompletion => ({
+    finalStandings: {
+      completed: 0,
+      total: 3,
+      champion: false,
+      runnerUp: false,
+      thirdPlace: false,
+    },
+    awards: {
+      completed: 0,
+      total: 4,
+      bestPlayer: false,
+      topGoalscorer: false,
+      bestGoalkeeper: false,
+      bestYoungPlayer: false,
+    },
+    qualifiers: {
+      completed: 0,
+      total: 16,
+    },
+    overallCompleted: 0,
+    overallTotal: 23,
+    overallPercentage: 0,
+    isPredictionLocked: false,
+    ...overrides,
+  });
+
+  describe('Overall Progress Display', () => {
+    it('renders overall completion count and percentage', () => {
+      const completion = createCompletionData({
+        overallCompleted: 10,
+        overallTotal: 23,
+        overallPercentage: 43,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.getByText(/Predicciones Torneo: 10\/23 \(43%\)/)).toBeInTheDocument();
+    });
+
+    it('displays 0% for no predictions', () => {
+      const completion = createCompletionData();
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.getByText(/Predicciones Torneo: 0\/23 \(0%\)/)).toBeInTheDocument();
+    });
+
+    it('displays 100% for complete predictions', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 3,
+          total: 3,
+          champion: true,
+          runnerUp: true,
+          thirdPlace: true,
+        },
+        awards: {
+          completed: 4,
+          total: 4,
+          bestPlayer: true,
+          topGoalscorer: true,
+          bestGoalkeeper: true,
+          bestYoungPlayer: true,
+        },
+        qualifiers: {
+          completed: 16,
+          total: 16,
+        },
+        overallCompleted: 23,
+        overallTotal: 23,
+        overallPercentage: 100,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.getByText(/Predicciones Torneo: 23\/23 \(100%\)/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Category Status Display', () => {
+    it('renders all three categories with correct completion counts', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 2,
+          total: 3,
+          champion: true,
+          runnerUp: true,
+          thirdPlace: false,
+        },
+        awards: {
+          completed: 3,
+          total: 4,
+          bestPlayer: true,
+          topGoalscorer: true,
+          bestGoalkeeper: true,
+          bestYoungPlayer: false,
+        },
+        qualifiers: {
+          completed: 8,
+          total: 16,
+        },
+        overallCompleted: 13,
+        overallTotal: 23,
+        overallPercentage: 57,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.getByText('Podio')).toBeInTheDocument();
+      expect(screen.getByText(/2\/3 \(67%\)/)).toBeInTheDocument();
+
+      expect(screen.getByText('Premios Individuales')).toBeInTheDocument();
+      expect(screen.getByText(/3\/4 \(75%\)/)).toBeInTheDocument();
+
+      expect(screen.getByText('Clasificados')).toBeInTheDocument();
+      expect(screen.getByText(/8\/16 \(50%\)/)).toBeInTheDocument();
+    });
+
+    it('shows checkmark icon for completed categories', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 3,
+          total: 3,
+          champion: true,
+          runnerUp: true,
+          thirdPlace: true,
+        },
+        awards: {
+          completed: 0,
+          total: 4,
+          bestPlayer: false,
+          topGoalscorer: false,
+          bestGoalkeeper: false,
+          bestYoungPlayer: false,
+        },
+        qualifiers: {
+          completed: 0,
+          total: 16,
+        },
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      // CheckCircleIcon should be present for completed category
+      const icons = document.querySelectorAll('svg[data-testid="CheckCircleIcon"]');
+      expect(icons.length).toBeGreaterThan(0);
+    });
+
+    it('shows warning icon for incomplete categories', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 1,
+          total: 3,
+          champion: true,
+          runnerUp: false,
+          thirdPlace: false,
+        },
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      // WarningIcon should be present for incomplete categories
+      const icons = document.querySelectorAll('svg[data-testid="WarningIcon"]');
+      expect(icons.length).toBeGreaterThan(0);
+    });
+
+    it('hides qualifiers category when total is 0', () => {
+      const completion = createCompletionData({
+        qualifiers: {
+          completed: 0,
+          total: 0,
+        },
+        overallTotal: 7, // Only 3 + 4
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.getByText('Podio')).toBeInTheDocument();
+      expect(screen.getByText('Premios Individuales')).toBeInTheDocument();
+      expect(screen.queryByText('Clasificados')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Action Links', () => {
+    it('shows "Completar" button for incomplete categories when not locked', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 1,
+          total: 3,
+          champion: true,
+          runnerUp: false,
+          thirdPlace: false,
+        },
+        isPredictionLocked: false,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      const completarButtons = screen.getAllByText('Completar');
+      expect(completarButtons.length).toBeGreaterThan(0);
+    });
+
+    it('hides "Completar" button for completed categories', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 3,
+          total: 3,
+          champion: true,
+          runnerUp: true,
+          thirdPlace: true,
+        },
+        awards: {
+          completed: 0,
+          total: 4,
+          bestPlayer: false,
+          topGoalscorer: false,
+          bestGoalkeeper: false,
+          bestYoungPlayer: false,
+        },
+        qualifiers: {
+          completed: 0,
+          total: 16,
+        },
+        isPredictionLocked: false,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      // Should have 2 "Completar" buttons (awards and qualifiers), not 3
+      const completarButtons = screen.getAllByText('Completar');
+      expect(completarButtons).toHaveLength(2);
+    });
+
+    it('links to correct pages', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 0,
+          total: 3,
+          champion: false,
+          runnerUp: false,
+          thirdPlace: false,
+        },
+        awards: {
+          completed: 0,
+          total: 4,
+          bestPlayer: false,
+          topGoalscorer: false,
+          bestGoalkeeper: false,
+          bestYoungPlayer: false,
+        },
+        qualifiers: {
+          completed: 0,
+          total: 16,
+        },
+        isPredictionLocked: false,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      // Check for links
+      const links = screen.getAllByRole('link');
+
+      // Podio and Premios Individuales should link to awards page
+      const awardsLinks = links.filter(link =>
+        link.getAttribute('href') === `/tournaments/${tournamentId}/awards`
+      );
+      expect(awardsLinks).toHaveLength(2);
+
+      // Clasificados should link to playoffs page
+      const playoffsLinks = links.filter(link =>
+        link.getAttribute('href') === `/tournaments/${tournamentId}/playoffs`
+      );
+      expect(playoffsLinks).toHaveLength(1);
+    });
+  });
+
+  describe('Lock Status', () => {
+    it('shows "Cerrado" chip when predictions are locked', () => {
+      const completion = createCompletionData({
+        isPredictionLocked: true,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.getByText('Cerrado')).toBeInTheDocument();
+    });
+
+    it('hides "Cerrado" chip when predictions are not locked', () => {
+      const completion = createCompletionData({
+        isPredictionLocked: false,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.queryByText('Cerrado')).not.toBeInTheDocument();
+    });
+
+    it('shows lock icon for incomplete categories when locked', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 1,
+          total: 3,
+          champion: true,
+          runnerUp: false,
+          thirdPlace: false,
+        },
+        isPredictionLocked: true,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      // LockIcon should be present for incomplete categories when locked
+      const icons = document.querySelectorAll('svg[data-testid="LockIcon"]');
+      expect(icons.length).toBeGreaterThan(0);
+    });
+
+    it('hides "Completar" buttons when locked', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 1,
+          total: 3,
+          champion: true,
+          runnerUp: false,
+          thirdPlace: false,
+        },
+        isPredictionLocked: true,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.queryByText('Completar')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Alert Messages', () => {
+    it('shows warning alert when incomplete and not locked', () => {
+      const completion = createCompletionData({
+        overallPercentage: 50,
+        isPredictionLocked: false,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveTextContent(/Completa tus predicciones de torneo antes del cierre/);
+      expect(alert).toHaveClass('MuiAlert-standardWarning');
+    });
+
+    it('hides alert when predictions are complete', () => {
+      const completion = createCompletionData({
+        overallPercentage: 100,
+        isPredictionLocked: false,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('hides alert when predictions are locked', () => {
+      const completion = createCompletionData({
+        overallPercentage: 50,
+        isPredictionLocked: true,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles zero total predictions gracefully', () => {
+      const completion = createCompletionData({
+        finalStandings: { completed: 0, total: 3, champion: false, runnerUp: false, thirdPlace: false },
+        awards: { completed: 0, total: 4, bestPlayer: false, topGoalscorer: false, bestGoalkeeper: false, bestYoungPlayer: false },
+        qualifiers: { completed: 0, total: 0 },
+        overallCompleted: 0,
+        overallTotal: 7,
+        overallPercentage: 0,
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      expect(screen.getByText(/Predicciones Torneo: 0\/7 \(0%\)/)).toBeInTheDocument();
+    });
+
+    it('calculates percentages correctly for each category', () => {
+      const completion = createCompletionData({
+        finalStandings: {
+          completed: 1,
+          total: 3,
+          champion: true,
+          runnerUp: false,
+          thirdPlace: false,
+        },
+        awards: {
+          completed: 2,
+          total: 4,
+          bestPlayer: true,
+          topGoalscorer: true,
+          bestGoalkeeper: false,
+          bestYoungPlayer: false,
+        },
+        qualifiers: {
+          completed: 4,
+          total: 16,
+        },
+      });
+
+      render(<TournamentPredictionStatusBar completion={completion} tournamentId={tournamentId} />);
+
+      // Podio: 1/3 = 33%
+      expect(screen.getByText(/1\/3 \(33%\)/)).toBeInTheDocument();
+
+      // Awards: 2/4 = 50%
+      expect(screen.getByText(/2\/4 \(50%\)/)).toBeInTheDocument();
+
+      // Qualifiers: 4/16 = 25%
+      expect(screen.getByText(/4\/16 \(25%\)/)).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/db/tournament-prediction-completion-repository.test.ts
+++ b/__tests__/db/tournament-prediction-completion-repository.test.ts
@@ -1,0 +1,284 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { getTournamentPredictionCompletion } from '../../app/db/tournament-prediction-completion-repository';
+import { db } from '../../app/db/database';
+import { testFactories } from './test-factories';
+import { createMockSelectQuery } from './mock-helpers';
+import * as tournamentGuessRepository from '../../app/db/tournament-guess-repository';
+import * as tournamentActions from '../../app/actions/tournament-actions';
+
+// Mock the database
+vi.mock('../../app/db/database', () => ({
+  db: {
+    selectFrom: vi.fn(),
+  },
+}));
+
+// Mock tournament guess repository
+vi.mock('../../app/db/tournament-guess-repository', () => ({
+  findTournamentGuessByUserIdTournament: vi.fn(),
+}));
+
+// Mock tournament actions
+vi.mock('../../app/actions/tournament-actions', () => ({
+  getTournamentStartDate: vi.fn(),
+}));
+
+describe('Tournament Prediction Completion Repository', () => {
+  const mockDb = vi.mocked(db);
+  const mockFindTournamentGuess = vi.mocked(tournamentGuessRepository.findTournamentGuessByUserIdTournament);
+  const mockGetTournamentStartDate = vi.mocked(tournamentActions.getTournamentStartDate);
+
+  const userId = 'user-1';
+  const tournamentId = 'tournament-1';
+  const mockTournament = testFactories.tournament({ id: tournamentId });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getTournamentPredictionCompletion', () => {
+    it('should return 0% completion when user has no predictions', async () => {
+      // Mock: No tournament guesses
+      mockFindTournamentGuess.mockResolvedValue(undefined);
+
+      // Mock: 16 first_round games exist, but user has 0 guesses
+      let callCount = 0;
+      mockDb.selectFrom.mockImplementation((tableName: string) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: count total first_round games
+          return createMockSelectQuery({ count: 16 }) as any;
+        } else {
+          // Second call: count user's first_round guesses (0)
+          return createMockSelectQuery({ count: 0 }) as any;
+        }
+      });
+
+      // Mock: Tournament started 2 days ago (not locked)
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      mockGetTournamentStartDate.mockResolvedValue(twoDaysAgo);
+
+      const result = await getTournamentPredictionCompletion(userId, tournamentId, mockTournament);
+
+      expect(result.finalStandings.completed).toBe(0);
+      expect(result.finalStandings.total).toBe(3);
+      expect(result.awards.completed).toBe(0);
+      expect(result.awards.total).toBe(4);
+      expect(result.qualifiers.completed).toBe(0);
+      expect(result.qualifiers.total).toBe(16);
+      expect(result.overallCompleted).toBe(0);
+      expect(result.overallTotal).toBe(23); // 3 + 4 + 16
+      expect(result.overallPercentage).toBe(0);
+      expect(result.isPredictionLocked).toBe(false);
+    });
+
+    it('should calculate partial completion correctly', async () => {
+      // Mock: Tournament guesses with champion and best player only
+      const mockTournamentGuess = {
+        id: 'guess-1',
+        tournament_id: tournamentId,
+        user_id: userId,
+        champion_team_id: 'team-1',
+        runner_up_team_id: null,
+        third_place_team_id: null,
+        best_player_id: 'player-1',
+        top_goalscorer_player_id: undefined,
+        best_goalkeeper_player_id: undefined,
+        best_young_player_id: undefined,
+      };
+      mockFindTournamentGuess.mockResolvedValue(mockTournamentGuess);
+
+      // Mock: 16 first_round games, user predicted 8
+      let callCount = 0;
+      mockDb.selectFrom.mockImplementation((tableName: string) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: count total first_round games
+          return createMockSelectQuery({ count: 16 }) as any;
+        } else {
+          // Second call: count user's first_round guesses
+          return createMockSelectQuery({ count: 8 }) as any;
+        }
+      });
+
+      // Mock: Tournament started 2 days ago (not locked)
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      mockGetTournamentStartDate.mockResolvedValue(twoDaysAgo);
+
+      const result = await getTournamentPredictionCompletion(userId, tournamentId, mockTournament);
+
+      expect(result.finalStandings.completed).toBe(1); // Only champion
+      expect(result.finalStandings.champion).toBe(true);
+      expect(result.finalStandings.runnerUp).toBe(false);
+      expect(result.finalStandings.thirdPlace).toBe(false);
+
+      expect(result.awards.completed).toBe(1); // Only best player
+      expect(result.awards.bestPlayer).toBe(true);
+      expect(result.awards.topGoalscorer).toBe(false);
+      expect(result.awards.bestGoalkeeper).toBe(false);
+      expect(result.awards.bestYoungPlayer).toBe(false);
+
+      expect(result.qualifiers.completed).toBe(8);
+      expect(result.qualifiers.total).toBe(16);
+
+      expect(result.overallCompleted).toBe(10); // 1 + 1 + 8
+      expect(result.overallTotal).toBe(23); // 3 + 4 + 16
+      expect(result.overallPercentage).toBe(43); // Math.round(10/23 * 100)
+      expect(result.isPredictionLocked).toBe(false);
+    });
+
+    it('should return 100% completion when all predictions are made', async () => {
+      // Mock: Complete tournament guesses
+      const mockTournamentGuess = {
+        id: 'guess-1',
+        tournament_id: tournamentId,
+        user_id: userId,
+        champion_team_id: 'team-1',
+        runner_up_team_id: 'team-2',
+        third_place_team_id: 'team-3',
+        best_player_id: 'player-1',
+        top_goalscorer_player_id: 'player-2',
+        best_goalkeeper_player_id: 'player-3',
+        best_young_player_id: 'player-4',
+      };
+      mockFindTournamentGuess.mockResolvedValue(mockTournamentGuess);
+
+      // Mock: 16 first_round games, user predicted all 16
+      let callCount = 0;
+      mockDb.selectFrom.mockImplementation((tableName: string) => {
+        callCount++;
+        if (callCount === 1) {
+          return createMockSelectQuery({ count: 16 }) as any;
+        } else {
+          return createMockSelectQuery({ count: 16 }) as any;
+        }
+      });
+
+      // Mock: Tournament started 2 days ago (not locked)
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      mockGetTournamentStartDate.mockResolvedValue(twoDaysAgo);
+
+      const result = await getTournamentPredictionCompletion(userId, tournamentId, mockTournament);
+
+      expect(result.finalStandings.completed).toBe(3);
+      expect(result.awards.completed).toBe(4);
+      expect(result.qualifiers.completed).toBe(16);
+      expect(result.overallCompleted).toBe(23);
+      expect(result.overallTotal).toBe(23);
+      expect(result.overallPercentage).toBe(100);
+      expect(result.isPredictionLocked).toBe(false);
+    });
+
+    it('should mark predictions as locked after 5 days', async () => {
+      // Mock: Some tournament guesses
+      const mockTournamentGuess = {
+        id: 'guess-1',
+        tournament_id: tournamentId,
+        user_id: userId,
+        champion_team_id: 'team-1',
+        runner_up_team_id: null,
+        third_place_team_id: null,
+        best_player_id: undefined,
+        top_goalscorer_player_id: undefined,
+        best_goalkeeper_player_id: undefined,
+        best_young_player_id: undefined,
+      };
+      mockFindTournamentGuess.mockResolvedValue(mockTournamentGuess);
+
+      // Mock: 16 first_round games, no user guesses
+      let callCount = 0;
+      mockDb.selectFrom.mockImplementation((tableName: string) => {
+        callCount++;
+        if (callCount === 1) {
+          return createMockSelectQuery({ count: 16 }) as any;
+        } else {
+          return createMockSelectQuery({ count: 0 }) as any;
+        }
+      });
+
+      // Mock: Tournament started 6 days ago (LOCKED)
+      const sixDaysAgo = new Date(Date.now() - 6 * 24 * 60 * 60 * 1000);
+      mockGetTournamentStartDate.mockResolvedValue(sixDaysAgo);
+
+      const result = await getTournamentPredictionCompletion(userId, tournamentId, mockTournament);
+
+      expect(result.isPredictionLocked).toBe(true);
+      expect(result.overallPercentage).toBe(4); // 1/23 * 100 = 4.3... -> 4
+    });
+
+    it('should handle tournaments with no playoff games', async () => {
+      // Mock: Complete final standings and awards
+      const mockTournamentGuess = {
+        id: 'guess-1',
+        tournament_id: tournamentId,
+        user_id: userId,
+        champion_team_id: 'team-1',
+        runner_up_team_id: 'team-2',
+        third_place_team_id: 'team-3',
+        best_player_id: 'player-1',
+        top_goalscorer_player_id: 'player-2',
+        best_goalkeeper_player_id: 'player-3',
+        best_young_player_id: 'player-4',
+      };
+      mockFindTournamentGuess.mockResolvedValue(mockTournamentGuess);
+
+      // Mock: 0 first_round games (no playoffs)
+      let callCount = 0;
+      mockDb.selectFrom.mockImplementation((tableName: string) => {
+        callCount++;
+        return createMockSelectQuery({ count: 0 }) as any;
+      });
+
+      // Mock: Tournament started 2 days ago
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      mockGetTournamentStartDate.mockResolvedValue(twoDaysAgo);
+
+      const result = await getTournamentPredictionCompletion(userId, tournamentId, mockTournament);
+
+      expect(result.qualifiers.completed).toBe(0);
+      expect(result.qualifiers.total).toBe(0);
+      expect(result.overallCompleted).toBe(7); // 3 + 4 + 0
+      expect(result.overallTotal).toBe(7); // 3 + 4 + 0
+      expect(result.overallPercentage).toBe(100);
+    });
+
+    it('should correctly identify individual prediction statuses', async () => {
+      // Mock: Mixed predictions
+      const mockTournamentGuess = {
+        id: 'guess-1',
+        tournament_id: tournamentId,
+        user_id: userId,
+        champion_team_id: 'team-1',
+        runner_up_team_id: 'team-2',
+        third_place_team_id: null,
+        best_player_id: undefined,
+        top_goalscorer_player_id: 'player-2',
+        best_goalkeeper_player_id: 'player-3',
+        best_young_player_id: undefined,
+      };
+      mockFindTournamentGuess.mockResolvedValue(mockTournamentGuess);
+
+      // Mock: Games (doesn't matter for this test)
+      mockDb.selectFrom.mockReturnValue(createMockSelectQuery({ count: 0 }) as any);
+
+      // Mock: Tournament date
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+      mockGetTournamentStartDate.mockResolvedValue(twoDaysAgo);
+
+      const result = await getTournamentPredictionCompletion(userId, tournamentId, mockTournament);
+
+      // Final standings: champion (yes), runnerUp (yes), thirdPlace (no)
+      expect(result.finalStandings.champion).toBe(true);
+      expect(result.finalStandings.runnerUp).toBe(true);
+      expect(result.finalStandings.thirdPlace).toBe(false);
+      expect(result.finalStandings.completed).toBe(2);
+
+      // Awards: bestPlayer (no), topGoalscorer (yes), bestGoalkeeper (yes), bestYoungPlayer (no)
+      expect(result.awards.bestPlayer).toBe(false);
+      expect(result.awards.topGoalscorer).toBe(true);
+      expect(result.awards.bestGoalkeeper).toBe(true);
+      expect(result.awards.bestYoungPlayer).toBe(false);
+      expect(result.awards.completed).toBe(2);
+    });
+  });
+});

--- a/app/components/tournament-prediction-status-bar.tsx
+++ b/app/components/tournament-prediction-status-bar.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import React from 'react';
+import { Box, Card, Typography, LinearProgress, Alert, Chip } from '@mui/material';
+import Link from 'next/link';
+import { TournamentPredictionCompletion } from '../db/tables-definition';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import WarningIcon from '@mui/icons-material/Warning';
+import LockIcon from '@mui/icons-material/Lock';
+
+interface TournamentPredictionStatusBarProps {
+  readonly completion: TournamentPredictionCompletion;
+  readonly tournamentId: string;
+}
+
+interface CategoryStatusProps {
+  readonly title: string;
+  readonly completed: number;
+  readonly total: number;
+  readonly link: string;
+  readonly isLocked: boolean;
+}
+
+function CategoryStatus({ title, completed, total, link, isLocked }: CategoryStatusProps) {
+  const isComplete = completed === total;
+  const percentage = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        py: 0.5,
+        gap: 1,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1 }}>
+        {isComplete ? (
+          <CheckCircleIcon sx={{ color: 'success.main', fontSize: 20 }} />
+        ) : isLocked ? (
+          <LockIcon sx={{ color: 'text.disabled', fontSize: 20 }} />
+        ) : (
+          <WarningIcon sx={{ color: 'warning.main', fontSize: 20 }} />
+        )}
+        <Typography
+          variant="body2"
+          sx={{
+            color: isComplete ? 'success.main' : isLocked ? 'text.disabled' : 'text.primary',
+            fontWeight: isComplete ? 600 : 400,
+          }}
+        >
+          {title}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Typography
+          variant="body2"
+          sx={{
+            color: isComplete ? 'success.main' : 'text.secondary',
+            fontWeight: 500,
+            minWidth: '60px',
+            textAlign: 'right',
+          }}
+        >
+          {completed}/{total} ({percentage}%)
+        </Typography>
+        {!isComplete && !isLocked && (
+          <Link href={link} style={{ textDecoration: 'none' }}>
+            <Chip
+              label="Completar"
+              size="small"
+              clickable
+              sx={{
+                bgcolor: 'primary.main',
+                color: 'primary.contrastText',
+                '&:hover': {
+                  bgcolor: 'primary.dark',
+                },
+              }}
+            />
+          </Link>
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+export function TournamentPredictionStatusBar({
+  completion,
+  tournamentId,
+}: TournamentPredictionStatusBarProps) {
+  const { finalStandings, awards, qualifiers, overallCompleted, overallTotal, overallPercentage, isPredictionLocked } = completion;
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        p: 2,
+        mb: 2,
+      }}
+    >
+      {/* Overall Progress Section */}
+      <Box sx={{ mb: 2 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1, flexWrap: 'wrap' }}>
+          <Typography variant="body2" color="text.secondary" fontWeight="medium" sx={{ minWidth: '200px' }}>
+            Predicciones Torneo: {overallCompleted}/{overallTotal} ({overallPercentage}%)
+          </Typography>
+          {isPredictionLocked && (
+            <Chip
+              icon={<LockIcon />}
+              label="Cerrado"
+              size="small"
+              sx={{
+                bgcolor: 'grey.300',
+                color: 'text.secondary',
+              }}
+            />
+          )}
+        </Box>
+        <LinearProgress
+          variant="determinate"
+          value={overallPercentage}
+          sx={{
+            height: 8,
+            borderRadius: 4,
+            bgcolor: 'grey.200',
+            '& .MuiLinearProgress-bar': {
+              bgcolor: overallPercentage === 100 ? 'success.main' : 'primary.main',
+            },
+          }}
+        />
+      </Box>
+
+      {/* Category Details Section */}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        <CategoryStatus
+          title="Podio"
+          completed={finalStandings.completed}
+          total={finalStandings.total}
+          link={`/tournaments/${tournamentId}/awards`}
+          isLocked={isPredictionLocked}
+        />
+        <CategoryStatus
+          title="Premios Individuales"
+          completed={awards.completed}
+          total={awards.total}
+          link={`/tournaments/${tournamentId}/awards`}
+          isLocked={isPredictionLocked}
+        />
+        {qualifiers.total > 0 && (
+          <CategoryStatus
+            title="Clasificados"
+            completed={qualifiers.completed}
+            total={qualifiers.total}
+            link={`/tournaments/${tournamentId}/playoffs`}
+            isLocked={isPredictionLocked}
+          />
+        )}
+      </Box>
+
+      {/* Alert for incomplete predictions */}
+      {overallPercentage < 100 && !isPredictionLocked && (
+        <Alert severity="warning" sx={{ mt: 2, py: 0.5 }}>
+          Completa tus predicciones de torneo antes del cierre (5 días después del inicio)
+        </Alert>
+      )}
+    </Card>
+  );
+}

--- a/app/db/tables-definition.ts
+++ b/app/db/tables-definition.ts
@@ -350,3 +350,34 @@ export interface ProdeGroupTournamentBettingPaymentTable extends Identifiable {
 export type ProdeGroupTournamentBettingPayment = Selectable<ProdeGroupTournamentBettingPaymentTable>;
 export type ProdeGroupTournamentBettingPaymentNew = Insertable<ProdeGroupTournamentBettingPaymentTable>;
 export type ProdeGroupTournamentBettingPaymentUpdate = Updateable<ProdeGroupTournamentBettingPaymentTable>;
+
+// Tournament prediction completion status
+export interface TournamentPredictionCompletion {
+  // Final standings (3 items: champion, runner-up, third place)
+  finalStandings: {
+    completed: number;
+    total: number;
+    champion: boolean;
+    runnerUp: boolean;
+    thirdPlace: boolean;
+  };
+  // Individual awards (4 items: best player, top goalscorer, best goalkeeper, best young player)
+  awards: {
+    completed: number;
+    total: number;
+    bestPlayer: boolean;
+    topGoalscorer: boolean;
+    bestGoalkeeper: boolean;
+    bestYoungPlayer: boolean;
+  };
+  // Qualifiers (dynamic count based on playoff bracket)
+  qualifiers: {
+    completed: number;
+    total: number;
+  };
+  // Overall
+  overallCompleted: number;
+  overallTotal: number;
+  overallPercentage: number;
+  isPredictionLocked: boolean;
+}

--- a/app/db/tournament-prediction-completion-repository.ts
+++ b/app/db/tournament-prediction-completion-repository.ts
@@ -1,0 +1,105 @@
+import { db } from "./database";
+import { TournamentPredictionCompletion, Tournament } from "./tables-definition";
+import { findTournamentGuessByUserIdTournament } from "./tournament-guess-repository";
+import { getTournamentStartDate } from "../actions/tournament-actions";
+
+/**
+ * Get tournament prediction completion status for a user
+ * Tracks completion across 3 categories: final standings, awards, and qualifiers
+ */
+export async function getTournamentPredictionCompletion(
+  userId: string,
+  tournamentId: string,
+  tournament: Tournament
+): Promise<TournamentPredictionCompletion> {
+  // Fetch user's tournament guesses
+  const tournamentGuesses = await findTournamentGuessByUserIdTournament(userId, tournamentId);
+
+  // Calculate final standings completion (champion, runner-up, third place)
+  const champion = !!tournamentGuesses?.champion_team_id;
+  const runnerUp = !!tournamentGuesses?.runner_up_team_id;
+  const thirdPlace = !!tournamentGuesses?.third_place_team_id;
+
+  // Only count third place if it's not null in the tournament definition
+  // (some tournaments don't have third place games)
+  const finalStandingsTotal = 3;
+  const finalStandingsCompleted =
+    (champion ? 1 : 0) +
+    (runnerUp ? 1 : 0) +
+    (thirdPlace ? 1 : 0);
+
+  // Calculate awards completion (4 individual awards)
+  const bestPlayer = !!tournamentGuesses?.best_player_id;
+  const topGoalscorer = !!tournamentGuesses?.top_goalscorer_player_id;
+  const bestGoalkeeper = !!tournamentGuesses?.best_goalkeeper_player_id;
+  const bestYoungPlayer = !!tournamentGuesses?.best_young_player_id;
+
+  const awardsTotal = 4;
+  const awardsCompleted =
+    (bestPlayer ? 1 : 0) +
+    (topGoalscorer ? 1 : 0) +
+    (bestGoalkeeper ? 1 : 0) +
+    (bestYoungPlayer ? 1 : 0);
+
+  // Calculate qualifiers completion (based on first_round game guesses)
+  // Count total first_round games
+  const totalFirstRoundGames = await db
+    .selectFrom('games')
+    .select(eb => eb.fn.countAll<number>().as('count'))
+    .where('tournament_id', '=', tournamentId)
+    .where('game_type', '=', 'first_round')
+    .executeTakeFirst();
+
+  const qualifiersTotal = Number(totalFirstRoundGames?.count ?? 0);
+
+  // Count user's first_round game guesses
+  const userFirstRoundGuesses = await db
+    .selectFrom('game_guesses')
+    .innerJoin('games', 'games.id', 'game_guesses.game_id')
+    .select(eb => eb.fn.countAll<number>().as('count'))
+    .where('games.tournament_id', '=', tournamentId)
+    .where('games.game_type', '=', 'first_round')
+    .where('game_guesses.user_id', '=', userId)
+    .where('game_guesses.home_team', 'is not', null)
+    .where('game_guesses.away_team', 'is not', null)
+    .executeTakeFirst();
+
+  const qualifiersCompleted = Number(userFirstRoundGuesses?.count ?? 0);
+
+  // Calculate overall completion
+  const overallTotal = finalStandingsTotal + awardsTotal + qualifiersTotal;
+  const overallCompleted = finalStandingsCompleted + awardsCompleted + qualifiersCompleted;
+  const overallPercentage = overallTotal > 0 ? Math.round((overallCompleted / overallTotal) * 100) : 0;
+
+  // Check if predictions are locked (5 days after tournament start)
+  const tournamentStartDate = await getTournamentStartDate(tournamentId);
+  const FIVE_DAYS_MS = 5 * 24 * 60 * 60 * 1000;
+  const currentTime = new Date();
+  const isPredictionLocked = (currentTime.getTime() - tournamentStartDate.getTime()) >= FIVE_DAYS_MS;
+
+  return {
+    finalStandings: {
+      completed: finalStandingsCompleted,
+      total: finalStandingsTotal,
+      champion,
+      runnerUp,
+      thirdPlace,
+    },
+    awards: {
+      completed: awardsCompleted,
+      total: awardsTotal,
+      bestPlayer,
+      topGoalscorer,
+      bestGoalkeeper,
+      bestYoungPlayer,
+    },
+    qualifiers: {
+      completed: qualifiersCompleted,
+      total: qualifiersTotal,
+    },
+    overallCompleted,
+    overallTotal,
+    overallPercentage,
+    isPredictionLocked,
+  };
+}

--- a/app/tournaments/[id]/page.tsx
+++ b/app/tournaments/[id]/page.tsx
@@ -14,6 +14,8 @@ import {findTournamentGuessByUserIdTournament} from "../../db/tournament-guess-r
 import {unstable_ViewTransition as ViewTransition} from "react";
 import {findTournamentById} from "../../db/tournament-repository";
 import {PredictionStatusBar} from "../../components/prediction-status-bar";
+import {TournamentPredictionStatusBar} from "../../components/tournament-prediction-status-bar";
+import {getTournamentPredictionCompletion} from "../../db/tournament-prediction-completion-repository";
 import type {ScoringConfig} from "../../components/tournament-page/rules";
 
 type Props = {
@@ -46,6 +48,11 @@ export default async function TournamentLandingPage(props: Props) {
 
   // Server Component pattern: import repository directly and extract scoring config
   const tournament = await findTournamentById(tournamentId);
+
+  // Fetch tournament prediction completion status
+  const tournamentPredictionCompletion = user && tournament ?
+    await getTournamentPredictionCompletion(user.id, tournamentId, tournament) :
+    null;
   const scoringConfig: ScoringConfig | undefined = tournament ? {
     game_exact_score_points: tournament.game_exact_score_points ?? 2,
     game_correct_outcome_points: tournament.game_correct_outcome_points ?? 1,
@@ -83,6 +90,12 @@ export default async function TournamentLandingPage(props: Props) {
                 urgentGames={dashboardStats.urgentGames}
                 warningGames={dashboardStats.warningGames}
                 noticeGames={dashboardStats.noticeGames}
+              />
+            )}
+            {user && tournamentPredictionCompletion && (
+              <TournamentPredictionStatusBar
+                completion={tournamentPredictionCompletion}
+                tournamentId={tournamentId}
               />
             )}
             <Fixtures games={gamesAroundMyTime} teamsMap={teamsMap}/>


### PR DESCRIPTION
## Summary
Implements tournament-level prediction tracking to help users identify incomplete predictions across three categories: final standings (podium), individual awards, and playoff qualifiers.

This addresses story #42 [UXI-025] from Sprint 7-9: Engagement & Gamification.

## Features
- New `TournamentPredictionStatusBar` component following UXI-002 (PredictionStatusBar) pattern
- Displays overall completion percentage with visual progress bar
- Shows completion status for each category with intuitive indicators:
  - ✓ Green checkmark for completed categories
  - ⚠ Orange warning for incomplete categories
  - 🔒 Gray lock icon when predictions are closed
- Provides direct navigation links to incomplete prediction sections
- Respects prediction lock status (5 days after tournament start)
- Alert warning for incomplete predictions when unlocked

## Implementation Details
- **Type Definition**: Added `TournamentPredictionCompletion` interface to `tables-definition.ts`
- **Repository**: Created `getTournamentPredictionCompletion()` function that queries tournament_guesses and game_guesses to calculate completion across:
  - Final standings (3 items): champion, runner-up, third place
  - Individual awards (4 items): best player, top goalscorer, best goalkeeper, best young player
  - Qualifiers (dynamic count based on first_round playoff games)
- **Component**: Built client component with MUI Card, LinearProgress, and category sections
- **Integration**: Added to tournament landing page below existing PredictionStatusBar
- **Tests**: Comprehensive unit tests for both repository (6 tests) and component (19 tests)

## Test Plan
- [x] Unit tests pass (25 tests)
- [x] Linting passes
- [ ] Visual verification on preview deployment
- [ ] Test with 0% completion (no predictions)
- [ ] Test with partial completion (mixed predictions)
- [ ] Test with 100% completion (all predictions)
- [ ] Test locked state (5+ days after tournament start)
- [ ] Test navigation links to /awards and /playoffs pages
- [ ] Verify responsive design on mobile

## Screenshots
_Will add after preview deployment verification_

🤖 Generated with [Claude Code](https://claude.com/claude-code)