### PR TITLE
[Bug] Backoffice Game Card: Prevent card flip on draft/publish and boost click

### DIFF
--- a/app/components/compact-game-view-card.tsx
+++ b/app/components/compact-game-view-card.tsx
@@ -209,6 +209,7 @@ export default function CompactGameViewCard({
                         icon={<TrophyIcon sx={{ fontSize: 14 }} />}
                         label={boostType === 'golden' ? '3x' : '2x'}
                         size="small"
+                        onClick={(e) => e.stopPropagation()}
                         sx={{
                           height: '20px',
                           backgroundColor: boostType === 'golden' ? alpha(theme.palette.accent.gold.main, 0.2) : alpha(theme.palette.accent.silver.main, 0.2),
@@ -255,6 +256,7 @@ export default function CompactGameViewCard({
                         checkedIcon={publishing? <CircularProgress size={24} color={'secondary'}/> :<SaveIcon />}
                         disabled={publishing}
                         onChange={handleDraftChange}
+                        onClick={(e) => e.stopPropagation()}
                       />
                     </Tooltip>
                   )}


### PR DESCRIPTION
## Summary
- Add `onClick={(e) => e.stopPropagation()}` to the draft/publish `Checkbox` so clicking it no longer triggers the card flip
- Add `onClick={(e) => e.stopPropagation()}` to the boost `Chip` (tooltip trigger) for the same reason
- Follows the same pattern already used for the time toggle in `GameCountdownDisplay`

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)