### PR TITLE
Plan: [Story] Add location data to tournaments for SportsEvent structured data #310

### DIFF
--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -499,4 +499,13 @@ Key flows:
     GET /robots.txt → app/robots.ts
       → returns MetadataRoute.Robots (static, no DB calls)
          disallows: /*/backoffice, /*/delete-account, /*/verify-email, /*/reset-password, /api/
+
+24. Tournament location management (Story #310)
+    TournamentMainDataTab [Client] → createOrUpdateTournament [server action]
+      ├── parseFormData (extracts locations[] from FormData 'locations' key)
+      └── prepareTournamentData → saveOrUpdateTournament → updateTournament / createTournament
+          (locations flows as part of tournamentData payload)
+
+    getTournamentLocations [server action] (read path for story #303 JSON-LD use)
+      └── findTournamentById → returns tournament.locations ?? []
 ```

--- a/__tests__/actions/tournament-actions.test.ts
+++ b/__tests__/actions/tournament-actions.test.ts
@@ -633,6 +633,7 @@ describe('Tournament Actions', () => {
 
       expect(mockCreateTournament).toHaveBeenCalledWith({
         ...mockTournamentData,
+        locations: '[]',
         theme: JSON.stringify({
           primary_color: '#ff0000',
           logo: undefined,
@@ -652,6 +653,7 @@ describe('Tournament Actions', () => {
       expect(mockFindTournamentById).toHaveBeenCalledWith('tournament1');
       expect(mockUpdateTournament).toHaveBeenCalledWith('tournament1', {
         ...mockTournamentData,
+        locations: '[]',
         theme: JSON.stringify({
           primary_color: '#ff0000',
           secondary_color: '#00ff00',
@@ -701,6 +703,7 @@ describe('Tournament Actions', () => {
       expect(mockS3Client.uploadFile).toHaveBeenCalled();
       expect(mockCreateTournament).toHaveBeenCalledWith({
         ...mockTournamentData,
+        locations: '[]',
         theme: JSON.stringify({
           primary_color: '#ff0000',
           logo: 'https://s3.example.com/new-logo.png',
@@ -726,6 +729,7 @@ describe('Tournament Actions', () => {
       expect(mockS3Client.deleteFile).toHaveBeenCalledWith('logos/logo.png');
       expect(mockUpdateTournament).toHaveBeenCalledWith('tournament1', {
         ...mockTournamentData,
+        locations: '[]',
         theme: JSON.stringify({
           primary_color: '#ff0000',
           secondary_color: '#00ff00',

--- a/__tests__/db/test-factories.ts
+++ b/__tests__/db/test-factories.ts
@@ -108,6 +108,7 @@ export const testFactories = {
     exact_position_qualified_points: 1,
     max_silver_games: 5,
     max_golden_games: 3,
+    locations: [],
     ...overrides,
   }),
 

--- a/app/actions/__tests__/tournament-location-actions.test.ts
+++ b/app/actions/__tests__/tournament-location-actions.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getTournamentLocations } from '../tournament-actions';
+import * as tournamentRepository from '@/app/db/tournament-repository';
+import { testFactories } from '../../../__tests__/db/test-factories';
+
+vi.mock('@/app/db/tournament-repository', () => ({
+  findTournamentById: vi.fn(),
+  findAllTournaments: vi.fn(),
+  findAllActiveTournaments: vi.fn(),
+  findPastTournaments: vi.fn(),
+  updateTournament: vi.fn(),
+  createTournament: vi.fn(),
+}));
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(),
+  getLocale: vi.fn().mockResolvedValue('en'),
+}));
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(),
+}));
+
+describe('getTournamentLocations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns empty array when tournament has no locations', async () => {
+    vi.mocked(tournamentRepository.findTournamentById).mockResolvedValue(
+      testFactories.tournament({ locations: [] })
+    );
+
+    const result = await getTournamentLocations('tournament-1');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns array of location strings for tournament with locations', async () => {
+    vi.mocked(tournamentRepository.findTournamentById).mockResolvedValue(
+      testFactories.tournament({ locations: ['Qatar', 'Lusail', 'Al Rayyan'] })
+    );
+
+    const result = await getTournamentLocations('tournament-1');
+
+    expect(result).toEqual(['Qatar', 'Lusail', 'Al Rayyan']);
+  });
+
+  it('returns empty array when tournament is not found', async () => {
+    vi.mocked(tournamentRepository.findTournamentById).mockResolvedValue(undefined);
+
+    const result = await getTournamentLocations('nonexistent-tournament');
+
+    expect(result).toEqual([]);
+  });
+
+  it('calls findTournamentById with the provided tournamentId', async () => {
+    vi.mocked(tournamentRepository.findTournamentById).mockResolvedValue(
+      testFactories.tournament({ id: 'specific-id' })
+    );
+
+    await getTournamentLocations('specific-id');
+
+    expect(tournamentRepository.findTournamentById).toHaveBeenCalledWith('specific-id');
+  });
+});

--- a/app/actions/tournament-actions.ts
+++ b/app/actions/tournament-actions.ts
@@ -247,8 +247,12 @@ async function validateAdminUser(locale: Locale = 'es'): Promise<void> {
 
 function parseFormData(formData: any): { tournamentData: any; logoFile: any } {
   const data = Object.fromEntries(formData);
+  const tournamentData = JSON.parse(data.tournament);
+  const parsedLocations: string[] = data.locations
+    ? (JSON.parse(data.locations as string) as string[]).filter((l: string) => l.trim() !== '')
+    : [];
   return {
-    tournamentData: JSON.parse(data.tournament),
+    tournamentData: { ...tournamentData, locations: JSON.stringify(parsedLocations) },
     logoFile: data.logo
   };
 }
@@ -344,6 +348,16 @@ async function cleanupOldLogo(existingTournament: Tournament | null, logoFile: a
       console.error('Error deleting old logo:', error);
     }
   }
+}
+
+/**
+ * Returns the locations array for a tournament.
+ * Returns [] if tournament not found or has no locations.
+ * Used by story #303 to populate the `location` field in SportsEvent JSON-LD.
+ */
+export async function getTournamentLocations(tournamentId: string): Promise<string[]> {
+  const tournament = await findTournamentById(tournamentId);
+  return tournament?.locations ?? [];
 }
 
 export async function getTournamentById(tournamentId: string) {

--- a/app/components/backoffice/__tests__/tournament-main-data-tab-locations.test.tsx
+++ b/app/components/backoffice/__tests__/tournament-main-data-tab-locations.test.tsx
@@ -1,0 +1,151 @@
+import { act, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import TournamentMainDataTab from '../tournament-main-data-tab'
+import { renderWithTheme } from '@/__tests__/utils/test-utils'
+import { testFactories } from '@/__tests__/db/test-factories'
+
+vi.mock('../../../actions/tournament-actions', () => ({
+  getTournamentById: vi.fn(),
+  createOrUpdateTournament: vi.fn(),
+  getPlayoffRounds: vi.fn(),
+  getTournamentLocations: vi.fn(),
+}))
+
+vi.mock('../../../actions/backoffice-actions', () => ({
+  getTournamentPermissionData: vi.fn(),
+  updateTournamentPermissions: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({
+    refresh: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  })),
+}))
+
+vi.mock('../../friend-groups/image-picker', () => ({
+  default: vi.fn(() => null),
+}))
+
+vi.mock('../internal/playoff-round-dialog', () => ({
+  default: vi.fn(() => null),
+}))
+
+vi.mock('../tournament-permissions-selector', () => ({
+  default: vi.fn(() => null),
+}))
+
+vi.mock('../i18n-field-editor', () => ({
+  default: vi.fn(() => null),
+}))
+
+vi.mock('mui-color-input', () => ({
+  MuiColorInput: vi.fn(({ value }: { value: string }) => (
+    <input data-testid="color-input" value={value} readOnly />
+  )),
+}))
+
+vi.mock('../../../utils/theme-utils', () => ({
+  getThemeLogoUrl: vi.fn(() => null),
+}))
+
+import {
+  getTournamentById,
+  createOrUpdateTournament,
+  getPlayoffRounds,
+} from '../../../actions/tournament-actions'
+
+function setupMocks(locations: string[] = []) {
+  const tournament = testFactories.tournament({ locations }) as any
+  vi.mocked(getTournamentById).mockResolvedValue(tournament)
+  vi.mocked(getPlayoffRounds).mockResolvedValue([])
+  vi.mocked(createOrUpdateTournament).mockResolvedValue(tournament)
+}
+
+async function renderAndWait(locations: string[] = []) {
+  setupMocks(locations)
+  renderWithTheme(<TournamentMainDataTab tournamentId="tournament-1" />)
+  await act(async () => {})
+}
+
+describe('TournamentMainDataTab — location management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows "No locations" alert when tournament has no locations', async () => {
+    await renderAndWait([])
+
+    await waitFor(() => {
+      expect(screen.getByText(/No locations defined for this tournament/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders a TextField for each location when tournament has locations', async () => {
+    await renderAndWait(['Qatar', 'Lusail'])
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Qatar')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('Lusail')).toBeInTheDocument()
+    })
+  })
+
+  it('adds an empty TextField when "Add Location" is clicked', async () => {
+    await renderAndWait([])
+
+    await waitFor(() => {
+      expect(screen.getByText(/No locations defined for this tournament/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Location/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/No locations defined for this tournament/i)).not.toBeInTheDocument()
+      expect(screen.getByPlaceholderText(/e\.g\. Qatar/i)).toBeInTheDocument()
+    })
+  })
+
+  it('removes the correct entry when its delete button is clicked', async () => {
+    await renderAndWait(['Qatar', 'Lusail'])
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Qatar')).toBeInTheDocument()
+    })
+
+    // Find the ListItem containing "Qatar" and click its delete button
+    const qatarInput = screen.getByDisplayValue('Qatar')
+    const listItem = qatarInput.closest('li')!
+    const deleteButton = within(listItem).getByRole('button')
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue('Qatar')).not.toBeInTheDocument()
+      expect(screen.getByDisplayValue('Lusail')).toBeInTheDocument()
+    })
+  })
+
+  it('serializes locations as JSON in FormData on submit, filtering empty strings', async () => {
+    await renderAndWait(['Qatar', 'Lusail'])
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Qatar')).toBeInTheDocument()
+    })
+
+    // Add an empty location (should be filtered out on submit)
+    fireEvent.click(screen.getByRole('button', { name: /Add Location/i }))
+
+    fireEvent.click(screen.getByRole('button', { name: /Save Changes/i }))
+
+    await waitFor(() => {
+      expect(createOrUpdateTournament).toHaveBeenCalled()
+    })
+
+    const [, submittedFormData] = vi.mocked(createOrUpdateTournament).mock.calls[0] as [string, FormData]
+    const locationsJson = submittedFormData.get('locations') as string
+    expect(JSON.parse(locationsJson)).toEqual(['Qatar', 'Lusail'])
+  })
+})

--- a/app/components/backoffice/tournament-main-data-tab.tsx
+++ b/app/components/backoffice/tournament-main-data-tab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import {useState, useEffect, useCallback} from 'react';
+import {useState, useEffect, useCallback, useRef} from 'react';
 import {
   Box,
   Grid,
@@ -32,6 +32,8 @@ import {useRouter} from "next/navigation";
 import TournamentPermissionsSelector from './tournament-permissions-selector';
 import { getTournamentPermissionData, updateTournamentPermissions } from '../../actions/backoffice-actions';
 import I18nFieldEditor from './i18n-field-editor';
+
+type LocationItem = { id: number; value: string };
 
 type Props = {
   readonly tournamentId: string;
@@ -83,7 +85,8 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
   const [transfermarktUrlTemplate, setTransfermarktUrlTemplate] = useState<string>('');
 
   // Tournament locations for SportsEvent structured data
-  const [locations, setLocations] = useState<string[]>([]);
+  const locationIdCounterRef = useRef(0);
+  const [locations, setLocations] = useState<LocationItem[]>([]);
 
   // Fetch playoff rounds
   const fetchPlayoffRounds = useCallback(async () => {
@@ -132,7 +135,7 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
         setAllowsThirdPlaceQualification(tournamentData.allows_third_place_qualification || false);
         setMaxThirdPlaceQualifiers(tournamentData.max_third_place_qualifiers || 4);
         setTransfermarktUrlTemplate(tournamentData.transfermarkt_url_template || '');
-        setLocations(tournamentData.locations ?? []);
+        setLocations((tournamentData.locations ?? []).map((v: string) => ({ id: locationIdCounterRef.current++, value: v })));
 
         // Fetch playoff rounds
         await fetchPlayoffRounds();
@@ -200,7 +203,7 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
         formData.append('logo', logoFile);
       }
 
-      formData.append('locations', JSON.stringify(locations.filter(l => l.trim() !== '')));
+      formData.append('locations', JSON.stringify(locations.map(l => l.value).filter(v => v.trim() !== '')));
 
       const updatedTournament = await createOrUpdateTournament(tournamentId, formData);
 
@@ -278,11 +281,11 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
 
   // Location management handlers
   const handleLocationChange = (index: number, newName: string) => {
-    setLocations(prev => prev.map((loc, i) => (i === index ? newName : loc)));
+    setLocations(prev => prev.map((loc, i) => (i === index ? { ...loc, value: newName } : loc)));
   };
 
   const addLocation = () => {
-    setLocations(prev => [...prev, '']);
+    setLocations(prev => [...prev, { id: locationIdCounterRef.current++, value: '' }]);
   };
 
   const deleteLocation = (index: number) => {
@@ -709,7 +712,7 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
                 <List dense>
                   {locations.map((loc, index) => (
                     <ListItem
-                      key={index}
+                      key={loc.id}
                       secondaryAction={
                         <IconButton edge="end" onClick={() => deleteLocation(index)} size="small">
                           <DeleteIcon fontSize="small" />
@@ -718,7 +721,7 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
                     >
                       <TextField
                         variant="standard"
-                        value={loc}
+                        value={loc.value}
                         onChange={(e) => handleLocationChange(index, e.target.value)}
                         placeholder="e.g. Qatar, New York"
                         fullWidth

--- a/app/components/backoffice/tournament-main-data-tab.tsx
+++ b/app/components/backoffice/tournament-main-data-tab.tsx
@@ -23,6 +23,7 @@ import { MuiColorInput } from 'mui-color-input';
 import LinkIcon from '@mui/icons-material/Link';
 import ImagePicker from "../friend-groups/image-picker";
 import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { TournamentFormSkeleton } from '../skeletons';
 import EditIcon from '@mui/icons-material/Edit';
 import PlayoffRoundDialog from './internal/playoff-round-dialog';
@@ -81,6 +82,9 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
   // Transfermarkt import configuration
   const [transfermarktUrlTemplate, setTransfermarktUrlTemplate] = useState<string>('');
 
+  // Tournament locations for SportsEvent structured data
+  const [locations, setLocations] = useState<string[]>([]);
+
   // Fetch playoff rounds
   const fetchPlayoffRounds = useCallback(async () => {
     setLoadingPlayoffRounds(true);
@@ -128,6 +132,7 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
         setAllowsThirdPlaceQualification(tournamentData.allows_third_place_qualification || false);
         setMaxThirdPlaceQualifiers(tournamentData.max_third_place_qualifiers || 4);
         setTransfermarktUrlTemplate(tournamentData.transfermarkt_url_template || '');
+        setLocations(tournamentData.locations ?? []);
 
         // Fetch playoff rounds
         await fetchPlayoffRounds();
@@ -194,6 +199,8 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
       if (logoFile) {
         formData.append('logo', logoFile);
       }
+
+      formData.append('locations', JSON.stringify(locations.filter(l => l.trim() !== '')));
 
       const updatedTournament = await createOrUpdateTournament(tournamentId, formData);
 
@@ -267,6 +274,19 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
     } finally {
       setLoading(false);
     }
+  };
+
+  // Location management handlers
+  const handleLocationChange = (index: number, newName: string) => {
+    setLocations(prev => prev.map((loc, i) => (i === index ? newName : loc)));
+  };
+
+  const addLocation = () => {
+    setLocations(prev => [...prev, '']);
+  };
+
+  const deleteLocation = (index: number) => {
+    setLocations(prev => prev.filter((_, i) => i !== index));
   };
 
   // Handle logo file selection
@@ -664,6 +684,51 @@ export default function TournamentMainDataTab({ tournamentId, onUpdate }: Props)
               margin="normal"
               helperText={`Use {teamName} and {teamId} as placeholders. E.g.: https://www.transfermarkt.com/{teamName}/kader/verein/{teamId}/saison_id/2024/plus/1`}
             />
+          </Grid>
+
+          <Grid size={{ xs: 12 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1 }}>
+              <Typography variant="subtitle2">
+                Tournament Locations
+              </Typography>
+              <Button
+                variant="outlined"
+                size="small"
+                startIcon={<AddIcon />}
+                onClick={addLocation}
+              >
+                Add Location
+              </Button>
+            </Box>
+            {locations.length === 0 ? (
+              <Alert severity="info" sx={{ mt: 1 }}>
+                No locations defined for this tournament.
+              </Alert>
+            ) : (
+              <Paper variant="outlined" sx={{ mt: 1, maxHeight: 300, overflow: 'auto' }}>
+                <List dense>
+                  {locations.map((loc, index) => (
+                    <ListItem
+                      key={index}
+                      secondaryAction={
+                        <IconButton edge="end" onClick={() => deleteLocation(index)} size="small">
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      }
+                    >
+                      <TextField
+                        variant="standard"
+                        value={loc}
+                        onChange={(e) => handleLocationChange(index, e.target.value)}
+                        placeholder="e.g. Qatar, New York"
+                        fullWidth
+                        size="small"
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              </Paper>
+            )}
           </Grid>
         </Grid>
 

--- a/app/db/tables-definition.ts
+++ b/app/db/tables-definition.ts
@@ -1,4 +1,5 @@
 import {
+  ColumnType,
   Generated,
   Insertable,
   JSONColumnType,
@@ -75,6 +76,10 @@ export interface TournamentTable extends Identifiable{
 
   // Transfermarkt import configuration
   transfermarkt_url_template?: string | null
+
+  // Location data for SportsEvent structured data (story #310)
+  // ColumnType: select=string[], insert=optional (DB DEFAULT '[]'), update=accepts array or raw JSON
+  locations: ColumnType<string[], string[] | string | undefined, string[] | string>
 }
 
 export type Tournament = Selectable<TournamentTable>

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-04-03
+**Last updated:** 2026-04-06
 
 ---
 

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -300,8 +300,10 @@ Tournament CRUD and data retrieval — the primary data access layer for tournam
   Calls: findFirstGameInTournament
 - **deactivateTournament(tournamentId, locale)**: `Promise<Tournament>` — Deactivates tournament (admin).
   Calls: getLoggedInUser, findTournamentById, updateTournament, applyLocalization
-- **createOrUpdateTournament(tournamentId, tournamentFormData, locale)**: `Promise<Tournament>` — Creates or updates tournament with optional logo upload. Persists `transfermarkt_url_template` when included in the JSON payload.
+- **createOrUpdateTournament(tournamentId, tournamentFormData, locale)**: `Promise<Tournament>` — Creates or updates tournament with optional logo upload. Persists `transfermarkt_url_template` and `locations` when included in the JSON payload.
   Calls: validateAdminUser, parseFormData, getExistingTournament, handleLogoUpload, prepareTournamentData, saveOrUpdateTournament, cleanupOldLogo, applyLocalization
+- **getTournamentLocations(tournamentId)**: `Promise<string[]>` — Returns the locations array for a tournament; returns `[]` if not found. Used by story #303 for SportsEvent JSON-LD.
+  Calls: findTournamentById
 - **getTournamentById(tournamentId)**: `Promise<Tournament | null>` — Gets single tournament with localization.
   Calls: findTournamentById, applyLocalization
 - **getCompleteTournamentGroups(tournamentId)**: `Promise<ExtendedGroupData[]>` — Gets all groups for tournament.

--- a/docs/code-structure/components/components-backoffice.md
+++ b/docs/code-structure/components/components-backoffice.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-04-03
+**Last updated:** 2026-04-06
 
 ---
 
@@ -70,7 +70,7 @@ Component for editing i18n JSONB fields with English and Spanish inputs. Reusabl
 Main tournament configuration form with colors, logos, playoff rounds, and location management. [Client] comprehensive tournament setup.
 - **TournamentMainDataTab({ tournamentId, onUpdate }: Props)**: `JSX.Element` — [Client] Configures tournament name, theme colors, logo, dev mode, playoff rounds, third-place qualification settings, Transfermarkt URL template, and city/country locations for SportsEvent JSON-LD (Story #310).
   Calls: getTournamentById, createOrUpdateTournament, getPlayoffRounds, getTournamentPermissionData, updateTournamentPermissions
-  Uses: useTranslations, useLocale, useRouter, useCallback, useEffect, useState
+  Uses: useRouter, useCallback, useEffect, useState, useRef
   Renders: MuiColorInput, ImagePicker, TextField, FormControlLabel, Switch, PlayoffRoundDialog, TournamentPermissionsSelector, Button, Paper, Alert, List, ListItem, IconButton (delete)
 
 ### app/components/backoffice/tournament-game-manager-tab.tsx

--- a/docs/code-structure/components/components-backoffice.md
+++ b/docs/code-structure/components/components-backoffice.md
@@ -67,11 +67,11 @@ Component for editing i18n JSONB fields with English and Spanish inputs. Reusabl
   Renders: TextField, Typography, Grid, Alert
 
 ### app/components/backoffice/tournament-main-data-tab.tsx
-Main tournament configuration form with colors, logos, playoff rounds. [Client] comprehensive tournament setup.
-- **TournamentMainDataTab({ tournamentId, onUpdate }: Props)**: `JSX.Element` — [Client] Configures tournament name, theme colors, logo, dev mode, playoff rounds, third-place qualification settings, and Transfermarkt URL template (Story #306).
+Main tournament configuration form with colors, logos, playoff rounds, and location management. [Client] comprehensive tournament setup.
+- **TournamentMainDataTab({ tournamentId, onUpdate }: Props)**: `JSX.Element` — [Client] Configures tournament name, theme colors, logo, dev mode, playoff rounds, third-place qualification settings, Transfermarkt URL template, and city/country locations for SportsEvent JSON-LD (Story #310).
   Calls: getTournamentById, createOrUpdateTournament, getPlayoffRounds, getTournamentPermissionData, updateTournamentPermissions
   Uses: useTranslations, useLocale, useRouter, useCallback, useEffect, useState
-  Renders: MuiColorInput, ImagePicker, TextField, FormControlLabel, Switch, PlayoffRoundDialog, TournamentPermissionsSelector, Button, Paper, Alert
+  Renders: MuiColorInput, ImagePicker, TextField, FormControlLabel, Switch, PlayoffRoundDialog, TournamentPermissionsSelector, Button, Paper, Alert, List, ListItem, IconButton (delete)
 
 ### app/components/backoffice/tournament-game-manager-tab.tsx
 Table for managing all tournament games with create/edit/delete. [Client] game CRUD interface.

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-04-05
+**Last updated:** 2026-04-06
 
 ---
 

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -33,6 +33,8 @@ Includes `TournamentScoreHistoryTable` for the `tournament_score_history` table 
 
 `TournamentTable` includes `transfermarkt_url_template?: string | null` — configurable URL template for Transfermarkt player imports; uses `{teamName}` and `{teamId}` placeholders (Story #306).
 
+`TournamentTable` includes `locations: ColumnType<string[], string[] | string | undefined, string[] | string>` — ordered list of city/country location names (e.g., `["Qatar", "Lusail"]`) stored as JSONB NOT NULL DEFAULT '[]'; select returns `string[]`, insert is optional (uses DB default), update accepts array or raw JSON string; used for SportsEvent JSON-LD structured data (Story #310).
+
 `TeamTable` includes `transfermarkt_id?: string | null` — the Transfermarkt team ID persisted after a successful player import for pre-filling on re-import (Story #306).
 
 Note: `yesterday_tournament_score`, `yesterday_total_game_score`, `yesterday_boost_bonus`, and `last_score_update_date` fields were removed from `TournamentGuessTable` in Story #278. Rank-change tracking now uses `tournament_score_history` snapshots (Story #272/#277).

--- a/migrations/20260406000000_add_locations_to_tournaments.sql
+++ b/migrations/20260406000000_add_locations_to_tournaments.sql
@@ -1,0 +1,5 @@
+-- Migration: 20260406000000_add_locations_to_tournaments.sql
+-- Story #310: Add location data to tournaments for SportsEvent structured data
+
+ALTER TABLE tournaments
+  ADD COLUMN locations JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/plans/STORY-310-context.md
+++ b/plans/STORY-310-context.md
@@ -1,0 +1,17 @@
+# Story 310 Context
+
+## Metadata
+- **Story Number:** 310
+- **Story Title:** [Story] Add location data to tournaments for SportsEvent structured data
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-310
+- **Branch:** feature/story-310
+- **PR Number:** 311
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/311
+
+## State
+- **Current Phase:** implementing
+- **Plan File:** plans/STORY-310-plan.md
+- **Task File:** (fill when implementation starts)
+
+## Quick Summary
+This story adds city/country-level location data to tournaments (e.g., "Qatar", "New York") stored in a new `tournament_locations` table. Admins can manage these locations via a new "Locations" tab in the backoffice. This is a prerequisite to story #303 which will use this data to populate the `location` field in the SportsEvent JSON-LD structured data. No JSON-LD changes are in scope for this story.

--- a/plans/STORY-310-plan.md
+++ b/plans/STORY-310-plan.md
@@ -2,21 +2,18 @@
 
 ## Context
 
-The SportsEvent JSON-LD added in story #303 is missing the `location` field required by Google's Rich Results Test. This story creates the data model and admin UI for tournament locations so admins can configure city/country-level names (e.g., "Qatar", "New York"). Story #303 will then use this data when generating JSON-LD structured data.
-
-A partial reference implementation exists as uncommitted changes in the main worktree — the plan incorporates those patterns with bug fixes.
+The SportsEvent JSON-LD added in story #303 is missing the `location` field required by Google's Rich Results Test. This story adds a `locations` JSONB column to the `tournaments` table so admins can configure city/country-level location names (e.g., "Qatar", "New York"). Story #303 will then use this data when generating JSON-LD structured data.
 
 ## Objective
 
-Enable admins to configure one or more location names for each tournament, persisted in a dedicated `tournament_locations` table. Provide read access via a server action for future JSON-LD integration.
+Enable admins to configure one or more location names for each tournament, stored as a `locations` JSONB column (`string[]`) on the `tournaments` table. Provide read access via the existing tournament fetch for future JSON-LD integration.
 
 ## Acceptance Criteria
 
 - [ ] Each tournament can have zero or more location names (e.g., "Qatar", "Lusail", "New York")
 - [ ] Admins can add, edit, and remove locations for a tournament in the backoffice "Tournament Data" tab
 - [ ] Tournaments with no locations configured show a clear "no locations" state in the UI
-- [ ] `getTournamentLocations` returns an empty array for tournaments with no locations (supports graceful JSON-LD omission in story #303)
-- [ ] All CRUD location actions require admin authentication
+- [ ] `tournament.locations` returns `[]` for tournaments with no locations (supports graceful JSON-LD omission in story #303)
 
 ## Out of Scope
 
@@ -28,38 +25,29 @@ Enable admins to configure one or more location names for each tournament, persi
 
 ## Technical Approach
 
+### Why JSONB over a separate table
+
+Locations are a simple `string[]` — no metadata, no individual querying, no need for normalization. The `tournaments` table already uses JSONB for `theme` and i18n fields. A `locations JSONB DEFAULT '[]'` column keeps the implementation minimal: one migration, no new repository, no new server action. Uniqueness is enforced in the application layer.
+
 ### Database
 
-New table `tournament_locations` with `(id, tournament_id, name, created_at, updated_at)`. Unique constraint on `(tournament_id, name)`. Cascade delete on tournament removal. Follows the same pattern as `tournament_venues`.
+`ALTER TABLE tournaments ADD COLUMN locations JSONB NOT NULL DEFAULT '[]'::jsonb`
 
-### Repository
+### TypeScript Types
 
-New `app/db/tournament-location-repository.ts` using the project's `createBaseFunctions` utility plus a custom `findByTournamentId` function. Consistent with `tournament-venue-repository.ts`.
+Add `locations: JSONColumnType<string[]>` to `TournamentTable` in `tables-definition.ts`. The existing `Tournament`, `TournamentNew`, `TournamentUpdate` derived types automatically include it via Kysely's `Selectable`/`Insertable`/`Updateable`.
 
 ### Server Actions
 
-Add to `app/actions/tournament-actions.ts`:
-- `getTournamentLocations(tournamentId)` — public read, no admin check needed
-- `createTournamentLocation`, `updateTournamentLocation`, `deleteTournamentLocation` — admin-only, for future direct CRUD use
-- Private `handleLocationsUpdate(tournamentId, locations)` — batch sync called from `createOrUpdateTournament`
-- Update `parseFormData` to extract locations with null safety
-- Update `createOrUpdateTournament` to call `handleLocationsUpdate` after saving
+No new action file needed. Locations are saved via the existing `createOrUpdateTournament(tournamentId, formData, locale)` action — `parseFormData` extracts the locations array from FormData and it gets merged into the tournament update payload.
+
+Add a thin `getTournamentLocations(tournamentId)` helper action for story #303's use (reads from the existing `findTournamentById` result).
 
 ### Admin UI
 
-Extend `TournamentMainDataTab` with an inline "Tournament Locations" section (not a new tab). The section shows a scrollable list of location TextFields with delete buttons, plus an "Add Location" button. Locations are saved when the user clicks "Save Changes".
-
-**Key design fix vs reference**: Use a `localId` field (stable UUID for new items, DB id for existing) to eliminate the key-matching bug in the uncommitted implementation.
-
-### Testing
-
-- Unit tests for `tournament-location-repository.ts` (mocked Kysely)
-- Unit tests for location actions in `tournament-actions.ts` (mocked repository + auth)
-- Component tests for the new locations UI in `TournamentMainDataTab`
+Extend `TournamentMainDataTab` with an inline "Tournament Locations" section (below Transfermarkt URL Template). Uses local React state (`string[]`) — no separate fetch needed since the tournament object already contains `locations`. Locations are saved with the main "Save Changes" button.
 
 ## Visual Prototype
-
-The "Tournament Data" tab already exists. Below the "Transfermarkt URL Template" field, add:
 
 ```
 Tournament Locations                              [ + Add Location ]
@@ -78,268 +66,154 @@ Tournament Locations                              [ + Add Location ]
 ℹ️  No locations defined for this tournament.
 ```
 
-Each row is an inline `TextField` (variant="standard") with a delete `IconButton`. Changes are saved with the main "Save Changes" button at the bottom of the form.
+Each row is an inline `TextField` (variant="standard") with a delete `IconButton`. Changes are saved with the main "Save Changes" button.
 
 ## Files to Create
 
 | File | Description |
 |------|-------------|
-| `migrations/20260406000000_create_tournament_locations.sql` | New table with unique constraint and cascade delete |
-| `app/db/tournament-location-repository.ts` | Repository with base CRUD + `findByTournamentId` |
-| `app/actions/__tests__/tournament-location-actions.test.ts` | Unit tests for location actions |
-| `app/db/__tests__/tournament-location-repository.test.ts` | Unit tests for repository |
+| `migrations/20260406000000_add_locations_to_tournaments.sql` | ADD COLUMN locations JSONB |
+| `app/actions/__tests__/tournament-location-actions.test.ts` | Unit tests for `getTournamentLocations` |
 
 ## Files to Modify
 
 | File | Change |
 |------|--------|
-| `app/db/tables-definition.ts` | Add `TournamentLocationTable` interface + `TournamentLocation`, `TournamentLocationNew`, `TournamentLocationUpdate` types |
-| `app/db/database.ts` | Import `TournamentLocationTable` + add `tournament_locations` entry |
-| `app/actions/tournament-actions.ts` | Add location actions, `LocationFormDataType`, `handleLocationsUpdate`, update `parseFormData` + `createOrUpdateTournament` |
-| `app/components/backoffice/tournament-main-data-tab.tsx` | Add location state/handlers/UI section |
-| `docs/code-structure/db.md` | Add `tournament-location-repository.ts` entry |
-| `docs/code-structure/actions.md` | Add location actions + update `createOrUpdateTournament` signature |
+| `app/db/tables-definition.ts` | Add `locations: JSONColumnType<string[]>` to `TournamentTable` |
+| `app/actions/tournament-actions.ts` | Add `getTournamentLocations`, update `parseFormData` to extract locations, update `createOrUpdateTournament` to include locations in save payload |
+| `app/components/backoffice/tournament-main-data-tab.tsx` | Initialize `locations` state from `tournament.locations`, add location management UI section |
+| `docs/code-structure/db.md` | Add `locations` field to `tournament-repository.ts` entry |
+| `docs/code-structure/actions.md` | Add `getTournamentLocations`, update `createOrUpdateTournament` signature |
 | `docs/code-structure/components/components-backoffice.md` | Update `TournamentMainDataTab` entry |
-| `CODE-STRUCTURE.md` | Update call graph with new location flows |
+| `CODE-STRUCTURE.md` | Update call graph |
 
 ## Mid-Level Design
 
 ### Call Graph Changes
 
-**YES — new flows added:**
+**YES — one existing flow modified:**
 
-- **New: Location read flow** — `TournamentMainDataTab` (Client) →  `getTournamentLocations(tournamentId)` → `tournamentLocationRepository.findByTournamentId`
-- **Modified: Tournament save flow** — `TournamentMainDataTab` (Client) → `createOrUpdateTournament(tournamentId, formData, locale)` (extended) → `handleLocationsUpdate(tournamentId, locations)` → `tournamentLocationRepository.{create|update|delete}`
+- **Modified: Tournament save flow** — `TournamentMainDataTab` (Client) → `createOrUpdateTournament(tournamentId, formData, locale)` now includes `locations: string[]` in the tournament data payload
+
+No new cross-layer flows; `getTournamentLocations` is a thin wrapper over the existing tournament fetch.
 
 ---
 
-### `migrations/20260406000000_create_tournament_locations.sql` *(new)*
+### `migrations/20260406000000_add_locations_to_tournaments.sql` *(new)*
 
 ```sql
-CREATE TABLE tournament_locations (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    tournament_id UUID NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
-    name VARCHAR(255) NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    UNIQUE (tournament_id, name)
-);
-
-CREATE INDEX idx_tournament_locations_tournament_id ON tournament_locations(tournament_id);
-
-CREATE TRIGGER update_tournament_locations_updated_at
-BEFORE UPDATE ON tournament_locations
-FOR EACH ROW
-EXECUTE FUNCTION update_updated_at_column();
+ALTER TABLE tournaments
+  ADD COLUMN locations JSONB NOT NULL DEFAULT '[]'::jsonb;
 ```
 
 ---
 
 ### `app/db/tables-definition.ts` *(modified)*
 
-**New types:**
-
+Add to `TournamentTable`:
 ```typescript
-export interface TournamentLocationTable extends Identifiable {
-  tournament_id: string;
-  name: string;
-  created_at: Generated<Date>;
-  updated_at: Generated<Date>;
-}
-
-export type TournamentLocation = Selectable<TournamentLocationTable>;
-export type TournamentLocationNew = Insertable<TournamentLocationTable>;
-export type TournamentLocationUpdate = Updateable<TournamentLocationTable>;
+locations: JSONColumnType<string[]>
 ```
-
----
-
-### `app/db/tournament-location-repository.ts` *(new)*
-
-- **`tournamentLocationRepository.findByTournamentId(tournamentId: string)`**: `Promise<TournamentLocation[]>`
-  Returns all locations for a tournament ordered by name. Uses `react.cache`.
-  Tests:
-  - returns empty array when tournament has no locations
-  - returns locations sorted by name ascending
-  - only returns locations for the specified tournament (not others)
-
-- **`tournamentLocationRepository.create(data: TournamentLocationNew)`**: `Promise<TournamentLocation>`
-  From `createBaseFunctions`. Inserts a new location row.
-  Tests: covered by `createBaseFunctions` (shared utility)
-
-- **`tournamentLocationRepository.update(id: string, data: TournamentLocationUpdate)`**: `Promise<TournamentLocation>`
-  From `createBaseFunctions`. Updates a location by id.
-
-- **`tournamentLocationRepository.delete(id: string)`**: `Promise<void>`
-  From `createBaseFunctions`. Deletes a location by id.
 
 ---
 
 ### `app/actions/tournament-actions.ts` *(modified)*
 
-**New private interface:**
+**New exported function:**
 
-```typescript
-interface LocationFormDataType {
-  id?: string;       // DB id, undefined for new unsaved items
-  localId: string;   // Stable key: DB id for existing, UUID for new
-  name: string;
-  isDeleted?: boolean;
-}
-```
-
-**New exported functions:**
-
-- **`getTournamentLocations(tournamentId: string)`**: `Promise<TournamentLocation[]>`
-  Reads all locations for a tournament. No admin check (read-only, called from admin page context).
-  Calls: `tournamentLocationRepository.findByTournamentId`
+- **`getTournamentLocations(tournamentId: string)`**: `Promise<string[]>`
+  Returns the `locations` array from the tournament record. Returns `[]` if tournament not found.
+  Calls: `findTournamentById`
   Tests:
-  - returns empty array when no locations exist
-  - returns array of TournamentLocation objects
-  - delegates to repository with correct tournamentId
+  - returns empty array when tournament has no locations (empty JSONB array)
+  - returns array of location strings for tournament with locations
+  - returns empty array when tournament not found
 
-- **`createTournamentLocation(tournamentId: string, name: string)`**: `Promise<TournamentLocation>`
-  Admin-only. Creates one location.
-  Calls: `validateAdminUser`, `tournamentLocationRepository.create`
+**Modified private function:**
+
+- **`parseFormData(formData: FormData)`**: `{ tournamentData: any; logoFile: File | null }`
+  Now merges `locations` (parsed from FormData `'locations'` key) into `tournamentData`. Null-safe: defaults to `[]` when key absent.
   Tests:
-  - throws Unauthorized when user is not admin
-  - creates and returns TournamentLocation when admin
-  - passes correct tournament_id and name to repository
+  - includes locations array in returned tournamentData when key present
+  - defaults locations to empty array when key absent
+  - filters out empty/whitespace-only location strings before merging
 
-- **`updateTournamentLocation(locationId: string, name: string)`**: `Promise<TournamentLocation>`
-  Admin-only. Updates location name.
-  Calls: `validateAdminUser`, `tournamentLocationRepository.update`
-  Tests:
-  - throws Unauthorized when user is not admin
-  - calls repository update with correct id and name
-  - returns updated TournamentLocation
+**Modified exported function:**
 
-- **`deleteTournamentLocation(locationId: string)`**: `Promise<void>`
-  Admin-only. Deletes a location.
-  Calls: `validateAdminUser`, `tournamentLocationRepository.delete`
-  Tests:
-  - throws Unauthorized when user is not admin
-  - calls repository delete with correct id
-  - returns without error when location exists and is deleted successfully
-
-**Modified private functions:**
-
-- **`parseFormData(formData: FormData)`**: `{ tournamentData: any; logoFile: File | null; locations: LocationFormDataType[] }`
-  Extracts tournament data, logo, and locations from FormData. Null-safe for locations. Trims location names and filters out empty/whitespace-only entries.
-  Tests:
-  - returns empty array when 'locations' key is absent
-  - parses locations array from JSON string
-  - handles empty locations array
-  - trims whitespace and skips whitespace-only location names
-
-- **`handleLocationsUpdate(tournamentId: string, locations: LocationFormDataType[])`**: `Promise<void>`
-  Private. Diffs incoming locations against DB state, then creates/updates/deletes as needed. Skips items with empty names. Uses try-catch to log and skip individual errors; throws after processing all items if any errors occurred.
-  Calls: `tournamentLocationRepository.findByTournamentId`, `tournamentLocationRepository.create`, `tournamentLocationRepository.update`, `tournamentLocationRepository.delete`
-  Tests:
-  - creates new locations (no id, not deleted, non-empty name)
-  - updates existing locations (has id, not deleted)
-  - deletes locations marked isDeleted
-  - deletes locations present in DB but absent from incoming list (implicit delete)
-  - skips items with empty name strings
-  - logs and skips errors from individual repository operations (partial success)
-
-**Modified exported functions:**
-
-- **`createOrUpdateTournament(tournamentId: string | null, tournamentFormData: FormData, locale: Locale)`**: `Promise<Tournament>` *(was: `tournamentFormData: any`)*
-  Now extracts and saves locations as part of the tournament save flow.
-  Calls: `validateAdminUser`, `parseFormData` (updated), `getExistingTournament`, `handleLogoUpload`, `prepareTournamentData`, `saveOrUpdateTournament`, `cleanupOldLogo`, `handleLocationsUpdate`, `applyLocalization`
+- **`createOrUpdateTournament(tournamentId: string | null, tournamentFormData: FormData, locale: Locale)`**: `Promise<Tournament>` *(unchanged signature; `locations` now flows through `tournamentData`)*
+  Calls: (unchanged) `validateAdminUser`, `parseFormData`, `getExistingTournament`, `handleLogoUpload`, `prepareTournamentData`, `saveOrUpdateTournament`, `cleanupOldLogo`, `applyLocalization`
   Tests (new scenarios only):
-  - locations are synchronized when saving a tournament
-  - no-op on locations when empty array provided
-  - returns Tournament and skips location sync if handleLocationsUpdate throws (error boundary)
+  - tournament is saved with provided locations array
+  - tournament is saved with empty locations array when none provided
+  - throws Unauthorized when non-admin attempts save (validateAdminUser guard)
 
 ---
 
 ### `app/components/backoffice/tournament-main-data-tab.tsx` *(modified)*
 
-**New interface** (local, not exported):
+**Modified state initialization** (in `fetchTournamentData` useEffect):
 ```typescript
-interface LocationFormDataType {
-  id?: string;
-  localId: string;  // stable key: DB id for existing, UUID for new
-  name: string;
-  isDeleted?: boolean;
-}
+setLocations(tournamentData.locations ?? []);
 ```
 
-**New state:** `const [locations, setLocations] = useState<LocationFormDataType[]>([])`
+**New state:** `const [locations, setLocations] = useState<string[]>([])`
 
 **New handlers:**
-- `handleLocationChange(localId: string, newName: string)`: `void` — updates name by `localId`
-- `addLocation()`: `void` — appends `{ localId: crypto.randomUUID(), name: '', isDeleted: false }`
-- `deleteLocation(localId: string)`: `void` — marks matching item as `isDeleted: true`
+- `handleLocationChange(index: number, newName: string)`: `void` — updates `locations[index]` by array index
+- `addLocation()`: `void` — appends `''` to locations array
+- `deleteLocation(index: number)`: `void` — removes `locations[index]`
 
-**Modified `useEffect` (fetchTournamentData):** Also calls `getTournamentLocations(tournamentId)` and maps to `LocationFormDataType` with `localId: loc.id`.
-
-**Modified `handleSubmit`:** Appends `formData.append('locations', JSON.stringify(locations))`.
+**Modified `handleSubmit`:** Appends `formData.append('locations', JSON.stringify(locations.filter(l => l.trim() !== '')))`.
 
 **New JSX section** below Transfermarkt URL Template: "Tournament Locations" with Add button, scrollable `List` of `TextField`+delete pairs, and empty `Alert`.
 
-Note: The `LocationFormDataType` interface is duplicated in `tournament-main-data-tab.tsx` (component state) and `tournament-actions.ts` (form parsing). This is intentional — the component type is purely local UI state; the action type is for parsing form data. They happen to have the same shape.
+Note: Using array index as key/handler parameter is safe here because re-renders always use the current filtered list (no async key mismatches).
 
 **Component tests:**
-- renders "No locations" alert when no locations loaded
-- renders list of location TextFields when locations exist
-- adds new location field when "Add Location" clicked
-- removes location from visible list when delete clicked
-- sends locations JSON in FormData on submit
+- renders "No locations" alert when `locations` is empty
+- renders list of location TextFields for each location string
+- adds new empty TextField when "Add Location" clicked
+- removes correct entry when delete clicked
+- sends locations JSON in FormData on submit (filters empty strings)
 
 ---
 
 ## Testing Strategy
 
-### Repository Tests (`tournament-location-repository.test.ts`)
-Mock `db` from `@/app/db/database`. Test `findByTournamentId` with mocked `selectFrom` chain using `vi.fn()` to create mock query builders.
-
 ### Action Tests (`tournament-location-actions.test.ts`)
-Mock `tournamentLocationRepository` using `vi.mock()` and `getLoggedInUser` using `vi.mocked()`. Use `testFactories.createTournamentLocation()` for fixture data. Cover:
-- All 4 exported location actions (happy path + unauthorized)
-- `parseFormData` null-safety, parsing, and whitespace trimming
-- `handleLocationsUpdate` diff logic (creates/updates/deletes/implicit deletes/partial errors)
+Use `vi.mock('@/app/db/tournament-repository')` and `vi.mocked(findTournamentById)` for mock setup. Use `testFactories.tournament({ locations: ['Qatar', 'Lusail'] })` (or inline object) for fixture data. Cover:
+- `getTournamentLocations` (empty, populated, not found)
+- `parseFormData` locations extraction and filtering
 
 ### Component Tests
-Extend or create tests for `TournamentMainDataTab`:
-- Mock `getTournamentLocations` and `createOrUpdateTournament`
-- Verify location list renders and interactions work
+Use `vi.mock('../../actions/tournament-actions')` with `vi.mocked(getTournamentLocations)` returning fixture arrays. Use `renderWithTheme(<TournamentMainDataTab ... />)` from project test utilities. Cover:
+- Verify location section renders, add/delete interactions update state
 
 ### Coverage Target
-≥80% on new files (repository, actions, component location logic)
+≥80% on changed code paths
 
 ## Implementation Steps
 
-### Wave 1 — Data Layer (prerequisite for everything)
-1. Create `migrations/20260406000000_create_tournament_locations.sql`
-2. Update `app/db/tables-definition.ts` — add `TournamentLocationTable` + types
-3. Update `app/db/database.ts` — import + add to `Database` interface
-4. Create `app/db/tournament-location-repository.ts`
+### Wave 1 — Data Layer
+1. Create `migrations/20260406000000_add_locations_to_tournaments.sql`
+2. Update `app/db/tables-definition.ts` — add `locations` field to `TournamentTable`
 
 ### Wave 2 — Actions Layer
-5. Update `app/actions/tournament-actions.ts` — add `LocationFormDataType`, location actions, `parseFormData` update, `handleLocationsUpdate`, `createOrUpdateTournament` update
+3. Update `app/actions/tournament-actions.ts` — add `getTournamentLocations`, update `parseFormData`, update `createOrUpdateTournament`
 
 ### Wave 3 — UI
-6. Update `app/components/backoffice/tournament-main-data-tab.tsx` — add location state, handlers, and UI section
+4. Update `app/components/backoffice/tournament-main-data-tab.tsx` — add location state, handlers, and UI section
 
 ### Wave 4 — Tests + Documentation
-7. Create `app/db/__tests__/tournament-location-repository.test.ts`
-8. Create `app/actions/__tests__/tournament-location-actions.test.ts`
-9. Update `docs/code-structure/db.md`
-10. Update `docs/code-structure/actions.md`
-11. Update `docs/code-structure/components/components-backoffice.md`
-12. Update `CODE-STRUCTURE.md` call graph
+5. Create `app/actions/__tests__/tournament-location-actions.test.ts`
+6. Update `docs/code-structure/db.md` (add `locations` to tournament entry)
+7. Update `docs/code-structure/actions.md`
+8. Update `docs/code-structure/components/components-backoffice.md`
+9. Update `CODE-STRUCTURE.md` call graph
 
 ## Validation Considerations
 
-- **Migration**: Requires running `20260406000000_create_tournament_locations.sql` against the DB before the app works (admin must run it)
-- **SonarCloud**: No new quality issues; ≥80% coverage on new code
-- **TypeScript**: `TournamentLocationTable` import in `database.ts` is critical — missing it causes compile error
-- **Null safety**: `parseFormData` must handle `locationsJson` being null (e.g., if `createOrUpdateTournament` is called without locations)
-- **UNIQUE constraint**: `(tournament_id, name)` — duplicate location names for the same tournament will throw at DB level; the UI should handle this gracefully (show error)
-
-## Open Questions
-
-None — requirements are clear. JSON-LD integration is out of scope per story notes.
+- **Migration**: `ALTER TABLE` adding a `NOT NULL DEFAULT '[]'` column is safe on existing rows — Postgres backfills with the default.
+- **SonarCloud**: No new quality issues; ≥80% coverage on new/changed code
+- **TypeScript**: `JSONColumnType<string[]>` — Kysely automatically parses JSONB on read, so `tournament.locations` will be `string[]` at runtime
+- **Deduplication**: Filter empty/whitespace strings before saving; UI should show an error if a duplicate name is entered (nice-to-have, not a hard requirement)

--- a/plans/STORY-310-plan.md
+++ b/plans/STORY-310-plan.md
@@ -1,0 +1,345 @@
+# Story #310: Add location data to tournaments for SportsEvent structured data
+
+## Context
+
+The SportsEvent JSON-LD added in story #303 is missing the `location` field required by Google's Rich Results Test. This story creates the data model and admin UI for tournament locations so admins can configure city/country-level names (e.g., "Qatar", "New York"). Story #303 will then use this data when generating JSON-LD structured data.
+
+A partial reference implementation exists as uncommitted changes in the main worktree — the plan incorporates those patterns with bug fixes.
+
+## Objective
+
+Enable admins to configure one or more location names for each tournament, persisted in a dedicated `tournament_locations` table. Provide read access via a server action for future JSON-LD integration.
+
+## Acceptance Criteria
+
+- [ ] Each tournament can have zero or more location names (e.g., "Qatar", "Lusail", "New York")
+- [ ] Admins can add, edit, and remove locations for a tournament in the backoffice "Tournament Data" tab
+- [ ] Tournaments with no locations configured show a clear "no locations" state in the UI
+- [ ] `getTournamentLocations` returns an empty array for tournaments with no locations (supports graceful JSON-LD omission in story #303)
+- [ ] All CRUD location actions require admin authentication
+
+## Out of Scope
+
+- JSON-LD integration (story #303 handles that)
+- Coordinates (lat/lng) or postal addresses
+- Linking locations to specific games or venues
+- Integration with the existing `tournament_venues` table
+- Displaying locations in the tournament UI (header, sidebar, etc.)
+
+## Technical Approach
+
+### Database
+
+New table `tournament_locations` with `(id, tournament_id, name, created_at, updated_at)`. Unique constraint on `(tournament_id, name)`. Cascade delete on tournament removal. Follows the same pattern as `tournament_venues`.
+
+### Repository
+
+New `app/db/tournament-location-repository.ts` using the project's `createBaseFunctions` utility plus a custom `findByTournamentId` function. Consistent with `tournament-venue-repository.ts`.
+
+### Server Actions
+
+Add to `app/actions/tournament-actions.ts`:
+- `getTournamentLocations(tournamentId)` — public read, no admin check needed
+- `createTournamentLocation`, `updateTournamentLocation`, `deleteTournamentLocation` — admin-only, for future direct CRUD use
+- Private `handleLocationsUpdate(tournamentId, locations)` — batch sync called from `createOrUpdateTournament`
+- Update `parseFormData` to extract locations with null safety
+- Update `createOrUpdateTournament` to call `handleLocationsUpdate` after saving
+
+### Admin UI
+
+Extend `TournamentMainDataTab` with an inline "Tournament Locations" section (not a new tab). The section shows a scrollable list of location TextFields with delete buttons, plus an "Add Location" button. Locations are saved when the user clicks "Save Changes".
+
+**Key design fix vs reference**: Use a `localId` field (stable UUID for new items, DB id for existing) to eliminate the key-matching bug in the uncommitted implementation.
+
+### Testing
+
+- Unit tests for `tournament-location-repository.ts` (mocked Kysely)
+- Unit tests for location actions in `tournament-actions.ts` (mocked repository + auth)
+- Component tests for the new locations UI in `TournamentMainDataTab`
+
+## Visual Prototype
+
+The "Tournament Data" tab already exists. Below the "Transfermarkt URL Template" field, add:
+
+```
+Tournament Locations                              [ + Add Location ]
+┌─────────────────────────────────────────────────────────────────┐
+│  Qatar                                                    [🗑]   │
+│  ─────────────────────────────────────────────────────────────  │
+│  Lusail                                                   [🗑]   │
+│  ─────────────────────────────────────────────────────────────  │
+│  Al Rayyan                                                [🗑]   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Empty state:
+```
+Tournament Locations                              [ + Add Location ]
+ℹ️  No locations defined for this tournament.
+```
+
+Each row is an inline `TextField` (variant="standard") with a delete `IconButton`. Changes are saved with the main "Save Changes" button at the bottom of the form.
+
+## Files to Create
+
+| File | Description |
+|------|-------------|
+| `migrations/20260406000000_create_tournament_locations.sql` | New table with unique constraint and cascade delete |
+| `app/db/tournament-location-repository.ts` | Repository with base CRUD + `findByTournamentId` |
+| `app/actions/__tests__/tournament-location-actions.test.ts` | Unit tests for location actions |
+| `app/db/__tests__/tournament-location-repository.test.ts` | Unit tests for repository |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/db/tables-definition.ts` | Add `TournamentLocationTable` interface + `TournamentLocation`, `TournamentLocationNew`, `TournamentLocationUpdate` types |
+| `app/db/database.ts` | Import `TournamentLocationTable` + add `tournament_locations` entry |
+| `app/actions/tournament-actions.ts` | Add location actions, `LocationFormDataType`, `handleLocationsUpdate`, update `parseFormData` + `createOrUpdateTournament` |
+| `app/components/backoffice/tournament-main-data-tab.tsx` | Add location state/handlers/UI section |
+| `docs/code-structure/db.md` | Add `tournament-location-repository.ts` entry |
+| `docs/code-structure/actions.md` | Add location actions + update `createOrUpdateTournament` signature |
+| `docs/code-structure/components/components-backoffice.md` | Update `TournamentMainDataTab` entry |
+| `CODE-STRUCTURE.md` | Update call graph with new location flows |
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+**YES — new flows added:**
+
+- **New: Location read flow** — `TournamentMainDataTab` (Client) →  `getTournamentLocations(tournamentId)` → `tournamentLocationRepository.findByTournamentId`
+- **Modified: Tournament save flow** — `TournamentMainDataTab` (Client) → `createOrUpdateTournament(tournamentId, formData, locale)` (extended) → `handleLocationsUpdate(tournamentId, locations)` → `tournamentLocationRepository.{create|update|delete}`
+
+---
+
+### `migrations/20260406000000_create_tournament_locations.sql` *(new)*
+
+```sql
+CREATE TABLE tournament_locations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tournament_id UUID NOT NULL REFERENCES tournaments(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (tournament_id, name)
+);
+
+CREATE INDEX idx_tournament_locations_tournament_id ON tournament_locations(tournament_id);
+
+CREATE TRIGGER update_tournament_locations_updated_at
+BEFORE UPDATE ON tournament_locations
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+```
+
+---
+
+### `app/db/tables-definition.ts` *(modified)*
+
+**New types:**
+
+```typescript
+export interface TournamentLocationTable extends Identifiable {
+  tournament_id: string;
+  name: string;
+  created_at: Generated<Date>;
+  updated_at: Generated<Date>;
+}
+
+export type TournamentLocation = Selectable<TournamentLocationTable>;
+export type TournamentLocationNew = Insertable<TournamentLocationTable>;
+export type TournamentLocationUpdate = Updateable<TournamentLocationTable>;
+```
+
+---
+
+### `app/db/tournament-location-repository.ts` *(new)*
+
+- **`tournamentLocationRepository.findByTournamentId(tournamentId: string)`**: `Promise<TournamentLocation[]>`
+  Returns all locations for a tournament ordered by name. Uses `react.cache`.
+  Tests:
+  - returns empty array when tournament has no locations
+  - returns locations sorted by name ascending
+  - only returns locations for the specified tournament (not others)
+
+- **`tournamentLocationRepository.create(data: TournamentLocationNew)`**: `Promise<TournamentLocation>`
+  From `createBaseFunctions`. Inserts a new location row.
+  Tests: covered by `createBaseFunctions` (shared utility)
+
+- **`tournamentLocationRepository.update(id: string, data: TournamentLocationUpdate)`**: `Promise<TournamentLocation>`
+  From `createBaseFunctions`. Updates a location by id.
+
+- **`tournamentLocationRepository.delete(id: string)`**: `Promise<void>`
+  From `createBaseFunctions`. Deletes a location by id.
+
+---
+
+### `app/actions/tournament-actions.ts` *(modified)*
+
+**New private interface:**
+
+```typescript
+interface LocationFormDataType {
+  id?: string;       // DB id, undefined for new unsaved items
+  localId: string;   // Stable key: DB id for existing, UUID for new
+  name: string;
+  isDeleted?: boolean;
+}
+```
+
+**New exported functions:**
+
+- **`getTournamentLocations(tournamentId: string)`**: `Promise<TournamentLocation[]>`
+  Reads all locations for a tournament. No admin check (read-only, called from admin page context).
+  Calls: `tournamentLocationRepository.findByTournamentId`
+  Tests:
+  - returns empty array when no locations exist
+  - returns array of TournamentLocation objects
+  - delegates to repository with correct tournamentId
+
+- **`createTournamentLocation(tournamentId: string, name: string)`**: `Promise<TournamentLocation>`
+  Admin-only. Creates one location.
+  Calls: `validateAdminUser`, `tournamentLocationRepository.create`
+  Tests:
+  - throws Unauthorized when user is not admin
+  - creates and returns TournamentLocation when admin
+  - passes correct tournament_id and name to repository
+
+- **`updateTournamentLocation(locationId: string, name: string)`**: `Promise<TournamentLocation>`
+  Admin-only. Updates location name.
+  Calls: `validateAdminUser`, `tournamentLocationRepository.update`
+  Tests:
+  - throws Unauthorized when user is not admin
+  - calls repository update with correct id and name
+  - returns updated TournamentLocation
+
+- **`deleteTournamentLocation(locationId: string)`**: `Promise<void>`
+  Admin-only. Deletes a location.
+  Calls: `validateAdminUser`, `tournamentLocationRepository.delete`
+  Tests:
+  - throws Unauthorized when user is not admin
+  - calls repository delete with correct id
+  - returns without error when location exists and is deleted successfully
+
+**Modified private functions:**
+
+- **`parseFormData(formData: FormData)`**: `{ tournamentData: any; logoFile: File | null; locations: LocationFormDataType[] }`
+  Extracts tournament data, logo, and locations from FormData. Null-safe for locations. Trims location names and filters out empty/whitespace-only entries.
+  Tests:
+  - returns empty array when 'locations' key is absent
+  - parses locations array from JSON string
+  - handles empty locations array
+  - trims whitespace and skips whitespace-only location names
+
+- **`handleLocationsUpdate(tournamentId: string, locations: LocationFormDataType[])`**: `Promise<void>`
+  Private. Diffs incoming locations against DB state, then creates/updates/deletes as needed. Skips items with empty names. Uses try-catch to log and skip individual errors; throws after processing all items if any errors occurred.
+  Calls: `tournamentLocationRepository.findByTournamentId`, `tournamentLocationRepository.create`, `tournamentLocationRepository.update`, `tournamentLocationRepository.delete`
+  Tests:
+  - creates new locations (no id, not deleted, non-empty name)
+  - updates existing locations (has id, not deleted)
+  - deletes locations marked isDeleted
+  - deletes locations present in DB but absent from incoming list (implicit delete)
+  - skips items with empty name strings
+  - logs and skips errors from individual repository operations (partial success)
+
+**Modified exported functions:**
+
+- **`createOrUpdateTournament(tournamentId: string | null, tournamentFormData: FormData, locale: Locale)`**: `Promise<Tournament>` *(was: `tournamentFormData: any`)*
+  Now extracts and saves locations as part of the tournament save flow.
+  Calls: `validateAdminUser`, `parseFormData` (updated), `getExistingTournament`, `handleLogoUpload`, `prepareTournamentData`, `saveOrUpdateTournament`, `cleanupOldLogo`, `handleLocationsUpdate`, `applyLocalization`
+  Tests (new scenarios only):
+  - locations are synchronized when saving a tournament
+  - no-op on locations when empty array provided
+  - returns Tournament and skips location sync if handleLocationsUpdate throws (error boundary)
+
+---
+
+### `app/components/backoffice/tournament-main-data-tab.tsx` *(modified)*
+
+**New interface** (local, not exported):
+```typescript
+interface LocationFormDataType {
+  id?: string;
+  localId: string;  // stable key: DB id for existing, UUID for new
+  name: string;
+  isDeleted?: boolean;
+}
+```
+
+**New state:** `const [locations, setLocations] = useState<LocationFormDataType[]>([])`
+
+**New handlers:**
+- `handleLocationChange(localId: string, newName: string)`: `void` — updates name by `localId`
+- `addLocation()`: `void` — appends `{ localId: crypto.randomUUID(), name: '', isDeleted: false }`
+- `deleteLocation(localId: string)`: `void` — marks matching item as `isDeleted: true`
+
+**Modified `useEffect` (fetchTournamentData):** Also calls `getTournamentLocations(tournamentId)` and maps to `LocationFormDataType` with `localId: loc.id`.
+
+**Modified `handleSubmit`:** Appends `formData.append('locations', JSON.stringify(locations))`.
+
+**New JSX section** below Transfermarkt URL Template: "Tournament Locations" with Add button, scrollable `List` of `TextField`+delete pairs, and empty `Alert`.
+
+Note: The `LocationFormDataType` interface is duplicated in `tournament-main-data-tab.tsx` (component state) and `tournament-actions.ts` (form parsing). This is intentional — the component type is purely local UI state; the action type is for parsing form data. They happen to have the same shape.
+
+**Component tests:**
+- renders "No locations" alert when no locations loaded
+- renders list of location TextFields when locations exist
+- adds new location field when "Add Location" clicked
+- removes location from visible list when delete clicked
+- sends locations JSON in FormData on submit
+
+---
+
+## Testing Strategy
+
+### Repository Tests (`tournament-location-repository.test.ts`)
+Mock `db` from `@/app/db/database`. Test `findByTournamentId` with mocked `selectFrom` chain using `vi.fn()` to create mock query builders.
+
+### Action Tests (`tournament-location-actions.test.ts`)
+Mock `tournamentLocationRepository` using `vi.mock()` and `getLoggedInUser` using `vi.mocked()`. Use `testFactories.createTournamentLocation()` for fixture data. Cover:
+- All 4 exported location actions (happy path + unauthorized)
+- `parseFormData` null-safety, parsing, and whitespace trimming
+- `handleLocationsUpdate` diff logic (creates/updates/deletes/implicit deletes/partial errors)
+
+### Component Tests
+Extend or create tests for `TournamentMainDataTab`:
+- Mock `getTournamentLocations` and `createOrUpdateTournament`
+- Verify location list renders and interactions work
+
+### Coverage Target
+≥80% on new files (repository, actions, component location logic)
+
+## Implementation Steps
+
+### Wave 1 — Data Layer (prerequisite for everything)
+1. Create `migrations/20260406000000_create_tournament_locations.sql`
+2. Update `app/db/tables-definition.ts` — add `TournamentLocationTable` + types
+3. Update `app/db/database.ts` — import + add to `Database` interface
+4. Create `app/db/tournament-location-repository.ts`
+
+### Wave 2 — Actions Layer
+5. Update `app/actions/tournament-actions.ts` — add `LocationFormDataType`, location actions, `parseFormData` update, `handleLocationsUpdate`, `createOrUpdateTournament` update
+
+### Wave 3 — UI
+6. Update `app/components/backoffice/tournament-main-data-tab.tsx` — add location state, handlers, and UI section
+
+### Wave 4 — Tests + Documentation
+7. Create `app/db/__tests__/tournament-location-repository.test.ts`
+8. Create `app/actions/__tests__/tournament-location-actions.test.ts`
+9. Update `docs/code-structure/db.md`
+10. Update `docs/code-structure/actions.md`
+11. Update `docs/code-structure/components/components-backoffice.md`
+12. Update `CODE-STRUCTURE.md` call graph
+
+## Validation Considerations
+
+- **Migration**: Requires running `20260406000000_create_tournament_locations.sql` against the DB before the app works (admin must run it)
+- **SonarCloud**: No new quality issues; ≥80% coverage on new code
+- **TypeScript**: `TournamentLocationTable` import in `database.ts` is critical — missing it causes compile error
+- **Null safety**: `parseFormData` must handle `locationsJson` being null (e.g., if `createOrUpdateTournament` is called without locations)
+- **UNIQUE constraint**: `(tournament_id, name)` — duplicate location names for the same tournament will throw at DB level; the UI should handle this gracefully (show error)
+
+## Open Questions
+
+None — requirements are clear. JSON-LD integration is out of scope per story notes.

--- a/plans/STORY-310-plan.md
+++ b/plans/STORY-310-plan.md
@@ -211,6 +211,18 @@ Use `vi.mock('../../actions/tournament-actions')` with `vi.mocked(getTournamentL
 8. Update `docs/code-structure/components/components-backoffice.md`
 9. Update `CODE-STRUCTURE.md` call graph
 
+## Implementation Amendments
+
+### Amendment 1: Use ColumnType instead of JSONColumnType for locations
+**Date:** 2026-04-06
+**Reason:** `JSONColumnType<string[]>` made `locations` required in inserts, breaking `backoffice-actions.ts` and `awards-tab.tsx` which create/update tournaments without providing `locations`. Since locations has a DB DEFAULT '[]', it should be optional in inserts.
+**Change:** Used `ColumnType<string[], string[] | string | undefined, string[] | string>` to explicitly define select=`string[]`, insert=optional, update=accepts array or JSON string. Also added `ColumnType` to imports.
+
+### Amendment 2: parseFormData stringifies locations before DB write
+**Date:** 2026-04-06
+**Reason:** Following the same pattern as `theme` (which is explicitly JSON.stringify'd before DB write), `locations` must be stringified before being passed to Kysely to ensure correct JSONB serialization.
+**Change:** `parseFormData` now returns `locations: JSON.stringify(parsedLocations)` (a raw JSON string) instead of the `string[]` array directly.
+
 ## Validation Considerations
 
 - **Migration**: `ALTER TABLE` adding a `NOT NULL DEFAULT '[]'` column is safe on existing rows — Postgres backfills with the default.


### PR DESCRIPTION
Fixes #310

## Summary
Implementation plan for the story.

## Plan Document
See `plans/STORY-310-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)