### PR TITLE
[UX] Friend Group Admin — Replace scrolling page with sub-tabs #248

### DIFF
--- a/__tests__/components/friend-groups/admin-section-tabs.test.tsx
+++ b/__tests__/components/friend-groups/admin-section-tabs.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import AdminSectionTabs from '../../../app/components/friend-groups/admin-section-tabs';
+import { renderWithTheme } from '../../utils/test-utils';
+import { testFactories } from '../../db/test-factories';
+
+// Mock sub-components to keep tests focused on tab logic
+vi.mock('@/app/components/friend-groups/join-request-manager', () => ({
+  default: () => <div data-testid="join-request-manager" />,
+}));
+
+vi.mock('@/app/components/friend-groups/group-privacy-settings', () => ({
+  default: () => <div data-testid="group-privacy-settings" />,
+}));
+
+vi.mock('@/app/components/friend-groups/group-tournament-betting-admin', () => ({
+  default: () => <div data-testid="group-tournament-betting-admin" />,
+}));
+
+vi.mock('@/app/components/friend-groups/friend-groups-themer', () => ({
+  default: () => <div data-testid="friend-groups-themer" />,
+}));
+
+const defaultGroup = testFactories.prodeGroup();
+
+const defaultProps = {
+  groupId: 'group-1',
+  initialRequests: [],
+  locale: 'es' as const,
+  tournamentId: 'tournament-1',
+  groupName: 'Test Group',
+  initialIsPublic: false,
+  initialDescription: null,
+  isAdmin: true,
+  members: [],
+  config: null,
+  payments: [],
+  group: defaultGroup,
+  pendingRequestCount: 0,
+};
+
+describe('AdminSectionTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Tab rendering', () => {
+    it('renders all 4 tabs with role="tab"', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} />);
+
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs).toHaveLength(4);
+    });
+
+    it('renders tab list with aria-label="admin section tabs"', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} />);
+
+      expect(screen.getByRole('tablist', { name: 'admin section tabs' })).toBeInTheDocument();
+    });
+
+    it('renders all 4 tab labels in Spanish', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} />);
+
+      expect(screen.getByRole('tab', { name: /Solicitudes/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Privacidad/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Apuestas/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Personalizar/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Default tab logic', () => {
+    it('defaults to privacy tab when pendingRequestCount is 0', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={0} />);
+
+      const privacyTab = screen.getByRole('tab', { name: /Privacidad/i });
+      expect(privacyTab).toHaveAttribute('aria-selected', 'true');
+
+      const requestsTab = screen.getByRole('tab', { name: /Solicitudes/i });
+      expect(requestsTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('defaults to requests tab when pendingRequestCount > 0', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={3} />);
+
+      const requestsTab = screen.getByRole('tab', { name: /Solicitudes/i });
+      expect(requestsTab).toHaveAttribute('aria-selected', 'true');
+
+      const privacyTab = screen.getByRole('tab', { name: /Privacidad/i });
+      expect(privacyTab).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('defaults to requests tab when pendingRequestCount is 1', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={1} />);
+
+      const requestsTab = screen.getByRole('tab', { name: /Solicitudes/i });
+      expect(requestsTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('Tab switching', () => {
+    it('clicking requests tab makes it active', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={0} />);
+
+      // Default is privacy; click requests
+      const requestsTab = screen.getByRole('tab', { name: /Solicitudes/i });
+      fireEvent.click(requestsTab);
+
+      expect(requestsTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('clicking betting tab makes it active', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} />);
+
+      const bettingTab = screen.getByRole('tab', { name: /Apuestas/i });
+      fireEvent.click(bettingTab);
+
+      expect(bettingTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('clicking customize tab makes it active', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} />);
+
+      const customizeTab = screen.getByRole('tab', { name: /Personalizar/i });
+      fireEvent.click(customizeTab);
+
+      expect(customizeTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('clicking privacy tab makes it active', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={3} />);
+
+      // Default is requests; click privacy
+      const privacyTab = screen.getByRole('tab', { name: /Privacidad/i });
+      fireEvent.click(privacyTab);
+
+      expect(privacyTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('Content rendering per tab', () => {
+    it('shows GroupPrivacySettings content on the privacy tab (default when no pending requests)', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={0} />);
+
+      expect(screen.getByTestId('group-privacy-settings')).toBeVisible();
+    });
+
+    it('shows JoinRequestManager content on the requests tab (default when pending requests > 0)', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={2} />);
+
+      expect(screen.getByTestId('join-request-manager')).toBeVisible();
+    });
+
+    it('shows GroupTournamentBettingAdmin content after clicking betting tab', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('tab', { name: /Apuestas/i }));
+
+      expect(screen.getByTestId('group-tournament-betting-admin')).toBeVisible();
+    });
+
+    it('shows ProdeGroupThemer content after clicking customize tab', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole('tab', { name: /Personalizar/i }));
+
+      expect(screen.getByTestId('friend-groups-themer')).toBeVisible();
+    });
+
+    it('shows JoinRequestManager content after clicking requests tab', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={0} />);
+
+      fireEvent.click(screen.getByRole('tab', { name: /Solicitudes/i }));
+
+      expect(screen.getByTestId('join-request-manager')).toBeVisible();
+    });
+  });
+
+  describe('Badge on Requests tab', () => {
+    it('shows badge count when pendingRequestCount > 0', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={3} />);
+
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('badge is invisible when pendingRequestCount is 0', () => {
+      const { container } = renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={0} />);
+
+      const badge = container.querySelector('.MuiBadge-badge');
+      expect(badge).toHaveClass('MuiBadge-invisible');
+    });
+
+    it('shows badge with max 99 when pendingRequestCount exceeds 99', () => {
+      renderWithTheme(<AdminSectionTabs {...defaultProps} pendingRequestCount={150} />);
+
+      expect(screen.getByText('99+')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx
+++ b/app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx
@@ -12,7 +12,6 @@ import JoinMessage from "../../../../../components/friend-groups/friend-groups-j
 import {findUsersByIds} from "../../../../../db/users-repository";
 import ProdeGroupTable from "../../../../../components/friend-groups/friends-group-table";
 import {getLoggedInUser} from "../../../../../actions/user-actions";
-import ProdeGroupThemer from "../../../../../components/friend-groups/friend-groups-themer";
 import {findTournamentById} from "../../../../../db/tournament-repository";
 import { toMap} from "../../../../../utils/ObjectUtils";
 import {InviteFriendsDialogButton} from "../../../../../components/friend-groups/invite-friends-dialog-button";
@@ -23,10 +22,8 @@ import { getUserScoresForTournament } from "../../../../../actions/prode-group-a
 import { getGroupJoinRequests, getPendingRequestCount } from "../../../../../actions/prode-group-join-request-actions";
 import PendingRequestView from "../../../../../components/friend-groups/pending-request-view";
 import AdminTabs from "../../../../../components/friend-groups/admin-tabs";
-import JoinRequestManager from "../../../../../components/friend-groups/join-request-manager";
-import GroupTournamentBettingAdmin from "../../../../../components/friend-groups/group-tournament-betting-admin";
 import PrivacyIndicatorIcon from "../../../../../components/friend-groups/privacy-indicator-icon";
-import GroupPrivacySettings from "../../../../../components/friend-groups/group-privacy-settings";
+import AdminSectionTabs from "../../../../../components/friend-groups/admin-section-tabs";
 
 type Props = {
   readonly params: Promise<{
@@ -221,44 +218,21 @@ export default async function TournamentScopedFriendGroup(props : Props){
               />
             }
             adminContent={
-              <Box>
-                {/* Section 1: Privacy Settings */}
-                <Box sx={{ mb: 3 }}>
-                  <GroupPrivacySettings
-                    groupId={prodeGroup.id}
-                    groupName={prodeGroup.name}
-                    initialIsPublic={prodeGroup.is_public ?? false}
-                    initialDescription={prodeGroup.description ?? null}
-                  />
-                </Box>
-
-                {/* Section 2: Join Requests */}
-                <Box sx={{ mb: 3 }}>
-                  <JoinRequestManager
-                    groupId={prodeGroup.id}
-                    initialRequests={joinRequests}
-                    locale={params.locale as 'en' | 'es'}
-                    tournamentId={tournament.id}
-                  />
-                </Box>
-
-                {/* Section 3: Betting Configuration */}
-                <Box sx={{ mb: 3 }}>
-                  <GroupTournamentBettingAdmin
-                    groupId={prodeGroup.id}
-                    tournamentId={tournament.id}
-                    isAdmin={isAdmin}
-                    members={members}
-                    config={config ?? null}
-                    payments={payments}
-                  />
-                </Box>
-
-                {/* Section 4: Theme Customization */}
-                <Box>
-                  <ProdeGroupThemer group={prodeGroup} />
-                </Box>
-              </Box>
+              <AdminSectionTabs
+                groupId={prodeGroup.id}
+                initialRequests={joinRequests}
+                locale={params.locale as 'en' | 'es'}
+                tournamentId={tournament.id}
+                groupName={prodeGroup.name}
+                initialIsPublic={prodeGroup.is_public ?? false}
+                initialDescription={prodeGroup.description ?? null}
+                isAdmin={isAdmin}
+                members={members}
+                config={config ?? null}
+                payments={payments}
+                group={prodeGroup}
+                pendingRequestCount={pendingRequestCount}
+              />
             }
           />
         </Grid>

--- a/app/components/friend-groups/admin-section-tabs.tsx
+++ b/app/components/friend-groups/admin-section-tabs.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Box, Tab, Badge } from '@mui/material';
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { useTranslations } from 'next-intl';
+import {
+  PersonAdd as PersonAddIcon,
+  Lock as LockIcon,
+  Casino as CasinoIcon,
+  Palette as PaletteIcon,
+} from '@mui/icons-material';
+import { Locale } from '@/i18n.config';
+import { ProdeGroup, ProdeGroupTournamentBetting, ProdeGroupTournamentBettingPayment } from '../../db/tables-definition';
+import JoinRequestManager from './join-request-manager';
+import GroupPrivacySettings from './group-privacy-settings';
+import GroupTournamentBettingAdmin from './group-tournament-betting-admin';
+import ProdeGroupThemer from './friend-groups-themer';
+
+interface JoinRequest {
+  id: string;
+  user_id: string;
+  user_nickname?: string | null;
+  user_email?: string | null;
+  requested_at: Date;
+  request_source: string;
+  status: string;
+  message?: string | null;
+}
+
+type AdminSectionTabValue = 'requests' | 'privacy' | 'betting' | 'customize';
+
+type Props = {
+  // JoinRequestManager
+  groupId: string;
+  initialRequests: JoinRequest[];
+  locale: Locale;
+  tournamentId: string;
+  // GroupPrivacySettings
+  groupName: string;
+  initialIsPublic: boolean;
+  initialDescription: string | null;
+  // GroupTournamentBettingAdmin
+  isAdmin: boolean;
+  members: { id: string; nombre: string }[];
+  config: ProdeGroupTournamentBetting | null;
+  payments: ProdeGroupTournamentBettingPayment[];
+  // ProdeGroupThemer
+  group: ProdeGroup;
+  // Tab logic
+  pendingRequestCount: number;
+};
+
+export default function AdminSectionTabs({
+  groupId,
+  initialRequests,
+  locale,
+  tournamentId,
+  groupName,
+  initialIsPublic,
+  initialDescription,
+  isAdmin,
+  members,
+  config,
+  payments,
+  group,
+  pendingRequestCount,
+}: Readonly<Props>) {
+  const t = useTranslations('groups.adminSectionTabs');
+
+  const initialTab: AdminSectionTabValue = pendingRequestCount > 0 ? 'requests' : 'privacy';
+  const [value, setValue] = useState<AdminSectionTabValue>(initialTab);
+
+  const handleChange = (_event: React.SyntheticEvent, newValue: AdminSectionTabValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Box sx={{ width: '100%', typography: 'body1' }}>
+      <TabContext value={value}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <TabList
+            onChange={handleChange}
+            aria-label="admin section tabs"
+            variant="scrollable"
+            scrollButtons="auto"
+          >
+            <Tab
+              icon={
+                <Badge badgeContent={pendingRequestCount} color="error" max={99}>
+                  <PersonAddIcon />
+                </Badge>
+              }
+              iconPosition="start"
+              label={t('requests')}
+              value="requests"
+            />
+            <Tab
+              icon={<LockIcon />}
+              iconPosition="start"
+              label={t('privacy')}
+              value="privacy"
+            />
+            <Tab
+              icon={<CasinoIcon />}
+              iconPosition="start"
+              label={t('betting')}
+              value="betting"
+            />
+            <Tab
+              icon={<PaletteIcon />}
+              iconPosition="start"
+              label={t('customize')}
+              value="customize"
+            />
+          </TabList>
+        </Box>
+        <TabPanel value="requests" sx={{ px: 0 }}>
+          <JoinRequestManager
+            groupId={groupId}
+            initialRequests={initialRequests}
+            locale={locale}
+            tournamentId={tournamentId}
+          />
+        </TabPanel>
+        <TabPanel value="privacy" sx={{ px: 0 }}>
+          <GroupPrivacySettings
+            groupId={groupId}
+            groupName={groupName}
+            initialIsPublic={initialIsPublic}
+            initialDescription={initialDescription}
+          />
+        </TabPanel>
+        <TabPanel value="betting" sx={{ px: 0 }}>
+          <GroupTournamentBettingAdmin
+            groupId={groupId}
+            tournamentId={tournamentId}
+            isAdmin={isAdmin}
+            members={members}
+            config={config}
+            payments={payments}
+          />
+        </TabPanel>
+        <TabPanel value="customize" sx={{ px: 0 }}>
+          <ProdeGroupThemer group={group} />
+        </TabPanel>
+      </TabContext>
+    </Box>
+  );
+}

--- a/locales/en/groups.json
+++ b/locales/en/groups.json
@@ -219,6 +219,12 @@
     "leaderboard": "Leaderboard",
     "admin": "Admin"
   },
+  "adminSectionTabs": {
+    "requests": "Requests",
+    "privacy": "Privacy",
+    "betting": "Betting",
+    "customize": "Customize"
+  },
   "joinRequest": {
     "preview": "Group Preview",
     "members": "{count, plural, =1 {1 member} other {# members}}",

--- a/locales/es/groups.json
+++ b/locales/es/groups.json
@@ -219,6 +219,12 @@
     "leaderboard": "Tabla de Posiciones",
     "admin": "Administración"
   },
+  "adminSectionTabs": {
+    "requests": "Solicitudes",
+    "privacy": "Privacidad",
+    "betting": "Apuestas",
+    "customize": "Personalizar"
+  },
   "joinRequest": {
     "preview": "Vista Previa del Grupo",
     "members": "{count, plural, =1 {1 miembro} other {# miembros}}",


### PR DESCRIPTION
## Summary

- Add `AdminSectionTabs` component with 4 sub-tabs (Requests, Privacy, Betting, Customize) inside the Admin tab panel
- Replace the vertically-stacked admin sections with tab-based navigation to eliminate scrolling on mobile
- Default tab is Requests when pending requests exist, Privacy otherwise; badge mirrors the outer Admin tab count

## Changes

- **New**: `app/components/friend-groups/admin-section-tabs.tsx` — inner tab component with MUI TabContext, scrollable on mobile, pure in-memory state
- **Modified**: `app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx` — swap stacked Box for `<AdminSectionTabs>`, clean up individual imports
- **Modified**: `locales/en/groups.json` + `locales/es/groups.json` — add `adminSectionTabs` translation block
- **New**: `__tests__/components/friend-groups/admin-section-tabs.test.tsx` — 18 unit tests covering tab logic, badge, content rendering

## Test plan

- [ ] All 18 new unit tests pass (`npm test`)
- [ ] Full test suite passes (5448 tests, 290 files)
- [ ] No ESLint errors (`npm run lint`)
- [ ] Build passes (`npm run build`)
- [ ] Vercel Preview: navigate to a tournament friend group as admin — verify 4 sub-tabs render
- [ ] Default tab is Requests when pending requests > 0, Privacy when 0
- [ ] Clicking each sub-tab shows only that section's content
- [ ] Mobile: tabs scroll horizontally without wrapping
- [ ] Badge count on Requests tab matches the outer Admin tab badge

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)