### PR TITLE
Plan: [Story] Favorite friend groups and navigation improvements #332

### DIFF
--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -381,11 +381,22 @@ Key flows:
                   └── ScoreGrowthChart [renders] (when rows.length > 0)
 
 13. Friend group management
-    FriendGroupsList / TournamentGroupsList [Client]
+    FriendGroupsList [Client] (sidebar)
       ├── createDbGroup [server action]
       │     └── createProdeGroup
-      └── deleteGroup [server action]
-            └── deleteProdeGroup
+      ├── deleteGroup [server action]
+      │     └── deleteProdeGroup
+      ├── toggleFavoriteGroupAction [server action]
+      │     └── getFavoriteGroupIds, addFavoriteGroup | removeFavoriteGroup
+      └── setMainGroupAction [server action]
+            └── getFavoriteGroupIds, setMainGroup
+    TournamentGroupsList [Client] (friend-groups page)
+      ├── createDbGroup [server action]
+      │     └── createProdeGroup
+      ├── toggleFavoriteGroupAction [server action]
+      │     └── getFavoriteGroupIds, addFavoriteGroup | removeFavoriteGroup
+      └── setMainGroupAction [server action]
+            └── getFavoriteGroupIds, setMainGroup
     LeaveGroupButton [Client]
       └── leaveGroupAction [server action]
             └── deleteParticipantFromGroup
@@ -638,8 +649,13 @@ Key flows:
         allGroups = [...userGroups, ...participantGroups]
         → await Promise.all(allGroups.map(g => getGroupRankingForUser(user.id, g.id, tournamentId)))
         → derives groupRanks: Record<string, number> (skips null results)
-        → passes groupRanks to TournamentSidebar → FriendGroupsList
+        → passes groupRanks, favoriteGroupIds, mainGroupId to TournamentSidebar → FriendGroupsList
           FriendGroupsList shows primary group rank in CardHeader subheader text and per-row Chips before group name links
+          FriendGroupsList sorts groups: main → favorites (alpha) → others; renders star/crown icons per row
+    - getGroupsForUser() now also fetches getFavoriteGroupIds and getMainGroupId in parallel
+        → returns favoriteGroupIds: string[] and mainGroupId: string | null alongside existing fields
+    - friend-groups/page.tsx also destructures favoriteGroupIds/mainGroupId from getGroupsForUser()
+        → passes to TournamentGroupsList for sorting and star/crown rendering on cards
     - GroupSelector [Client] (top nav) now calls isHubEnabled():
         when true  → Hub tab rendered before Matches, links to /tournaments/${id}/hub
         when false → Hub tab absent

--- a/__tests__/actions/favorite-group-actions.test.ts
+++ b/__tests__/actions/favorite-group-actions.test.ts
@@ -1,0 +1,157 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import * as userActions from '../../app/actions/user-actions'
+import * as favoriteGroupsRepository from '../../app/db/favorite-groups-repository'
+import {
+  toggleFavoriteGroupAction,
+  setMainGroupAction,
+  clearMainGroupAction,
+} from '../../app/actions/favorite-group-actions'
+import { revalidatePath } from 'next/cache'
+import { testFactories } from '../db/test-factories'
+
+vi.mock('../../auth', () => ({ auth: vi.fn() }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('../../app/actions/user-actions')
+vi.mock('../../app/db/favorite-groups-repository')
+
+const mockGetLoggedInUser = vi.mocked(userActions.getLoggedInUser)
+const mockGetFavoriteGroupIds = vi.mocked(favoriteGroupsRepository.getFavoriteGroupIds)
+const mockAddFavoriteGroup = vi.mocked(favoriteGroupsRepository.addFavoriteGroup)
+const mockRemoveFavoriteGroup = vi.mocked(favoriteGroupsRepository.removeFavoriteGroup)
+const mockSetMainGroup = vi.mocked(favoriteGroupsRepository.setMainGroup)
+const mockClearMainGroup = vi.mocked(favoriteGroupsRepository.clearMainGroup)
+const mockRevalidatePath = vi.mocked(revalidatePath)
+
+const USER_ID = 'user-1'
+const GROUP_ID = 'group-1'
+
+const defaultUser = testFactories.user({ id: USER_ID })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetLoggedInUser.mockResolvedValue(defaultUser as any)
+  mockGetFavoriteGroupIds.mockResolvedValue([])
+  mockAddFavoriteGroup.mockResolvedValue(undefined)
+  mockRemoveFavoriteGroup.mockResolvedValue(undefined)
+  mockSetMainGroup.mockResolvedValue(undefined)
+  mockClearMainGroup.mockResolvedValue(undefined)
+})
+
+// ---------------------------------------------------------------------------
+// toggleFavoriteGroupAction
+// ---------------------------------------------------------------------------
+
+describe('toggleFavoriteGroupAction', () => {
+  it('throws Unauthorized when user is not logged in', async () => {
+    mockGetLoggedInUser.mockResolvedValue(null as any)
+
+    await expect(toggleFavoriteGroupAction(GROUP_ID)).rejects.toThrow('Unauthorized')
+  })
+
+  it('adds the group to favorites when not currently favorited', async () => {
+    mockGetFavoriteGroupIds.mockResolvedValue([])
+
+    const result = await toggleFavoriteGroupAction(GROUP_ID)
+
+    expect(mockAddFavoriteGroup).toHaveBeenCalledWith(USER_ID, GROUP_ID)
+    expect(mockRemoveFavoriteGroup).not.toHaveBeenCalled()
+    expect(result).toEqual({ isFavorite: true })
+  })
+
+  it('removes the group from favorites when currently favorited', async () => {
+    mockGetFavoriteGroupIds.mockResolvedValue([GROUP_ID])
+
+    const result = await toggleFavoriteGroupAction(GROUP_ID)
+
+    expect(mockRemoveFavoriteGroup).toHaveBeenCalledWith(USER_ID, GROUP_ID)
+    expect(mockAddFavoriteGroup).not.toHaveBeenCalled()
+    expect(result).toEqual({ isFavorite: false })
+  })
+
+  it('calls revalidatePath after toggling', async () => {
+    await toggleFavoriteGroupAction(GROUP_ID)
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/[locale]/tournaments/[id]', 'layout')
+  })
+
+  it('does not affect other favorited groups when removing one', async () => {
+    const otherGroupId = 'group-2'
+    mockGetFavoriteGroupIds.mockResolvedValue([GROUP_ID, otherGroupId])
+
+    await toggleFavoriteGroupAction(GROUP_ID)
+
+    expect(mockRemoveFavoriteGroup).toHaveBeenCalledWith(USER_ID, GROUP_ID)
+    expect(mockRemoveFavoriteGroup).not.toHaveBeenCalledWith(USER_ID, otherGroupId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setMainGroupAction
+// ---------------------------------------------------------------------------
+
+describe('setMainGroupAction', () => {
+  it('throws Unauthorized when user is not logged in', async () => {
+    mockGetLoggedInUser.mockResolvedValue(null as any)
+
+    await expect(setMainGroupAction(GROUP_ID)).rejects.toThrow('Unauthorized')
+  })
+
+  it('throws when the group is not in the user favorites', async () => {
+    mockGetFavoriteGroupIds.mockResolvedValue([])
+
+    await expect(setMainGroupAction(GROUP_ID)).rejects.toThrow(
+      'Group must be a favorite before setting as main'
+    )
+    expect(mockSetMainGroup).not.toHaveBeenCalled()
+  })
+
+  it('sets the group as main when it is already a favorite', async () => {
+    mockGetFavoriteGroupIds.mockResolvedValue([GROUP_ID])
+
+    await setMainGroupAction(GROUP_ID)
+
+    expect(mockSetMainGroup).toHaveBeenCalledWith(USER_ID, GROUP_ID)
+  })
+
+  it('calls revalidatePath after setting main group', async () => {
+    mockGetFavoriteGroupIds.mockResolvedValue([GROUP_ID])
+
+    await setMainGroupAction(GROUP_ID)
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/[locale]/tournaments/[id]', 'layout')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// clearMainGroupAction
+// ---------------------------------------------------------------------------
+
+describe('clearMainGroupAction', () => {
+  it('throws Unauthorized when user is not logged in', async () => {
+    mockGetLoggedInUser.mockResolvedValue(null as any)
+
+    await expect(clearMainGroupAction()).rejects.toThrow('Unauthorized')
+  })
+
+  it('calls clearMainGroup for the logged-in user', async () => {
+    await clearMainGroupAction()
+
+    expect(mockClearMainGroup).toHaveBeenCalledWith(USER_ID)
+  })
+
+  it('calls revalidatePath after clearing main group', async () => {
+    await clearMainGroupAction()
+
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/[locale]/tournaments/[id]', 'layout')
+  })
+
+  it('does not call clearMainGroup for other users', async () => {
+    const otherUser = testFactories.user({ id: 'other-user' })
+    mockGetLoggedInUser.mockResolvedValue(otherUser as any)
+
+    await clearMainGroupAction()
+
+    expect(mockClearMainGroup).toHaveBeenCalledWith('other-user')
+    expect(mockClearMainGroup).not.toHaveBeenCalledWith(USER_ID)
+  })
+})

--- a/__tests__/actions/prode-group-actions.test.ts
+++ b/__tests__/actions/prode-group-actions.test.ts
@@ -39,6 +39,10 @@ vi.mock('../../app/db/prode-group-join-request-repository');
 vi.mock('../../app/actions/short-url-actions');
 vi.mock('../../app/utils/email-templates');
 vi.mock('../../app/utils/email');
+vi.mock('../../app/db/favorite-groups-repository', () => ({
+  getFavoriteGroupIds: vi.fn().mockResolvedValue([]),
+  getMainGroupId: vi.fn().mockResolvedValue(null),
+}));
 
 const mockGetLoggedInUser = vi.mocked(userActions.getLoggedInUser);
 const mockCreateProdeGroup = vi.mocked(prodeGroupRepository.createProdeGroup);
@@ -188,7 +192,7 @@ describe('Prode Group Actions', () => {
   describe('getGroupsForUser', () => {
     it('returns user and participant groups', async () => {
       const result = await getGroupsForUser();
-      expect(result).toEqual({ userGroups: [mockGroup], participantGroups: [mockGroup], pendingRequests: [] });
+      expect(result).toEqual({ userGroups: [mockGroup], participantGroups: [mockGroup], pendingRequests: [], favoriteGroupIds: [], mainGroupId: null });
     });
     it('returns undefined if not logged in', async () => {
       mockGetLoggedInUser.mockResolvedValue(undefined);

--- a/__tests__/actions/prode-group-actions.test.ts
+++ b/__tests__/actions/prode-group-actions.test.ts
@@ -41,7 +41,6 @@ vi.mock('../../app/utils/email-templates');
 vi.mock('../../app/utils/email');
 vi.mock('../../app/db/favorite-groups-repository', () => ({
   getFavoriteGroupIds: vi.fn().mockResolvedValue([]),
-  getMainGroupId: vi.fn().mockResolvedValue(null),
 }));
 
 const mockGetLoggedInUser = vi.mocked(userActions.getLoggedInUser);
@@ -192,7 +191,7 @@ describe('Prode Group Actions', () => {
   describe('getGroupsForUser', () => {
     it('returns user and participant groups', async () => {
       const result = await getGroupsForUser();
-      expect(result).toEqual({ userGroups: [mockGroup], participantGroups: [mockGroup], pendingRequests: [], favoriteGroupIds: [], mainGroupId: null });
+      expect(result).toEqual({ userGroups: [mockGroup], participantGroups: [mockGroup], pendingRequests: [], favoriteGroupIds: [] });
     });
     it('returns undefined if not logged in', async () => {
       mockGetLoggedInUser.mockResolvedValue(undefined);

--- a/__tests__/components/tournament-page/tournament-group-card.test.tsx
+++ b/__tests__/components/tournament-page/tournament-group-card.test.tsx
@@ -71,8 +71,8 @@ describe('TournamentGroupCard', () => {
 
   it('has link to tournament-scoped friend group detail page', () => {
     renderWithTheme(<TournamentGroupCard group={mockGroup} tournamentId={tournamentId} />);
-    // Spanish: "Ver Marcador" instead of "View Leaderboard"
-    const link = screen.getByRole('link', { name: /Ver Marcador/ });
+    // Spanish: "Ver Posiciones" instead of "View Leaderboard" (fixed from "Ver Posiciones" in Story #332)
+    const link = screen.getByRole('link', { name: /Ver Posiciones/ });
     expect(link).toHaveAttribute('href', `/es/tournaments/${tournamentId}/friend-groups/${mockGroup.groupId}`);
   });
 
@@ -189,7 +189,7 @@ describe('TournamentGroupCard', () => {
       expect(pendingButton).toBeDisabled();
     });
 
-    it('shows "Ver Marcador" link when userStatus is member', () => {
+    it('shows "Ver Posiciones" link when userStatus is member', () => {
       renderWithTheme(
         <TournamentGroupCard
           variant="discovery"
@@ -197,10 +197,10 @@ describe('TournamentGroupCard', () => {
           tournamentId={tournamentId}
         />
       );
-      expect(screen.getByRole('link', { name: /Ver Marcador/ })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /Ver Posiciones/ })).toBeInTheDocument();
     });
 
-    it('Ver Marcador link points to the correct URL', () => {
+    it('Ver Posiciones link points to the correct URL', () => {
       renderWithTheme(
         <TournamentGroupCard
           variant="discovery"
@@ -208,7 +208,7 @@ describe('TournamentGroupCard', () => {
           tournamentId={tournamentId}
         />
       );
-      const link = screen.getByRole('link', { name: /Ver Marcador/ });
+      const link = screen.getByRole('link', { name: /Ver Posiciones/ });
       expect(link).toHaveAttribute(
         'href',
         `/es/tournaments/${tournamentId}/friend-groups/${discoveryGroup.id}`

--- a/__tests__/db/favorite-groups-repository.test.ts
+++ b/__tests__/db/favorite-groups-repository.test.ts
@@ -1,0 +1,185 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import {
+  getFavoriteGroupIds,
+  getMainGroupId,
+  addFavoriteGroup,
+  removeFavoriteGroup,
+  setMainGroup,
+  clearMainGroup,
+} from '../../app/db/favorite-groups-repository'
+import {
+  createMockSelectQuery,
+  createMockInsertQuery,
+  createMockUpdateQuery,
+  createMockDeleteQuery,
+  createMockNullQuery,
+  expectKyselyQuery,
+} from './mock-helpers'
+
+const mockDb = vi.hoisted(() => ({
+  selectFrom: vi.fn(),
+  insertInto: vi.fn(),
+  updateTable: vi.fn(),
+  deleteFrom: vi.fn(),
+}))
+
+vi.mock('../../app/db/database', () => ({ db: mockDb }))
+
+const USER_ID = 'user-1'
+const GROUP_ID = 'group-1'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// getFavoriteGroupIds
+// ---------------------------------------------------------------------------
+
+describe('getFavoriteGroupIds', () => {
+  it('returns group ids for the user', async () => {
+    const rows = [{ group_id: 'group-1' }, { group_id: 'group-2' }]
+    const mockQuery = createMockSelectQuery(rows)
+    mockDb.selectFrom.mockReturnValue(mockQuery)
+
+    const result = await getFavoriteGroupIds(USER_ID)
+
+    expect(result).toEqual(['group-1', 'group-2'])
+    expectKyselyQuery(mockDb, mockQuery)
+      .toHaveCalledSelectFrom('user_favorite_groups')
+      .toHaveCalledWhere('user_id', '=', USER_ID)
+      .toHaveCalledExecute()
+  })
+
+  it('returns empty array when user has no favorites', async () => {
+    const mockQuery = createMockSelectQuery([])
+    mockDb.selectFrom.mockReturnValue(mockQuery)
+
+    const result = await getFavoriteGroupIds(USER_ID)
+
+    expect(result).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getMainGroupId
+// ---------------------------------------------------------------------------
+
+describe('getMainGroupId', () => {
+  it('returns the group id when a main group is set', async () => {
+    const mockQuery = createMockSelectQuery({ group_id: GROUP_ID })
+    mockDb.selectFrom.mockReturnValue(mockQuery)
+
+    const result = await getMainGroupId(USER_ID)
+
+    expect(result).toBe(GROUP_ID)
+    expectKyselyQuery(mockDb, mockQuery)
+      .toHaveCalledSelectFrom('user_favorite_groups')
+      .toHaveCalledWhere('user_id', '=', USER_ID)
+      .toHaveCalledWhere('is_main', '=', true)
+      .toHaveCalledExecuteTakeFirst()
+  })
+
+  it('returns null when no main group is set', async () => {
+    const mockQuery = createMockNullQuery()
+    mockDb.selectFrom.mockReturnValue(mockQuery)
+
+    const result = await getMainGroupId(USER_ID)
+
+    expect(result).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addFavoriteGroup
+// ---------------------------------------------------------------------------
+
+describe('addFavoriteGroup', () => {
+  it('inserts a new favorite row with is_main=false', async () => {
+    const mockQuery = createMockInsertQuery({ user_id: USER_ID, group_id: GROUP_ID, is_main: false })
+    mockDb.insertInto.mockReturnValue(mockQuery)
+
+    await addFavoriteGroup(USER_ID, GROUP_ID)
+
+    expectKyselyQuery(mockDb, mockQuery).toHaveCalledInsertInto('user_favorite_groups')
+    expect(mockQuery.values).toHaveBeenCalledWith({
+      user_id: USER_ID,
+      group_id: GROUP_ID,
+      is_main: false,
+    })
+    expect(mockQuery.onConflict).toHaveBeenCalled()
+    expectKyselyQuery(mockDb, mockQuery).toHaveCalledExecute()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// removeFavoriteGroup
+// ---------------------------------------------------------------------------
+
+describe('removeFavoriteGroup', () => {
+  it('deletes the favorite row for the given user and group', async () => {
+    const mockQuery = createMockDeleteQuery({})
+    mockDb.deleteFrom.mockReturnValue(mockQuery)
+
+    await removeFavoriteGroup(USER_ID, GROUP_ID)
+
+    expectKyselyQuery(mockDb, mockQuery)
+      .toHaveCalledDeleteFrom('user_favorite_groups')
+      .toHaveCalledWhere('user_id', '=', USER_ID)
+      .toHaveCalledWhere('group_id', '=', GROUP_ID)
+      .toHaveCalledExecute()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setMainGroup
+// ---------------------------------------------------------------------------
+
+describe('setMainGroup', () => {
+  it('clears any existing main group then upserts the new main group', async () => {
+    const mockUpdateQuery = createMockUpdateQuery({})
+    const mockInsertQuery = createMockInsertQuery({})
+    mockDb.updateTable.mockReturnValue(mockUpdateQuery)
+    mockDb.insertInto.mockReturnValue(mockInsertQuery)
+
+    await setMainGroup(USER_ID, GROUP_ID)
+
+    // First: clear existing main
+    expectKyselyQuery(mockDb, mockUpdateQuery)
+      .toHaveCalledUpdateTable('user_favorite_groups')
+      .toHaveCalledWhere('user_id', '=', USER_ID)
+      .toHaveCalledWhere('is_main', '=', true)
+      .toHaveCalledExecute()
+    expect(mockUpdateQuery.set).toHaveBeenCalledWith({ is_main: false })
+
+    // Then: upsert the new main
+    expectKyselyQuery(mockDb, mockInsertQuery).toHaveCalledInsertInto('user_favorite_groups')
+    expect(mockInsertQuery.values).toHaveBeenCalledWith({
+      user_id: USER_ID,
+      group_id: GROUP_ID,
+      is_main: true,
+    })
+    expect(mockInsertQuery.onConflict).toHaveBeenCalled()
+    expectKyselyQuery(mockDb, mockInsertQuery).toHaveCalledExecute()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// clearMainGroup
+// ---------------------------------------------------------------------------
+
+describe('clearMainGroup', () => {
+  it('sets is_main=false for the user current main group', async () => {
+    const mockQuery = createMockUpdateQuery({})
+    mockDb.updateTable.mockReturnValue(mockQuery)
+
+    await clearMainGroup(USER_ID)
+
+    expectKyselyQuery(mockDb, mockQuery)
+      .toHaveCalledUpdateTable('user_favorite_groups')
+      .toHaveCalledWhere('user_id', '=', USER_ID)
+      .toHaveCalledWhere('is_main', '=', true)
+      .toHaveCalledExecute()
+    expect(mockQuery.set).toHaveBeenCalledWith({ is_main: false })
+  })
+})

--- a/app/[locale]/tournaments/[id]/friend-groups/page.tsx
+++ b/app/[locale]/tournaments/[id]/friend-groups/page.tsx
@@ -46,6 +46,8 @@ export default async function TournamentGroupsPage(props: Props) {
       groups={groupStats}
       tournamentId={tournamentId}
       pendingRequests={pendingRequests}
+      favoriteGroupIds={prodeGroups.favoriteGroupIds}
+      mainGroupId={prodeGroups.mainGroupId}
     />
   );
 }

--- a/app/[locale]/tournaments/[id]/friend-groups/page.tsx
+++ b/app/[locale]/tournaments/[id]/friend-groups/page.tsx
@@ -47,7 +47,6 @@ export default async function TournamentGroupsPage(props: Props) {
       tournamentId={tournamentId}
       pendingRequests={pendingRequests}
       favoriteGroupIds={prodeGroups.favoriteGroupIds}
-      mainGroupId={prodeGroups.mainGroupId}
     />
   );
 }

--- a/app/actions/__tests__/hub-actions.test.ts
+++ b/app/actions/__tests__/hub-actions.test.ts
@@ -7,6 +7,7 @@ import * as tournamentRepository from '@/app/db/tournament-repository'
 import * as prodeGroupRepository from '@/app/db/prode-group-repository'
 import * as groupRankingRepository from '@/app/db/group-ranking-repository'
 import * as tournamentGuessRepository from '@/app/db/tournament-guess-repository'
+import * as favoriteGroupsRepository from '@/app/db/favorite-groups-repository'
 import * as userActions from '../user-actions'
 import { applyLocalizationBatch } from '@/app/utils/localization-helper'
 import { testFactories } from '../../../__tests__/db/test-factories'
@@ -36,6 +37,10 @@ vi.mock('@/app/db/tournament-repository', () => ({
 
 vi.mock('../user-actions', () => ({
   getLoggedInUser: vi.fn(),
+}))
+
+vi.mock('@/app/db/favorite-groups-repository', () => ({
+  getFavoriteGroupIds: vi.fn(),
 }))
 
 vi.mock('@/app/db/prode-group-repository', () => ({
@@ -371,6 +376,7 @@ describe('getLeaderboardPeekData', () => {
       makeRankings(group1.id, [USER_ID, 'user-2', 'user-3'], USER_ID)
     )
     vi.mocked(groupRankingRepository.getLatestTwoGroupRankingSnapshots).mockResolvedValue([])
+    vi.mocked(favoriteGroupsRepository.getFavoriteGroupIds).mockResolvedValue([])
   })
 
   it('returns empty array when user is not authenticated', async () => {
@@ -405,6 +411,27 @@ describe('getLeaderboardPeekData', () => {
     expect(result).toHaveLength(3)
     expect(result[0].groupId).toBe(group1.id)
     expect(result[1].groupId).toBe(group2.id)
+    expect(result[2].groupId).toBe(group3.id)
+  })
+
+  it('sorts favorite groups before non-favorites regardless of member count', async () => {
+    // group1: 5 members (largest), group2: 3 members (favorited), group3: 2 members
+    // Without favorites: group1, group2, group3
+    // With group2 favorited: group2 (favorite), group1 (most members), group3
+    vi.mocked(prodeGroupRepository.findProdeGroupsByOwner).mockResolvedValue([
+      group1, group2, group3,
+    ])
+    vi.mocked(groupRankingRepository.getLatestRankingsForGroup)
+      .mockResolvedValueOnce(makeRankings(group1.id, [USER_ID, 'u2', 'u3', 'u4', 'u5'], USER_ID))
+      .mockResolvedValueOnce(makeRankings(group2.id, [USER_ID, 'u2', 'u3'], USER_ID))
+      .mockResolvedValueOnce(makeRankings(group3.id, [USER_ID, 'u2'], USER_ID))
+    vi.mocked(favoriteGroupsRepository.getFavoriteGroupIds).mockResolvedValue([group2.id])
+
+    const result = await getLeaderboardPeekData(TOURNAMENT_ID, 'en')
+
+    expect(result).toHaveLength(3)
+    expect(result[0].groupId).toBe(group2.id) // favorite first
+    expect(result[1].groupId).toBe(group1.id) // then by member count desc
     expect(result[2].groupId).toBe(group3.id)
   })
 

--- a/app/actions/favorite-group-actions.ts
+++ b/app/actions/favorite-group-actions.ts
@@ -1,0 +1,55 @@
+'use server'
+
+import { revalidatePath } from 'next/cache'
+import { getLoggedInUser } from './user-actions'
+import {
+  getFavoriteGroupIds,
+  addFavoriteGroup,
+  removeFavoriteGroup,
+  setMainGroup,
+  clearMainGroup,
+} from '../db/favorite-groups-repository'
+
+export async function toggleFavoriteGroupAction(groupId: string): Promise<{ isFavorite: boolean }> {
+  const user = await getLoggedInUser()
+  if (!user) {
+    throw new Error('Unauthorized')
+  }
+
+  const favoriteIds = await getFavoriteGroupIds(user.id)
+  const isFavorite = favoriteIds.includes(groupId)
+
+  if (isFavorite) {
+    await removeFavoriteGroup(user.id, groupId)
+  } else {
+    await addFavoriteGroup(user.id, groupId)
+  }
+
+  revalidatePath('/[locale]/tournaments/[id]', 'layout')
+  return { isFavorite: !isFavorite }
+}
+
+export async function setMainGroupAction(groupId: string): Promise<void> {
+  const user = await getLoggedInUser()
+  if (!user) {
+    throw new Error('Unauthorized')
+  }
+
+  const favoriteIds = await getFavoriteGroupIds(user.id)
+  if (!favoriteIds.includes(groupId)) {
+    throw new Error('Group must be a favorite before setting as main')
+  }
+
+  await setMainGroup(user.id, groupId)
+  revalidatePath('/[locale]/tournaments/[id]', 'layout')
+}
+
+export async function clearMainGroupAction(): Promise<void> {
+  const user = await getLoggedInUser()
+  if (!user) {
+    throw new Error('Unauthorized')
+  }
+
+  await clearMainGroup(user.id)
+  revalidatePath('/[locale]/tournaments/[id]', 'layout')
+}

--- a/app/actions/hub-actions.ts
+++ b/app/actions/hub-actions.ts
@@ -6,6 +6,7 @@ import { findTeamInTournament, findQualifiedTeams } from '../db/team-repository'
 import { findTournamentById } from '../db/tournament-repository'
 import { findProdeGroupsByOwner, findProdeGroupsByParticipant } from '../db/prode-group-repository'
 import { getLatestRankingsForGroup, getLatestTwoGroupRankingSnapshots } from '../db/group-ranking-repository'
+import { getFavoriteGroupIds } from '../db/favorite-groups-repository'
 import { getTournamentGuessStatsForUsers, findTournamentGuessByUserIdTournament } from '../db/tournament-guess-repository'
 import { getLoggedInUser } from './user-actions'
 import { applyLocalizationBatch } from '../utils/localization-helper'
@@ -192,9 +193,10 @@ export async function getLeaderboardPeekData(
   const user = await getLoggedInUser()
   if (!user?.id) return []
 
-  const [ownedGroups, participantGroups] = await Promise.all([
+  const [ownedGroups, participantGroups, favoriteGroupIds] = await Promise.all([
     findProdeGroupsByOwner(user.id),
     findProdeGroupsByParticipant(user.id),
+    getFavoriteGroupIds(user.id),
   ])
 
   // Deduplicate: owner may also appear in participant list
@@ -226,8 +228,14 @@ export async function getLeaderboardPeekData(
     }
   }
 
-  // Sort by member count descending (most active groups first), take top 3
-  candidates.sort((a, b) => b.rankings.length - a.rankings.length)
+  // Sort: favorites first (by member count desc), then non-favorites (by member count desc)
+  const favoriteSet = new Set(favoriteGroupIds)
+  candidates.sort((a, b) => {
+    const aFav = favoriteSet.has(a.group.id) ? 1 : 0
+    const bFav = favoriteSet.has(b.group.id) ? 1 : 0
+    if (bFav !== aFav) return bFav - aFav
+    return b.rankings.length - a.rankings.length
+  })
   const topCandidates = candidates.slice(0, MAX_PEEK_GROUPS)
 
   if (topCandidates.length === 0) return []

--- a/app/actions/prode-group-actions.ts
+++ b/app/actions/prode-group-actions.ts
@@ -27,6 +27,7 @@ import { findTournamentGuessByUserIdsTournament } from '../db/tournament-guess-r
 import { customToMap } from "../utils/ObjectUtils";
 import { TournamentGroupStats, UserScore } from "../definitions";
 import { findUsersByIds } from "../db/users-repository";
+import { getFavoriteGroupIds, getMainGroupId } from "../db/favorite-groups-repository";
 
 export async function createDbGroup( groupName: string) {
   const user = await getLoggedInUser()
@@ -46,9 +47,13 @@ export async function getGroupsForUser() {
   if(!user) {
     return
   }
-  const userGroups = await findProdeGroupsByOwner(user.id)
-  const participantGroups = await findProdeGroupsByParticipant(user.id)
-  const pendingRequests = await findJoinRequestsByUser(user.id, 'pending')
+  const [userGroups, participantGroups, pendingRequests, favoriteGroupIds, mainGroupId] = await Promise.all([
+    findProdeGroupsByOwner(user.id),
+    findProdeGroupsByParticipant(user.id),
+    findJoinRequestsByUser(user.id, 'pending'),
+    getFavoriteGroupIds(user.id),
+    getMainGroupId(user.id),
+  ])
 
   return ({
     userGroups,
@@ -57,7 +62,9 @@ export async function getGroupsForUser() {
       id: r.id,
       group_id: r.group_id,
       group_name: r.group_name
-    }))
+    })),
+    favoriteGroupIds,
+    mainGroupId,
   })
 }
 

--- a/app/actions/prode-group-actions.ts
+++ b/app/actions/prode-group-actions.ts
@@ -27,7 +27,7 @@ import { findTournamentGuessByUserIdsTournament } from '../db/tournament-guess-r
 import { customToMap } from "../utils/ObjectUtils";
 import { TournamentGroupStats, UserScore } from "../definitions";
 import { findUsersByIds } from "../db/users-repository";
-import { getFavoriteGroupIds, getMainGroupId } from "../db/favorite-groups-repository";
+import { getFavoriteGroupIds } from "../db/favorite-groups-repository";
 
 export async function createDbGroup( groupName: string) {
   const user = await getLoggedInUser()
@@ -47,12 +47,11 @@ export async function getGroupsForUser() {
   if(!user) {
     return
   }
-  const [userGroups, participantGroups, pendingRequests, favoriteGroupIds, mainGroupId] = await Promise.all([
+  const [userGroups, participantGroups, pendingRequests, favoriteGroupIds] = await Promise.all([
     findProdeGroupsByOwner(user.id),
     findProdeGroupsByParticipant(user.id),
     findJoinRequestsByUser(user.id, 'pending'),
     getFavoriteGroupIds(user.id),
-    getMainGroupId(user.id),
   ])
 
   return ({
@@ -64,7 +63,6 @@ export async function getGroupsForUser() {
       group_name: r.group_name
     })),
     favoriteGroupIds,
-    mainGroupId,
   })
 }
 

--- a/app/components/tournament-page/friend-groups-list.tsx
+++ b/app/components/tournament-page/friend-groups-list.tsx
@@ -17,16 +17,12 @@ import {
   ExpandMore as ExpandMoreIcon,
   Groups as GroupsIcon,
   Search as SearchIcon,
-  Star as StarIcon,
-  StarBorder as StarBorderIcon,
-  WorkspacePremium as WorkspacePremiumIcon,
 } from "@mui/icons-material";
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import {ExpandMore} from './expand-more';
 import {Controller, useForm} from "react-hook-form";
 import * as React from "react";
 import {createDbGroup, deleteGroup} from "../../actions/prode-group-actions";
-import { toggleFavoriteGroupAction, setMainGroupAction } from "../../actions/favorite-group-actions";
 import InviteFriendsDialog from "../invite-friends-dialog";
 import Link from "next/link";
 import { useLocale, useTranslations } from 'next-intl';
@@ -43,23 +39,17 @@ type Props = {
   pendingRequests?: { id: string; group_id: string; group_name?: string | null }[]
   groupRanks?: Record<string, number>
   favoriteGroupIds?: string[]
-  mainGroupId?: string | null
 }
 
 type GroupForm = {
   name: string
 }
 
-function sortGroups(groups: GroupItem[], favoriteIds: string[], mainGroupId: string | null): GroupItem[] {
+function sortGroups(groups: GroupItem[], favoriteIds: string[]): GroupItem[] {
   return [...groups].sort((a, b) => {
-    const aIsMain = a.id === mainGroupId
-    const bIsMain = b.id === mainGroupId
-    if (aIsMain !== bIsMain) return aIsMain ? -1 : 1
-
     const aIsFav = favoriteIds.includes(a.id)
     const bIsFav = favoriteIds.includes(b.id)
     if (aIsFav !== bIsFav) return aIsFav ? -1 : 1
-
     if (aIsFav && bIsFav) return a.name.localeCompare(b.name)
     return 0
   })
@@ -72,33 +62,26 @@ export default function FriendGroupsList({
   isActive = false,
   pendingRequests = [],
   groupRanks,
-  favoriteGroupIds: initialFavoriteGroupIds = [],
-  mainGroupId: initialMainGroupId = null,
+  favoriteGroupIds = [],
 } : Props) {
   const t = useTranslations('groups');
-  const tFavorites = useTranslations('groups.favorites');
   const theme = useTheme();
   const locale = useLocale();
   const router = useRouter();
 
   const [ownedGroups, setOwnedGroups] = useState(initialUserGroups);
-  const [localFavoriteIds, setLocalFavoriteIds] = useState<string[]>(initialFavoriteGroupIds)
-  const [localMainGroupId, setLocalMainGroupId] = useState<string | null>(initialMainGroupId)
-  const [, startTransition] = useTransition()
 
   // Combine all groups for unified sorting
   const allGroups: GroupItem[] = [
     ...ownedGroups.map(g => ({ ...g, isOwner: true })),
     ...participantGroups.map(g => ({ ...g, isOwner: false })),
   ]
-  const sortedGroups = sortGroups(allGroups, localFavoriteIds, localMainGroupId)
+  const sortedGroups = sortGroups(allGroups, favoriteGroupIds)
 
   const isEmpty = Boolean(tournamentId && allGroups.length === 0 && pendingRequests.length === 0);
 
-  // Primary group for subheader: main group if set, otherwise first in sorted list
-  const primaryGroup = localMainGroupId
-    ? sortedGroups.find(g => g.id === localMainGroupId) ?? sortedGroups[0]
-    : sortedGroups[0]
+  // Primary group for subheader: first favorite, or first overall
+  const primaryGroup = sortedGroups[0]
   const primaryGroupRank = primaryGroup ? (groupRanks?.[primaryGroup.id] ?? null) : null;
   const groupCount = allGroups.length
   const groupCountWithOptionalRank = primaryGroupRank !== null && primaryGroup
@@ -111,6 +94,7 @@ export default function FriendGroupsList({
   const [openConfirmDeleteGroup, setOpenConfirmDeleteGroup] = useState<string | false>(false)
   const [loading, setLoading] = useState(false)
   const { control, handleSubmit } = useForm<GroupForm>()
+
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -136,34 +120,6 @@ export default function FriendGroupsList({
     setOwnedGroups([...ownedGroups, newGroup])
     setLoading(false)
     setOpenCreateDialog(false)
-  }
-
-  const handleToggleFavorite = (groupId: string) => {
-    const isFav = localFavoriteIds.includes(groupId)
-    if (isFav) {
-      setLocalFavoriteIds(localFavoriteIds.filter(id => id !== groupId))
-      if (localMainGroupId === groupId) setLocalMainGroupId(null)
-    } else {
-      setLocalFavoriteIds([...localFavoriteIds, groupId])
-    }
-    startTransition(async () => {
-      await toggleFavoriteGroupAction(groupId)
-    })
-  }
-
-  const handleSetMain = (groupId: string) => {
-    if (localMainGroupId === groupId) {
-      // Already main — no-op (crown click on the main just stays)
-      return
-    }
-    setLocalMainGroupId(groupId)
-    // Ensure it's also a favorite
-    if (!localFavoriteIds.includes(groupId)) {
-      setLocalFavoriteIds([...localFavoriteIds, groupId])
-    }
-    startTransition(async () => {
-      await setMainGroupAction(groupId)
-    })
   }
 
   return (
@@ -218,53 +174,31 @@ export default function FriendGroupsList({
             <List sx={{ width: '100%'}} disablePadding>
             {sortedGroups.map(group => {
               const rank = groupRanks?.[group.id];
-              const isFav = localFavoriteIds.includes(group.id)
-              const isMain = localMainGroupId === group.id
               return (
                 <ListItem
                   key={group.id}
                   alignItems='flex-start'
                   disableGutters
                   secondaryAction={
-                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                      <IconButton
-                        size="small"
-                        onClick={() => handleToggleFavorite(group.id)}
-                        aria-label={isFav ? tFavorites('removeFavorite') : tFavorites('addFavorite')}
-                        sx={{ color: isFav ? 'warning.main' : 'action.disabled', p: 0.5 }}
-                      >
-                        {isFav ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
-                      </IconButton>
-                      {group.isOwner && (
-                        <>
-                          <IconButton title={t('actions.delete')} color="secondary" onClick={() => setOpenConfirmDeleteGroup(group.id)}>
-                            <DeleteIcon/>
-                          </IconButton>
-                          <InviteFriendsDialog
-                            trigger={
-                              <IconButton title={t('actions.invite')} color="primary">
-                                <ShareIcon/>
-                              </IconButton>}
-                            groupId={group.id}
-                            groupName={group.name}
-                            tournamentId={tournamentId} />
-                        </>
-                      )}
-                    </Box>
+                    group.isOwner ? (
+                      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                        <IconButton title={t('actions.delete')} color="secondary" onClick={() => setOpenConfirmDeleteGroup(group.id)}>
+                          <DeleteIcon/>
+                        </IconButton>
+                        <InviteFriendsDialog
+                          trigger={
+                            <IconButton title={t('actions.invite')} color="primary">
+                              <ShareIcon/>
+                            </IconButton>}
+                          groupId={group.id}
+                          groupName={group.name}
+                          tournamentId={tournamentId} />
+                      </Box>
+                    ) : undefined
                   }
                 >
                   <ListItemText>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      {isMain && (
-                        <IconButton
-                          size="small"
-                          onClick={() => handleSetMain(group.id)}
-                          aria-label={tFavorites('mainGroupLabel')}
-                          sx={{ color: 'warning.main', p: 0.25 }}
-                        >
-                          <WorkspacePremiumIcon fontSize="small" />
-                        </IconButton>
-                      )}
                       {rank !== undefined && (
                         <Chip label={`#${rank}`} size="small" color="primary" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
                       )}

--- a/app/components/tournament-page/friend-groups-list.tsx
+++ b/app/components/tournament-page/friend-groups-list.tsx
@@ -10,17 +10,30 @@ import {
   ListItem,
   ListItemText, TextField, useTheme
 } from "@mui/material";
-import {Add as AddIcon, Delete as DeleteIcon, Share as ShareIcon, ExpandMore as ExpandMoreIcon, Groups as GroupsIcon, Search as SearchIcon} from "@mui/icons-material";
-import {useState} from "react";
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Share as ShareIcon,
+  ExpandMore as ExpandMoreIcon,
+  Groups as GroupsIcon,
+  Search as SearchIcon,
+  Star as StarIcon,
+  StarBorder as StarBorderIcon,
+  WorkspacePremium as WorkspacePremiumIcon,
+} from "@mui/icons-material";
+import { useState, useTransition } from "react";
 import {ExpandMore} from './expand-more';
 import {Controller, useForm} from "react-hook-form";
 import * as React from "react";
 import {createDbGroup, deleteGroup} from "../../actions/prode-group-actions";
+import { toggleFavoriteGroupAction, setMainGroupAction } from "../../actions/favorite-group-actions";
 import InviteFriendsDialog from "../invite-friends-dialog";
 import Link from "next/link";
 import { useLocale, useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import FriendGroupsSidebarEmptyState from "../friend-groups/FriendGroupsSidebarEmptyState";
+
+type GroupItem = { id: string; name: string; isOwner: boolean }
 
 type Props = {
   userGroups: { id: string, name: string}[]
@@ -29,38 +42,75 @@ type Props = {
   isActive?: boolean
   pendingRequests?: { id: string; group_id: string; group_name?: string | null }[]
   groupRanks?: Record<string, number>
+  favoriteGroupIds?: string[]
+  mainGroupId?: string | null
 }
 
 type GroupForm = {
   name: string
 }
 
+function sortGroups(groups: GroupItem[], favoriteIds: string[], mainGroupId: string | null): GroupItem[] {
+  return [...groups].sort((a, b) => {
+    const aIsMain = a.id === mainGroupId
+    const bIsMain = b.id === mainGroupId
+    if (aIsMain !== bIsMain) return aIsMain ? -1 : 1
+
+    const aIsFav = favoriteIds.includes(a.id)
+    const bIsFav = favoriteIds.includes(b.id)
+    if (aIsFav !== bIsFav) return aIsFav ? -1 : 1
+
+    if (aIsFav && bIsFav) return a.name.localeCompare(b.name)
+    return 0
+  })
+}
+
 export default function FriendGroupsList({
-  userGroups:initialUserGroups,
+  userGroups: initialUserGroups,
   participantGroups,
   tournamentId,
   isActive = false,
   pendingRequests = [],
   groupRanks,
+  favoriteGroupIds: initialFavoriteGroupIds = [],
+  mainGroupId: initialMainGroupId = null,
 } : Props) {
   const t = useTranslations('groups');
+  const tFavorites = useTranslations('groups.favorites');
   const theme = useTheme();
   const locale = useLocale();
   const router = useRouter();
-  const [userGroups, setUserGroups] = useState(initialUserGroups);
-  const isEmpty = Boolean(tournamentId && userGroups.length + participantGroups.length === 0 && pendingRequests.length === 0);
-  const primaryGroup = userGroups[0] ?? participantGroups[0];
+
+  const [ownedGroups, setOwnedGroups] = useState(initialUserGroups);
+  const [localFavoriteIds, setLocalFavoriteIds] = useState<string[]>(initialFavoriteGroupIds)
+  const [localMainGroupId, setLocalMainGroupId] = useState<string | null>(initialMainGroupId)
+  const [, startTransition] = useTransition()
+
+  // Combine all groups for unified sorting
+  const allGroups: GroupItem[] = [
+    ...ownedGroups.map(g => ({ ...g, isOwner: true })),
+    ...participantGroups.map(g => ({ ...g, isOwner: false })),
+  ]
+  const sortedGroups = sortGroups(allGroups, localFavoriteIds, localMainGroupId)
+
+  const isEmpty = Boolean(tournamentId && allGroups.length === 0 && pendingRequests.length === 0);
+
+  // Primary group for subheader: main group if set, otherwise first in sorted list
+  const primaryGroup = localMainGroupId
+    ? sortedGroups.find(g => g.id === localMainGroupId) ?? sortedGroups[0]
+    : sortedGroups[0]
   const primaryGroupRank = primaryGroup ? (groupRanks?.[primaryGroup.id] ?? null) : null;
-  const groupCount = userGroups.length + participantGroups.length;
+  const groupCount = allGroups.length
   const groupCountWithOptionalRank = primaryGroupRank !== null && primaryGroup
     ? t('header.groupCountWithRank', { count: groupCount, rank: primaryGroupRank, groupName: primaryGroup.name })
     : t('header.groupCount', { count: groupCount });
   const groupCountText = groupCount > 0 ? groupCountWithOptionalRank : t('header.noGroups');
+
   const [expanded, setExpanded] = useState(isEmpty);
   const [openCreateDialog, setOpenCreateDialog] = useState(false);
   const [openConfirmDeleteGroup, setOpenConfirmDeleteGroup] = useState<string | false>(false)
   const [loading, setLoading] = useState(false)
-  const { control, handleSubmit } =useForm<GroupForm>()
+  const { control, handleSubmit } = useForm<GroupForm>()
 
   const handleExpandClick = () => {
     setExpanded(!expanded);
@@ -73,9 +123,8 @@ export default function FriendGroupsList({
   const handleGroupDelete = async () => {
     setLoading(true)
     if(openConfirmDeleteGroup) {
-      // Delete the group on the backend
       deleteGroup(openConfirmDeleteGroup)
-      setUserGroups(userGroups.filter(group => group.id !== openConfirmDeleteGroup))
+      setOwnedGroups(ownedGroups.filter(group => group.id !== openConfirmDeleteGroup))
     }
     setLoading(false)
     setOpenConfirmDeleteGroup(false)
@@ -84,12 +133,37 @@ export default function FriendGroupsList({
   const createGroup = async (group: GroupForm) => {
     setLoading(true)
     const newGroup = await createDbGroup(group.name)
-    setUserGroups([
-      ...userGroups,
-      newGroup
-    ])
+    setOwnedGroups([...ownedGroups, newGroup])
     setLoading(false)
     setOpenCreateDialog(false)
+  }
+
+  const handleToggleFavorite = (groupId: string) => {
+    const isFav = localFavoriteIds.includes(groupId)
+    if (isFav) {
+      setLocalFavoriteIds(localFavoriteIds.filter(id => id !== groupId))
+      if (localMainGroupId === groupId) setLocalMainGroupId(null)
+    } else {
+      setLocalFavoriteIds([...localFavoriteIds, groupId])
+    }
+    startTransition(async () => {
+      await toggleFavoriteGroupAction(groupId)
+    })
+  }
+
+  const handleSetMain = (groupId: string) => {
+    if (localMainGroupId === groupId) {
+      // Already main — no-op (crown click on the main just stays)
+      return
+    }
+    setLocalMainGroupId(groupId)
+    // Ensure it's also a favorite
+    if (!localFavoriteIds.includes(groupId)) {
+      setLocalFavoriteIds([...localFavoriteIds, groupId])
+    }
+    startTransition(async () => {
+      await setMainGroupAction(groupId)
+    })
   }
 
   return (
@@ -141,60 +215,68 @@ export default function FriendGroupsList({
               </Box>
             </>
           ) : (
-            <List sx={{ width: '100%'}} disablePadding >
-            {userGroups.map(userGroup => {
-              const rank = groupRanks?.[userGroup.id];
+            <List sx={{ width: '100%'}} disablePadding>
+            {sortedGroups.map(group => {
+              const rank = groupRanks?.[group.id];
+              const isFav = localFavoriteIds.includes(group.id)
+              const isMain = localMainGroupId === group.id
               return (
-                <ListItem key={userGroup.id}
-                          alignItems='flex-start'
-                          disableGutters
-                          secondaryAction={
-                            <>
-                              <IconButton title={t('actions.delete')} color="secondary" onClick={() => setOpenConfirmDeleteGroup(userGroup.id)}>
-                                <DeleteIcon/>
-                              </IconButton>
-                              <InviteFriendsDialog
-                                trigger={
-                                  <IconButton title={t('actions.invite')} color="primary">
-                                    <ShareIcon/>
-                                  </IconButton>}
-                                groupId={userGroup.id}
-                                groupName={userGroup.name}
-                                tournamentId={tournamentId} />
-                            </>
-                          }>
+                <ListItem
+                  key={group.id}
+                  alignItems='flex-start'
+                  disableGutters
+                  secondaryAction={
+                    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                      <IconButton
+                        size="small"
+                        onClick={() => handleToggleFavorite(group.id)}
+                        aria-label={isFav ? tFavorites('removeFavorite') : tFavorites('addFavorite')}
+                        sx={{ color: isFav ? 'warning.main' : 'action.disabled', p: 0.5 }}
+                      >
+                        {isFav ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
+                      </IconButton>
+                      {group.isOwner && (
+                        <>
+                          <IconButton title={t('actions.delete')} color="secondary" onClick={() => setOpenConfirmDeleteGroup(group.id)}>
+                            <DeleteIcon/>
+                          </IconButton>
+                          <InviteFriendsDialog
+                            trigger={
+                              <IconButton title={t('actions.invite')} color="primary">
+                                <ShareIcon/>
+                              </IconButton>}
+                            groupId={group.id}
+                            groupName={group.name}
+                            tournamentId={tournamentId} />
+                        </>
+                      )}
+                    </Box>
+                  }
+                >
                   <ListItemText>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      {isMain && (
+                        <IconButton
+                          size="small"
+                          onClick={() => handleSetMain(group.id)}
+                          aria-label={tFavorites('mainGroupLabel')}
+                          sx={{ color: 'warning.main', p: 0.25 }}
+                        >
+                          <WorkspacePremiumIcon fontSize="small" />
+                        </IconButton>
+                      )}
                       {rank !== undefined && (
                         <Chip label={`#${rank}`} size="small" color="primary" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
                       )}
-                      <Link href={tournamentId ? `/${locale}/tournaments/${tournamentId}/friend-groups/${userGroup.id}` : `/${locale}/friend-groups/${userGroup.id}`}>
-                        {userGroup.name}
+                      <Link href={tournamentId ? `/${locale}/tournaments/${tournamentId}/friend-groups/${group.id}` : `/${locale}/friend-groups/${group.id}`}>
+                        {group.name}
                       </Link>
                     </Box>
                   </ListItemText>
                 </ListItem>
               );
             })}
-            {(userGroups.length > 0 && participantGroups.length > 0) &&  <ListItem divider/>}
-            {participantGroups.map(participantGroup => {
-              const rank = groupRanks?.[participantGroup.id];
-              return (
-                <ListItem key={participantGroup.id} disableGutters>
-                  <ListItemText>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                      {rank !== undefined && (
-                        <Chip label={`#${rank}`} size="small" color="primary" variant="outlined" sx={{ height: 18, fontSize: '0.65rem' }} />
-                      )}
-                      <Link href={tournamentId ? `/${locale}/tournaments/${tournamentId}/friend-groups/${participantGroup.id}` : `/${locale}/friend-groups/${participantGroup.id}`}>
-                        {participantGroup.name}
-                      </Link>
-                    </Box>
-                  </ListItemText>
-                </ListItem>
-              );
-            })}
-            {pendingRequests.length > 0 && (userGroups.length > 0 || participantGroups.length > 0) && <ListItem divider/>}
+            {pendingRequests.length > 0 && allGroups.length > 0 && <ListItem divider/>}
             {pendingRequests.map(request => (
               <ListItem key={request.id} disableGutters sx={{ gap: 1 }}>
                 <ListItemText
@@ -316,6 +398,5 @@ export default function FriendGroupsList({
         </DialogActions>
       </Dialog>
     </>
-
   )
 }

--- a/app/components/tournament-page/tournament-group-card.tsx
+++ b/app/components/tournament-page/tournament-group-card.tsx
@@ -10,7 +10,7 @@ import {
   Stack,
   IconButton
 } from "@mui/material";
-import {Groups as GroupsIcon, Share as ShareIcon, MonetizationOn as MonetizationOnIcon} from "@mui/icons-material";
+import {Groups as GroupsIcon, Share as ShareIcon, MonetizationOn as MonetizationOnIcon, Star as StarIcon, StarBorder as StarBorderIcon, WorkspacePremium as WorkspacePremiumIcon} from "@mui/icons-material";
 import type { TournamentGroupStats } from "../../definitions";
 import InviteFriendsDialog from "../invite-friends-dialog";
 import { useLocale, useTranslations } from 'next-intl';
@@ -33,6 +33,10 @@ interface MyGroupsCardProps {
   readonly group: TournamentGroupStats;
   readonly tournamentId: string;
   readonly isPending?: boolean;
+  readonly isFavorite?: boolean;
+  readonly isMainGroup?: boolean;
+  readonly onToggleFavorite?: (groupId: string) => void;
+  readonly onSetMainGroup?: (groupId: string) => void;
 }
 
 // discovery variant props
@@ -52,6 +56,7 @@ export default function TournamentGroupCard(props: TournamentGroupCardProps) {
   const tPending = useTranslations('groups.pendingRequest');
   const tDiscovery = useTranslations('groups.discovery');
   const tBetting = useTranslations('groups.betting');
+  const tFavorites = useTranslations('groups.favorites');
 
   if (props.variant === 'discovery') {
     const { group, tournamentId, onRequestJoin } = props;
@@ -172,7 +177,7 @@ export default function TournamentGroupCard(props: TournamentGroupCardProps) {
   }
 
   // my-groups variant (original behavior, unchanged)
-  const { group, tournamentId, isPending = false } = props;
+  const { group, tournamentId, isPending = false, isFavorite = false, isMainGroup = false, onToggleFavorite, onSetMainGroup } = props;
   const isLeader = group.userPosition === 1;
   const leaderDisplay = isLeader ? t('you') : group.leaderName;
 
@@ -189,17 +194,28 @@ export default function TournamentGroupCard(props: TournamentGroupCardProps) {
             />
           </Box>
         )}
-        {/* Group Name with Owner Badge and Share Button */}
+        {/* Group Name with Owner Badge, Share Button, Favorite/Main icons */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+          {isMainGroup && (
+            <WorkspacePremiumIcon
+              fontSize="small"
+              sx={{ color: 'warning.main', flexShrink: 0 }}
+              titleAccess={tFavorites('mainGroupLabel')}
+            />
+          )}
           <Typography
             variant="h6"
-            component="h3"
+            component={Link}
+            href={`/${locale}/tournaments/${tournamentId}/friend-groups/${group.groupId}`}
             sx={{
               fontWeight: 600,
               flexGrow: 1,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap'
+              whiteSpace: 'nowrap',
+              color: 'inherit',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
             }}
           >
             {group.groupName}
@@ -226,6 +242,16 @@ export default function TournamentGroupCard(props: TournamentGroupCardProps) {
             </>
           )}
           <PrivacyIndicatorIcon isPublic={group.is_public ?? false} size="small" />
+          {!isPending && (
+            <IconButton
+              size="small"
+              onClick={() => onToggleFavorite?.(group.groupId)}
+              aria-label={isFavorite ? tFavorites('removeFavorite') : tFavorites('addFavorite')}
+              sx={{ color: isFavorite ? 'warning.main' : 'action.disabled', p: 0.5 }}
+            >
+              {isFavorite ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
+            </IconButton>
+          )}
         </Box>
 
         {/* Stats Section */}

--- a/app/components/tournament-page/tournament-group-card.tsx
+++ b/app/components/tournament-page/tournament-group-card.tsx
@@ -8,9 +8,10 @@ import {
   CardContent,
   CardActions,
   Stack,
-  IconButton
+  IconButton,
+  Tooltip,
 } from "@mui/material";
-import {Groups as GroupsIcon, Share as ShareIcon, MonetizationOn as MonetizationOnIcon, Star as StarIcon, StarBorder as StarBorderIcon, WorkspacePremium as WorkspacePremiumIcon} from "@mui/icons-material";
+import {Groups as GroupsIcon, Share as ShareIcon, MonetizationOn as MonetizationOnIcon, Star as StarIcon, StarBorder as StarBorderIcon} from "@mui/icons-material";
 import type { TournamentGroupStats } from "../../definitions";
 import InviteFriendsDialog from "../invite-friends-dialog";
 import { useLocale, useTranslations } from 'next-intl';
@@ -34,9 +35,7 @@ interface MyGroupsCardProps {
   readonly tournamentId: string;
   readonly isPending?: boolean;
   readonly isFavorite?: boolean;
-  readonly isMainGroup?: boolean;
   readonly onToggleFavorite?: (groupId: string) => void;
-  readonly onSetMainGroup?: (groupId: string) => void;
 }
 
 // discovery variant props
@@ -177,7 +176,7 @@ export default function TournamentGroupCard(props: TournamentGroupCardProps) {
   }
 
   // my-groups variant (original behavior, unchanged)
-  const { group, tournamentId, isPending = false, isFavorite = false, isMainGroup = false, onToggleFavorite, onSetMainGroup } = props;
+  const { group, tournamentId, isPending = false, isFavorite = false, onToggleFavorite } = props;
   const isLeader = group.userPosition === 1;
   const leaderDisplay = isLeader ? t('you') : group.leaderName;
 
@@ -194,15 +193,8 @@ export default function TournamentGroupCard(props: TournamentGroupCardProps) {
             />
           </Box>
         )}
-        {/* Group Name with Owner Badge, Share Button, Favorite/Main icons */}
+        {/* Group Name with Owner Badge, Share Button, Favorite icon */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-          {isMainGroup && (
-            <WorkspacePremiumIcon
-              fontSize="small"
-              sx={{ color: 'warning.main', flexShrink: 0 }}
-              titleAccess={tFavorites('mainGroupLabel')}
-            />
-          )}
           <Typography
             variant="h6"
             component={Link}
@@ -243,14 +235,16 @@ export default function TournamentGroupCard(props: TournamentGroupCardProps) {
           )}
           <PrivacyIndicatorIcon isPublic={group.is_public ?? false} size="small" />
           {!isPending && (
-            <IconButton
-              size="small"
-              onClick={() => onToggleFavorite?.(group.groupId)}
-              aria-label={isFavorite ? tFavorites('removeFavorite') : tFavorites('addFavorite')}
-              sx={{ color: isFavorite ? 'warning.main' : 'action.disabled', p: 0.5 }}
-            >
-              {isFavorite ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
-            </IconButton>
+            <Tooltip title={isFavorite ? tFavorites('removeFavorite') : tFavorites('addFavorite')}>
+              <IconButton
+                size="small"
+                onClick={() => onToggleFavorite?.(group.groupId)}
+                aria-label={isFavorite ? tFavorites('removeFavorite') : tFavorites('addFavorite')}
+                sx={{ color: isFavorite ? 'warning.main' : 'action.disabled', p: 0.5 }}
+              >
+                {isFavorite ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
           )}
         </Box>
 

--- a/app/components/tournament-page/tournament-groups-list.tsx
+++ b/app/components/tournament-page/tournament-groups-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { Box, Typography, Button, Grid } from "../mui-wrappers/";
 import {
   Stack,
@@ -16,6 +16,7 @@ import type { TournamentGroupStats } from "../../definitions";
 import TournamentGroupCard from "./tournament-group-card";
 import FriendGroupsLandingEmptyState from "../friend-groups/FriendGroupsLandingEmptyState";
 import { createDbGroup } from "../../actions/prode-group-actions";
+import { toggleFavoriteGroupAction, setMainGroupAction } from "../../actions/favorite-group-actions";
 import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from 'next/navigation';
 
@@ -32,19 +33,46 @@ interface TournamentGroupsListProps {
   readonly groups: TournamentGroupStats[];
   readonly tournamentId: string;
   readonly pendingRequests?: UserJoinRequest[];
+  readonly favoriteGroupIds?: string[];
+  readonly mainGroupId?: string | null;
 }
 
 type GroupForm = {
   name: string;
 }
 
-export default function TournamentGroupsList({ groups, tournamentId, pendingRequests = [] }: TournamentGroupsListProps) {
+function sortGroupsByFavorites(
+  groups: TournamentGroupStats[],
+  favoriteIds: string[],
+  mainGroupId: string | null
+): TournamentGroupStats[] {
+  return [...groups].sort((a, b) => {
+    const aIsMain = a.groupId === mainGroupId
+    const bIsMain = b.groupId === mainGroupId
+    if (aIsMain !== bIsMain) return aIsMain ? -1 : 1
+
+    const aIsFav = favoriteIds.includes(a.groupId)
+    const bIsFav = favoriteIds.includes(b.groupId)
+    if (aIsFav !== bIsFav) return aIsFav ? -1 : 1
+
+    if (aIsFav && bIsFav) return a.groupName.localeCompare(b.groupName)
+    return 0
+  })
+}
+
+export default function TournamentGroupsList({ groups, tournamentId, pendingRequests = [], favoriteGroupIds: initialFavoriteGroupIds = [], mainGroupId: initialMainGroupId = null }: TournamentGroupsListProps) {
   const tCreate = useTranslations('groups.create');
   const tList = useTranslations('groups.list');
   const tActions = useTranslations('groups.actions');
   const tDiscovery = useTranslations('groups.discovery');
   const locale = useLocale();
   const router = useRouter();
+
+  const [localFavoriteIds, setLocalFavoriteIds] = useState<string[]>(initialFavoriteGroupIds)
+  const [localMainGroupId, setLocalMainGroupId] = useState<string | null>(initialMainGroupId)
+  const [, startTransition] = useTransition()
+
+  const sortedGroups = sortGroupsByFavorites(groups, localFavoriteIds, localMainGroupId)
 
   const [openCreateDialog, setOpenCreateDialog] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -72,6 +100,30 @@ export default function TournamentGroupsList({ groups, tournamentId, pendingRequ
   const handleDiscoverGroups = () => {
     router.push(`/${locale}/tournaments/${tournamentId}/friend-groups/discover`);
   };
+
+  const handleToggleFavorite = (groupId: string) => {
+    const isFav = localFavoriteIds.includes(groupId)
+    if (isFav) {
+      setLocalFavoriteIds(localFavoriteIds.filter(id => id !== groupId))
+      if (localMainGroupId === groupId) setLocalMainGroupId(null)
+    } else {
+      setLocalFavoriteIds([...localFavoriteIds, groupId])
+    }
+    startTransition(async () => {
+      await toggleFavoriteGroupAction(groupId)
+    })
+  }
+
+  const handleSetMainGroup = (groupId: string) => {
+    if (localMainGroupId === groupId) return
+    setLocalMainGroupId(groupId)
+    if (!localFavoriteIds.includes(groupId)) {
+      setLocalFavoriteIds([...localFavoriteIds, groupId])
+    }
+    startTransition(async () => {
+      await setMainGroupAction(groupId)
+    })
+  }
 
   // Show empty state if no groups and no actively pending requests
   const activePendingRequests = pendingRequests.filter(req => req.status === 'pending');
@@ -179,9 +231,16 @@ export default function TournamentGroupsList({ groups, tournamentId, pendingRequ
             {/* Groups Grid */}
             <Grid container spacing={3}>
               {/* Approved Groups */}
-              {groups.map((group) => (
+              {sortedGroups.map((group) => (
                 <Grid size={{ xs: 12, sm: 12, md: 6 }} key={group.groupId}>
-                  <TournamentGroupCard group={group} tournamentId={tournamentId} />
+                  <TournamentGroupCard
+                    group={group}
+                    tournamentId={tournamentId}
+                    isFavorite={localFavoriteIds.includes(group.groupId)}
+                    isMainGroup={localMainGroupId === group.groupId}
+                    onToggleFavorite={handleToggleFavorite}
+                    onSetMainGroup={handleSetMainGroup}
+                  />
                 </Grid>
               ))}
 

--- a/app/components/tournament-page/tournament-groups-list.tsx
+++ b/app/components/tournament-page/tournament-groups-list.tsx
@@ -16,7 +16,7 @@ import type { TournamentGroupStats } from "../../definitions";
 import TournamentGroupCard from "./tournament-group-card";
 import FriendGroupsLandingEmptyState from "../friend-groups/FriendGroupsLandingEmptyState";
 import { createDbGroup } from "../../actions/prode-group-actions";
-import { toggleFavoriteGroupAction, setMainGroupAction } from "../../actions/favorite-group-actions";
+import { toggleFavoriteGroupAction } from "../../actions/favorite-group-actions";
 import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from 'next/navigation';
 
@@ -34,7 +34,6 @@ interface TournamentGroupsListProps {
   readonly tournamentId: string;
   readonly pendingRequests?: UserJoinRequest[];
   readonly favoriteGroupIds?: string[];
-  readonly mainGroupId?: string | null;
 }
 
 type GroupForm = {
@@ -43,24 +42,18 @@ type GroupForm = {
 
 function sortGroupsByFavorites(
   groups: TournamentGroupStats[],
-  favoriteIds: string[],
-  mainGroupId: string | null
+  favoriteIds: string[]
 ): TournamentGroupStats[] {
   return [...groups].sort((a, b) => {
-    const aIsMain = a.groupId === mainGroupId
-    const bIsMain = b.groupId === mainGroupId
-    if (aIsMain !== bIsMain) return aIsMain ? -1 : 1
-
     const aIsFav = favoriteIds.includes(a.groupId)
     const bIsFav = favoriteIds.includes(b.groupId)
     if (aIsFav !== bIsFav) return aIsFav ? -1 : 1
-
     if (aIsFav && bIsFav) return a.groupName.localeCompare(b.groupName)
     return 0
   })
 }
 
-export default function TournamentGroupsList({ groups, tournamentId, pendingRequests = [], favoriteGroupIds: initialFavoriteGroupIds = [], mainGroupId: initialMainGroupId = null }: TournamentGroupsListProps) {
+export default function TournamentGroupsList({ groups, tournamentId, pendingRequests = [], favoriteGroupIds: initialFavoriteGroupIds = [] }: TournamentGroupsListProps) {
   const tCreate = useTranslations('groups.create');
   const tList = useTranslations('groups.list');
   const tActions = useTranslations('groups.actions');
@@ -69,10 +62,9 @@ export default function TournamentGroupsList({ groups, tournamentId, pendingRequ
   const router = useRouter();
 
   const [localFavoriteIds, setLocalFavoriteIds] = useState<string[]>(initialFavoriteGroupIds)
-  const [localMainGroupId, setLocalMainGroupId] = useState<string | null>(initialMainGroupId)
   const [, startTransition] = useTransition()
 
-  const sortedGroups = sortGroupsByFavorites(groups, localFavoriteIds, localMainGroupId)
+  const sortedGroups = sortGroupsByFavorites(groups, localFavoriteIds)
 
   const [openCreateDialog, setOpenCreateDialog] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -105,23 +97,12 @@ export default function TournamentGroupsList({ groups, tournamentId, pendingRequ
     const isFav = localFavoriteIds.includes(groupId)
     if (isFav) {
       setLocalFavoriteIds(localFavoriteIds.filter(id => id !== groupId))
-      if (localMainGroupId === groupId) setLocalMainGroupId(null)
     } else {
       setLocalFavoriteIds([...localFavoriteIds, groupId])
     }
     startTransition(async () => {
       await toggleFavoriteGroupAction(groupId)
-    })
-  }
-
-  const handleSetMainGroup = (groupId: string) => {
-    if (localMainGroupId === groupId) return
-    setLocalMainGroupId(groupId)
-    if (!localFavoriteIds.includes(groupId)) {
-      setLocalFavoriteIds([...localFavoriteIds, groupId])
-    }
-    startTransition(async () => {
-      await setMainGroupAction(groupId)
+      router.refresh()
     })
   }
 
@@ -237,9 +218,7 @@ export default function TournamentGroupsList({ groups, tournamentId, pendingRequ
                     group={group}
                     tournamentId={tournamentId}
                     isFavorite={localFavoriteIds.includes(group.groupId)}
-                    isMainGroup={localMainGroupId === group.groupId}
                     onToggleFavorite={handleToggleFavorite}
-                    onSetMainGroup={handleSetMainGroup}
                   />
                 </Grid>
               ))}

--- a/app/components/tournament-page/tournament-sidebar.tsx
+++ b/app/components/tournament-page/tournament-sidebar.tsx
@@ -27,7 +27,6 @@ interface TournamentSidebarProps {
     participantGroups: any[]
     pendingRequests?: { id: string; group_id: string; group_name?: string | null }[]
     favoriteGroupIds?: string[]
-    mainGroupId?: string | null
   }
   readonly user?: User
   readonly groupRanks?: Record<string, number>
@@ -96,7 +95,6 @@ export default function TournamentSidebar({
               isActive={currentSection === 'friend-groups'}
               groupRanks={groupRanks}
               favoriteGroupIds={prodeGroups.favoriteGroupIds}
-              mainGroupId={prodeGroups.mainGroupId}
             />
           )}
 

--- a/app/components/tournament-page/tournament-sidebar.tsx
+++ b/app/components/tournament-page/tournament-sidebar.tsx
@@ -26,6 +26,8 @@ interface TournamentSidebarProps {
     userGroups: any[]
     participantGroups: any[]
     pendingRequests?: { id: string; group_id: string; group_name?: string | null }[]
+    favoriteGroupIds?: string[]
+    mainGroupId?: string | null
   }
   readonly user?: User
   readonly groupRanks?: Record<string, number>
@@ -93,6 +95,8 @@ export default function TournamentSidebar({
               tournamentId={tournamentId}
               isActive={currentSection === 'friend-groups'}
               groupRanks={groupRanks}
+              favoriteGroupIds={prodeGroups.favoriteGroupIds}
+              mainGroupId={prodeGroups.mainGroupId}
             />
           )}
 

--- a/app/db/database.ts
+++ b/app/db/database.ts
@@ -23,7 +23,8 @@ import {
   ShortUrlTable,
   TournamentScoreHistoryTable,
   AdSettingsTable,
-  GroupRankingTable
+  GroupRankingTable,
+  UserFavoriteGroupTable
 } from "./tables-definition";
 
 export interface Database {
@@ -65,6 +66,8 @@ export interface Database {
   ad_settings: AdSettingsTable
 
   group_rankings: GroupRankingTable
+
+  user_favorite_groups: UserFavoriteGroupTable
 }
 
 export const db= createKysely<Database>();

--- a/app/db/favorite-groups-repository.ts
+++ b/app/db/favorite-groups-repository.ts
@@ -1,0 +1,64 @@
+import { db } from './database'
+
+export async function getFavoriteGroupIds(userId: string): Promise<string[]> {
+  const rows = await db
+    .selectFrom('user_favorite_groups')
+    .select('group_id')
+    .where('user_id', '=', userId)
+    .execute()
+  return rows.map((r) => r.group_id)
+}
+
+export async function getMainGroupId(userId: string): Promise<string | null> {
+  const row = await db
+    .selectFrom('user_favorite_groups')
+    .select('group_id')
+    .where('user_id', '=', userId)
+    .where('is_main', '=', true)
+    .executeTakeFirst()
+  return row?.group_id ?? null
+}
+
+export async function addFavoriteGroup(userId: string, groupId: string): Promise<void> {
+  await db
+    .insertInto('user_favorite_groups')
+    .values({ user_id: userId, group_id: groupId, is_main: false })
+    .onConflict((oc) => oc.doNothing())
+    .execute()
+}
+
+export async function removeFavoriteGroup(userId: string, groupId: string): Promise<void> {
+  await db
+    .deleteFrom('user_favorite_groups')
+    .where('user_id', '=', userId)
+    .where('group_id', '=', groupId)
+    .execute()
+}
+
+export async function setMainGroup(userId: string, groupId: string): Promise<void> {
+  // Clear any existing main group for this user
+  await db
+    .updateTable('user_favorite_groups')
+    .set({ is_main: false })
+    .where('user_id', '=', userId)
+    .where('is_main', '=', true)
+    .execute()
+
+  // Upsert the row as main (group must already be a favorite)
+  await db
+    .insertInto('user_favorite_groups')
+    .values({ user_id: userId, group_id: groupId, is_main: true })
+    .onConflict((oc) =>
+      oc.columns(['user_id', 'group_id']).doUpdateSet({ is_main: true })
+    )
+    .execute()
+}
+
+export async function clearMainGroup(userId: string): Promise<void> {
+  await db
+    .updateTable('user_favorite_groups')
+    .set({ is_main: false })
+    .where('user_id', '=', userId)
+    .where('is_main', '=', true)
+    .execute()
+}

--- a/app/db/tables-definition.ts
+++ b/app/db/tables-definition.ts
@@ -664,3 +664,13 @@ export type GroupRankingSnapshotNew = Pick<
   Insertable<GroupRankingTable>,
   'user_id' | 'group_id' | 'tournament_id' | 'snapshot_date' | 'rank' | 'score'
 >
+
+export interface UserFavoriteGroupTable {
+  user_id: string
+  group_id: string
+  is_main: boolean
+  created_at: Generated<Date>
+}
+
+export type UserFavoriteGroup = Selectable<UserFavoriteGroupTable>
+export type UserFavoriteGroupNew = Omit<Insertable<UserFavoriteGroupTable>, 'created_at'>

--- a/app/definitions.ts
+++ b/app/definitions.ts
@@ -107,4 +107,6 @@ export interface TournamentGroupStats {
   themeColor?: string | null
   is_public?: boolean
   bettingEnabled?: boolean
+  isFavorite?: boolean
+  isMainGroup?: boolean
 }

--- a/app/definitions.ts
+++ b/app/definitions.ts
@@ -108,5 +108,4 @@ export interface TournamentGroupStats {
   is_public?: boolean
   bettingEnabled?: boolean
   isFavorite?: boolean
-  isMainGroup?: boolean
 }

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -161,8 +161,8 @@ Friend group management — creation, membership, scoring, and theme updates.
 
 - **createDbGroup(groupName)**: `Promise<ProdeGroup>` — Creates a new friend group.
   Calls: getLoggedInUser, createProdeGroup
-- **getGroupsForUser()**: `Promise<{ owned: ProdeGroup[]; participating: ProdeGroup[]; pendingRequests: JoinRequest[] }>` — Gets user's groups (owned, participating, and pending join requests).
-  Calls: getLoggedInUser, findProdeGroupsByOwner, findProdeGroupsByParticipant, findJoinRequestsByUser
+- **getGroupsForUser()**: `Promise<{ userGroups: ProdeGroup[]; participantGroups: ProdeGroup[]; pendingRequests: { id: string; group_id: string; group_name: string | null }[]; favoriteGroupIds: string[]; mainGroupId: string | null } | undefined>` — Gets user's groups (owned, participating, pending join requests) plus favorite group IDs and main group ID in parallel.
+  Calls: getLoggedInUser, findProdeGroupsByOwner, findProdeGroupsByParticipant, findJoinRequestsByUser, getFavoriteGroupIds, getMainGroupId
 - **deleteGroup(groupId)**: `Promise<void>` — Deletes group (owner only).
   Calls: getLoggedInUser, findProdeGroupById, deleteAllParticipantsFromGroup, deleteProdeGroup
 - **promoteParticipantToAdmin(groupId, userId)**: `Promise<void>` — Promotes participant to admin.
@@ -183,6 +183,16 @@ Friend group management — creation, membership, scoring, and theme updates.
   Calls: findProdeGroupById, findParticipantsInGroup, getUserScoresForTournament, getGroupTournamentBettingConfig, findUsersByIds
 - **sendGroupEmailInvitations(groupId, recipients, customMessage, locale, groupLogoUrl?, themeColor?)**: `Promise<{sent: number; failed: string[]}>` — Sends localized group invitation emails to up to 50 recipients. Validates user is owner or admin, deduplicates by email, sends in parallel via Promise.allSettled, returns counts of sent/failed.
   Calls: getLoggedInUser, findProdeGroupById, findParticipantsInGroup, generateShortUrlForGroup, buildShortUrl, generateGroupInvitationEmail, sendEmail
+
+### app/actions/favorite-group-actions.ts
+Server Actions for managing user-level favorite and main-group designation (Story #332).
+
+- **toggleFavoriteGroupAction(groupId: string)**: `Promise<{ isFavorite: boolean }>` — Adds or removes the group from the authenticated user's favorites. Returns the new state.
+  Calls: getLoggedInUser, getFavoriteGroupIds, addFavoriteGroup | removeFavoriteGroup, revalidatePath
+- **setMainGroupAction(groupId: string)**: `Promise<void>` — Designates the group as the user's main group. Group must already be a favorite; throws otherwise.
+  Calls: getLoggedInUser, getFavoriteGroupIds, setMainGroup, revalidatePath
+- **clearMainGroupAction()**: `Promise<void>` — Clears the user's main group designation.
+  Calls: getLoggedInUser, clearMainGroup, revalidatePath
 
 ### app/actions/prode-group-discovery-actions.ts
 Public group discovery and search for group browsing.

--- a/docs/code-structure/components/components-results-playoffs.md
+++ b/docs/code-structure/components/components-results-playoffs.md
@@ -199,9 +199,10 @@ Deprecated empty state component for groups (replaced by FriendGroupsLandingEmpt
 ### app/components/tournament-page/friend-groups-list.tsx
 Card showing user groups, participant groups, and pending requests with create/delete dialogs and optional rank badges.
 
-- **FriendGroupsList(props: Props)**: `JSX.Element` — [Client] Collapsible card with group lists, create/delete dialogs, invite functionality, and empty state. Optional `groupRanks?: Record<string, number>` prop: when provided, shows the primary group rank inline in the CardHeader subheader text (via i18n key `header.groupCountWithRank`) and a per-row Chip before the group name link for each group with an available rank.
-  Calls: createDbGroup, deleteGroup
-  Uses: useState, useTheme, useLocale, useRouter, useForm, useTranslations
+- **FriendGroupsList(props: Props)**: `JSX.Element` — [Client] Collapsible card with combined sorted group list, create/delete dialogs, invite functionality, and empty state. Accepts `favoriteGroupIds?: string[]` and `mainGroupId?: string | null`; sorts groups main → favorites (alpha) → others. Renders star (StarIcon/StarBorderIcon) and crown (WorkspacePremiumIcon) icon buttons per row. Optimistic local state updated immediately; server actions called via useTransition.
+  Props: `userGroups`, `participantGroups`, `tournamentId?`, `isActive?`, `pendingRequests?`, `groupRanks?`, `favoriteGroupIds?`, `mainGroupId?`
+  Calls: createDbGroup, deleteGroup, toggleFavoriteGroupAction, setMainGroupAction
+  Uses: useState, useTransition, useTheme, useLocale, useRouter, useForm, useTranslations
   Renders: FriendGroupsSidebarEmptyState, InviteFriendsDialog, ExpandMore, Chip
 
 ### app/components/tournament-page/group-standings-sidebar.tsx
@@ -230,16 +231,18 @@ Comprehensive rules and constraints display with expandable sections and example
 Card component for displaying group info with dual variant support (my-groups and discovery).
 
 - **DiscoveryGroupData**: `interface` — Data structure for public group discovery.
-- **TournamentGroupCard(props: TournamentGroupCardProps)**: `JSX.Element` — [Client] Renders different UI based on variant (my-groups with stats/actions, discovery with request-to-join). Supports pending request blur effect.
+- **TournamentGroupCard(props: TournamentGroupCardProps)**: `JSX.Element` — [Client] Renders different UI based on variant (my-groups with stats/actions, discovery with request-to-join). Supports pending request blur effect. my-groups variant: group name is a clickable Next.js Link; star icon button toggles favorite; crown icon shown when isMainGroup=true.
+  Props (my-groups only): `isFavorite?: boolean`, `isMainGroup?: boolean`, `onToggleFavorite?: (groupId: string) => void`, `onSetMainGroup?: (groupId: string) => void`
   Uses: useLocale, useTranslations
   Renders: PrivacyIndicatorIcon, InviteFriendsDialog
 
 ### app/components/tournament-page/tournament-groups-list.tsx
 Main groups list with create/discover dialogs and grid display of group cards.
 
-- **TournamentGroupsList({ groups, tournamentId, pendingRequests }: TournamentGroupsListProps)**: `JSX.Element` — [Client] Renders grid of group cards, shows empty state when no groups, includes create dialog.
-  Calls: createDbGroup
-  Uses: useState, useForm, useTranslations, useLocale, useRouter
+- **TournamentGroupsList({ groups, tournamentId, pendingRequests, favoriteGroupIds, mainGroupId }: TournamentGroupsListProps)**: `JSX.Element` — [Client] Renders grid of group cards sorted by favorites (main → favorites alpha → others), shows empty state when no groups, includes create dialog. Optimistic favorite state updated immediately; server actions called via useTransition.
+  Props: `groups`, `tournamentId`, `pendingRequests?`, `favoriteGroupIds?: string[]`, `mainGroupId?: string | null`
+  Calls: createDbGroup, toggleFavoriteGroupAction, setMainGroupAction
+  Uses: useState, useTransition, useForm, useTranslations, useLocale, useRouter
   Renders: FriendGroupsLandingEmptyState, TournamentGroupCard, Dialog
 
 ### app/components/tournament-page/user-tournament-statistics.tsx

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -31,6 +31,9 @@ Includes `TournamentScoreHistoryTable` for the `tournament_score_history` table 
 - **GroupRankingTable**: Interface for `group_rankings` table with `id` (Generated), `user_id`, `group_id`, `tournament_id`, `snapshot_date` (INTEGER YYYYMMDD), `rank`, `score`, `created_at` (Generated). Unique constraint on `(user_id, group_id, tournament_id, snapshot_date)`.
 - **GroupRanking**: `Selectable<GroupRankingTable>` — full row shape.
 - **GroupRankingSnapshotNew**: `Pick<Insertable<GroupRankingTable>, 'user_id' | 'group_id' | 'tournament_id' | 'snapshot_date' | 'rank' | 'score'>` — insert shape (excludes auto-generated fields).
+- **UserFavoriteGroupTable**: Interface for `user_favorite_groups` table with composite PK `(user_id, group_id)`, `is_main` (BOOLEAN DEFAULT FALSE), `created_at` (Generated). Partial unique index on `user_id WHERE is_main = TRUE` enforces at most one main group per user.
+- **UserFavoriteGroup**: `Selectable<UserFavoriteGroupTable>` — full row shape.
+- **UserFavoriteGroupNew**: `Omit<Insertable<UserFavoriteGroupTable>, 'created_at'>` — insert shape.
 
 `UserTable` includes `is_ad_free?: boolean` (NOT NULL DEFAULT FALSE in DB — optional in TypeScript because it is omitted from inserts by default).
 
@@ -355,4 +358,20 @@ Repository for the `group_rankings` table. Stores daily rank snapshots per user/
 - **getLatestRankingsForGroupWithChange(groupId: string, tournamentId: string)**: `Promise<{ userId: string; currentRank: number; previousRank: number | null; currentScore: number }[]>` — All users' ranks at the latest snapshot date, paired with each user's rank at the penultimate snapshot date (for rank-change computation). Three-step query: get 2 most-recent distinct dates, fetch latest rows, fetch penultimate rows (if exists), join via Map. Returns empty array when no snapshots exist; `previousRank` is null for users absent from the penultimate snapshot.
   Calls: db
 - **findGroupsForUsers(userIds: string[])**: `Promise<{ id: string }[]>` — Distinct group IDs where at least one member (owner or participant) is in `userIds`. Returns empty array for empty input. Uses LEFT JOIN on `prode_group_participants`.
+  Calls: db
+
+### app/db/favorite-groups-repository.ts
+Repository for the `user_favorite_groups` table. Manages user-level favorite and main-group designation for friend groups (Story #332).
+
+- **getFavoriteGroupIds(userId: string)**: `Promise<string[]>` — All group IDs the user has favorited.
+  Calls: db
+- **getMainGroupId(userId: string)**: `Promise<string | null>` — The user's designated main group ID, or null if none.
+  Calls: db
+- **addFavoriteGroup(userId: string, groupId: string)**: `Promise<void>` — Inserts a favorite row; no-op on conflict (idempotent).
+  Calls: db
+- **removeFavoriteGroup(userId: string, groupId: string)**: `Promise<void>` — Deletes the favorite row (cascades main designation if that row had is_main=true).
+  Calls: db
+- **setMainGroup(userId: string, groupId: string)**: `Promise<void>` — Clears any existing main group for the user, then upserts the row with is_main=true. Group must already be a favorite (upsert will add it if not).
+  Calls: db
+- **clearMainGroup(userId: string)**: `Promise<void>` — Sets is_main=false for the user's current main group; no-op if no main group is set.
   Calls: db

--- a/docs/code-structure/pages.md
+++ b/docs/code-structure/pages.md
@@ -159,7 +159,7 @@ Tournament context layout with header, sidebar, and bottom navigation.
   Calls: hasUserPermission
 - **extractScoringConfig(tournament)**: `ScoringConfig | undefined` — [Server] Extracts scoring configuration from tournament object.
 - **isWithinFiveDaysOfStart(startDate)**: `boolean` — [Server] Checks if current time is within 5 days of tournament start.
-- **TournamentLayout(props: TournamentLayoutProps)**: `JSX.Element` — [Server] Renders two-column layout with main content (9/12) and sidebar (3/12 desktop, hidden mobile); handles tournament switcher, navigation, badges, SportsEvent JSON-LD structured data, and parallel group rank fetching. After `getGroupsForUser`, fetches ranks for all user groups in parallel via `getGroupRankingForUser`, derives `groupRanks: Record<string, number>`, and passes to `TournamentSidebar`.
+- **TournamentLayout(props: TournamentLayoutProps)**: `JSX.Element` — [Server] Renders two-column layout with main content (9/12) and sidebar (3/12 desktop, hidden mobile); handles tournament switcher, navigation, badges, SportsEvent JSON-LD structured data, and parallel group rank fetching. After `getGroupsForUser`, fetches ranks for all user groups in parallel via `getGroupRankingForUser`, derives `groupRanks: Record<string, number>`, and passes `prodeGroups` (including `favoriteGroupIds` and `mainGroupId`) to `TournamentSidebar → FriendGroupsList`.
   Calls: getLocale, getLoggedInUser, getTournamentAndGroupsData, getTournaments, getTournamentStartDate, getGroupStandingsForTournament, getGroupsForUser, findTournamentGuessByUserIdTournament, getPlayersInTournament, findTournamentById, getGameGuessStatisticsForUsers, getThemeLogoUrl, isDevelopmentMode, buildSportsEventJsonLd, getGroupRankingForUser
   Renders: JsonLd, TournamentSwitcher, GroupSelector, TournamentSidebar, ThemeSwitcher, LanguageSwitcher, UserActions, DevTournamentBadge, ScrollableContentArea, EmptyAwardsSnackbar, EnvironmentIndicator, TournamentBottomNavWrapper, NewTournamentSnackbar
 
@@ -228,7 +228,7 @@ Qualified teams (group finalists) prediction page with drag-and-drop interface.
 ### app/[locale]/tournaments/[id]/friend-groups/page.tsx
 Tournament-scoped friend groups list showing group stats for specific tournament.
 
-- **TournamentGroupsPage(props)**: `JSX.Element` — [Server] Fetches user's groups and calculates tournament-specific stats; renders groups list.
+- **TournamentGroupsPage(props)**: `JSX.Element` — [Server] Fetches user's groups and calculates tournament-specific stats; passes `favoriteGroupIds` and `mainGroupId` from `getGroupsForUser` to `TournamentGroupsList` for sorting and star/crown rendering.
   Calls: getLoggedInUser, getGroupsForUser, calculateTournamentGroupStats, getUserJoinRequests
   Renders: TournamentGroupsList
 

--- a/locales/en/groups.json
+++ b/locales/en/groups.json
@@ -606,6 +606,13 @@
     "noHistory": "No history yet",
     "noHistoryDescription": "Score history will appear once the tournament starts and scores are calculated."
   },
+  "favorites": {
+    "addFavorite": "Add to favorites",
+    "removeFavorite": "Remove from favorites",
+    "setMainGroup": "Set as main group",
+    "clearMainGroup": "Clear main group",
+    "mainGroupLabel": "Main group"
+  },
   "metadata": {
     "description": "View friend group standings and compete in {name}"
   }

--- a/locales/en/groups.json
+++ b/locales/en/groups.json
@@ -607,11 +607,8 @@
     "noHistoryDescription": "Score history will appear once the tournament starts and scores are calculated."
   },
   "favorites": {
-    "addFavorite": "Add to favorites",
-    "removeFavorite": "Remove from favorites",
-    "setMainGroup": "Set as main group",
-    "clearMainGroup": "Clear main group",
-    "mainGroupLabel": "Main group"
+    "addFavorite": "Make this one of your favorite groups",
+    "removeFavorite": "This is one of your favorite groups"
   },
   "metadata": {
     "description": "View friend group standings and compete in {name}"

--- a/locales/es/groups.json
+++ b/locales/es/groups.json
@@ -208,7 +208,7 @@
     "yourPoints": "Tus Puntos",
     "leader": "Líder",
     "viewDetails": "Ver Detalles",
-    "viewLeaderboard": "Ver Marcador",
+    "viewLeaderboard": "Ver Posiciones",
     "positionOf": "#{position} de {total}"
   },
   "customization": {
@@ -328,8 +328,8 @@
     "createdBy": "Creado por {name}",
     "requestToJoin": "Solicitar Unirse",
     "pending": "Solicitud Pendiente",
-    "viewGroup": "Ver Marcador",
-    "viewLeaderboard": "Ver Marcador",
+    "viewGroup": "Ver Posiciones",
+    "viewLeaderboard": "Ver Posiciones",
     "readMore": "Leer más",
     "readLess": "Leer menos",
     "loginToJoin": "Inicia sesión para unirte a este grupo",
@@ -605,6 +605,13 @@
     "rankChartTitle": "Posición en el tiempo",
     "noHistory": "Sin historial",
     "noHistoryDescription": "El historial de puntos aparecerá cuando comience el torneo y se calculen los puntajes."
+  },
+  "favorites": {
+    "addFavorite": "Agregar a favoritos",
+    "removeFavorite": "Quitar de favoritos",
+    "setMainGroup": "Establecer como grupo principal",
+    "clearMainGroup": "Quitar grupo principal",
+    "mainGroupLabel": "Grupo principal"
   },
   "metadata": {
     "description": "Ver la tabla de posiciones del grupo {name}"

--- a/locales/es/groups.json
+++ b/locales/es/groups.json
@@ -607,11 +607,8 @@
     "noHistoryDescription": "El historial de puntos aparecerá cuando comience el torneo y se calculen los puntajes."
   },
   "favorites": {
-    "addFavorite": "Agregar a favoritos",
-    "removeFavorite": "Quitar de favoritos",
-    "setMainGroup": "Establecer como grupo principal",
-    "clearMainGroup": "Quitar grupo principal",
-    "mainGroupLabel": "Grupo principal"
+    "addFavorite": "Agregar este grupo a tus favoritos",
+    "removeFavorite": "Este es uno de tus grupos favoritos"
   },
   "metadata": {
     "description": "Ver la tabla de posiciones del grupo {name}"

--- a/migrations/20260417000000_create_user_favorite_groups.sql
+++ b/migrations/20260417000000_create_user_favorite_groups.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_favorite_groups (
+  user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  group_id   UUID NOT NULL REFERENCES prode_groups(id) ON DELETE CASCADE,
+  is_main    BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, group_id)
+);
+
+-- Enforce at most one main group per user
+CREATE UNIQUE INDEX user_favorite_groups_main_idx
+  ON user_favorite_groups(user_id) WHERE is_main = TRUE;

--- a/plans/STORY-332-context.md
+++ b/plans/STORY-332-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** [Story] Favorite friend groups and navigation improvements
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-332
 - **Branch:** feature/story-332
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 337
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/337
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-332-context.md
+++ b/plans/STORY-332-context.md
@@ -1,0 +1,16 @@
+# Story 332 Context
+
+## Metadata
+- **Story Number:** 332
+- **Story Title:** [Story] Favorite friend groups and navigation improvements
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-332
+- **Branch:** feature/story-332
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-332-plan.md
+
+## Quick Summary
+Adds favorite/main-group designation for friend groups: star icon on sidebar rows and Friend Groups page cards, sort favorites to top, one group can be designated "Main Group" (crown icon, always first). Also makes group name a clickable link in the Friend Groups page cards, and fixes the Spanish translation "Ver Marcador" → "Ver Posiciones".

--- a/plans/STORY-332-context.md
+++ b/plans/STORY-332-context.md
@@ -9,8 +9,9 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/337
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** implementing
 - **Plan File:** plans/STORY-332-plan.md
+- **Task File:** plans/STORY-332-tasks.md
 
 ## Quick Summary
 Adds favorite/main-group designation for friend groups: star icon on sidebar rows and Friend Groups page cards, sort favorites to top, one group can be designated "Main Group" (crown icon, always first). Also makes group name a clickable link in the Friend Groups page cards, and fixes the Spanish translation "Ver Marcador" → "Ver Posiciones".

--- a/plans/STORY-332-plan.md
+++ b/plans/STORY-332-plan.md
@@ -1,0 +1,400 @@
+# Plan: Story #332 — Favorite Friend Groups & Navigation Improvements
+
+## Context
+
+Users with many friend groups face a flat, unordered list in both the sidebar and the Friend Groups page. There's no way to surface important groups or control which group is highlighted in the sidebar. Two specific navigation issues also exist: group title names in the Friend Groups page are not clickable links, and the Spanish translation "Ver Marcador" doesn't reflect the correct word (posiciones = standings/positions). This story adds favorite/main group designation, sorts favorites to the top, makes group titles navigable, and fixes the translation.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Star icon on group rows (sidebar) and group cards (Friend Groups page) toggles favorite status
+- [ ] Favorite groups sort to top of sidebar list and Friend Groups page
+- [ ] Exactly one group can be designated as "Main Group" (crown icon; first in the sorted list)
+- [ ] Group title/name in Friend Groups page card is a clickable link to the group page
+- [ ] Spanish: "Ver Marcador" → "Ver Posiciones" in all occurrences
+- [ ] Works in EN and ES
+
+---
+
+## Technical Approach
+
+### 1. DB Migration
+
+New table `user_favorite_groups`:
+
+```sql
+CREATE TABLE user_favorite_groups (
+  user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  group_id   UUID NOT NULL REFERENCES prode_groups(id) ON DELETE CASCADE,
+  is_main    BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, group_id)
+);
+-- Enforce at most one main group per user
+CREATE UNIQUE INDEX user_favorite_groups_main_idx
+  ON user_favorite_groups(user_id) WHERE is_main = TRUE;
+```
+
+A group can only be main if it is also a favorite. Removing a favorite auto-clears the main flag (the DELETE removes the whole row).
+
+### 2. Data Layer
+
+**New file: `app/db/favorite-groups-repository.ts`**
+- `getFavoriteGroupIds(userId)` — return `string[]` of favorited group IDs
+- `getMainGroupId(userId)` — return `string | null` for the main group
+- `addFavoriteGroup(userId, groupId)` — insert row
+- `removeFavoriteGroup(userId, groupId)` — delete row (cascades main flag)
+- `setMainGroup(userId, groupId)` — upsert row with `is_main=true` + clears any previous main via UPDATE
+- `clearMainGroup(userId)` — set `is_main=false` for user's current main group
+
+**Modified: `app/db/tables-definition.ts`**
+- Add `UserFavoriteGroupTable` interface
+
+**Modified: `app/db/database.ts`**
+- Add `user_favorite_groups: UserFavoriteGroupTable` to `DB` interface
+
+### 3. Server Actions
+
+**New file: `app/actions/favorite-group-actions.ts`**
+- `toggleFavoriteGroupAction(groupId)` — add or remove from favorites; revalidate
+- `setMainGroupAction(groupId)` — set as main; revalidate
+- `clearMainGroupAction()` — clear main group designation; revalidate
+
+**Modified: `app/actions/prode-group-actions.ts` (`getGroupsForUser`)**
+- Also fetch `favoriteGroupIds` and `mainGroupId` for the current user
+- Return these alongside the existing `userGroups`, `participantGroups`, `pendingRequests`
+
+### 4. UI — Sorting Logic (shared utility)
+
+A sorting helper function (inline in components):
+```
+1. Main group (is_main=true) — always first
+2. Other favorites (sorted by name alphabetically)
+3. Non-favorites (existing order preserved)
+```
+
+### 5. UI — `FriendGroupsList` (sidebar)
+
+**File: `app/components/tournament-page/friend-groups-list.tsx`**
+
+New props:
+- `favoriteGroupIds?: string[]`
+- `mainGroupId?: string | null`
+
+Changes:
+- Sort all groups using the sort logic above before rendering
+- Add a `StarBorderIcon` / `StarIcon` (amber) icon button next to each group name
+- Add a `WorkspacePremiumIcon` (or `EmojiEventsIcon`) crown icon button for favorited groups to designate/clear main
+- Primary group in the header subheader becomes the main group (if designated) or falls back to current behavior
+- Calls `toggleFavoriteGroupAction` / `setMainGroupAction` via `useTransition` for optimistic UI
+
+### 6. UI — `TournamentGroupCard` (my-groups variant)
+
+**File: `app/components/tournament-page/tournament-group-card.tsx`**
+
+New props on `MyGroupsCardProps`:
+- `isFavorite?: boolean`
+- `isMainGroup?: boolean`
+- `onToggleFavorite?: (groupId: string) => void`
+- `onSetMainGroup?: (groupId: string) => void`
+
+Changes:
+- Add star icon button in the card header (top right, alongside Share/Owner badge)
+- Add crown icon for main group (only visible for favorited cards)
+- **Make group name a `Link`** to `/${locale}/tournaments/${tournamentId}/friend-groups/${group.groupId}` — wraps the Typography element
+
+### 7. UI — `TournamentGroupsList` (Friend Groups page)
+
+**File: `app/components/tournament-page/tournament-groups-list.tsx`**
+
+New props:
+- `favoriteGroupIds?: string[]`
+- `mainGroupId?: string | null`
+
+Changes:
+- Sort `groups` array with main → favorites → others before rendering
+- Pass `isFavorite`, `isMainGroup`, `onToggleFavorite`, `onSetMainGroup` to each `TournamentGroupCard`
+- Handle optimistic state updates: maintain local `favoriteGroupIds` / `mainGroupId` in `useState`, update immediately, then call server action via `useTransition`
+
+### 8. Data Flow Changes
+
+**`app/[locale]/tournaments/[id]/friend-groups/page.tsx`**
+- Destructure `favoriteGroupIds` and `mainGroupId` from `getGroupsForUser()` result
+- Pass them as props to `TournamentGroupsList`
+
+**`app/[locale]/tournaments/[id]/layout.tsx`**
+- `prodeGroups` now includes `favoriteGroupIds` and `mainGroupId`
+- Pass through to `TournamentSidebar` → `FriendGroupsList`
+
+**`app/[locale]/tournaments/[id]/layout.tsx` + `TournamentSidebarProps`**
+- Update `prodeGroups` type to include `favoriteGroupIds?: string[]` and `mainGroupId?: string | null`
+
+### 9. Translation Fix
+
+**`locales/es/groups.json`**
+- `groups.card.viewLeaderboard`: `"Ver Marcador"` → `"Ver Posiciones"`
+- `groups.discovery.viewGroup`: `"Ver Marcador"` → `"Ver Posiciones"`
+- `groups.discovery.viewLeaderboard`: `"Ver Marcador"` → `"Ver Posiciones"`
+- Add new keys for favorites: `groups.favorites.addFavorite`, `groups.favorites.removeFavorite`, `groups.favorites.setMainGroup`, `groups.favorites.clearMainGroup`, `groups.favorites.mainGroupLabel`
+
+**`locales/en/groups.json`**
+- Add same new `groups.favorites.*` keys in English
+
+---
+
+## Visual Prototype
+
+### Sidebar (`FriendGroupsList`) — list row
+```
+┌─────────────────────────────────────────────┐
+│ Friend Groups                    [▾]        │
+│ 3 groups · #2 in Main Crew                  │
+├─────────────────────────────────────────────┤
+│  👑 #2  Main Crew              [★][×][↗]   │  ← main group (crown + filled star)
+│  ⭐ #5  Work Buds             [★][×][↗]   │  ← favorite (filled star)
+│     #9  Casual League         [☆][×][↗]   │  ← not a favorite (empty star)
+│  ─────────────────────────────────────────  │
+│  [+ Create Group]                           │
+└─────────────────────────────────────────────┘
+```
+- Crown only appears on the main group's row
+- Clicking filled ★ on main group → removes from favorites (clears main too)
+- Clicking filled ★ on non-main favorite → removes from favorites
+- Clicking empty ☆ → adds to favorites
+- Clicking 👑 on a favorite → sets it as main (previous main loses crown)
+
+### TournamentGroupCard — header area
+```
+┌────────────────────────────────────────────┐
+│  Main Crew                    [Owner] [★]  │  ← star icon in header
+│  ↑ clicking name navigates to group page   │
+│                                            │
+│  Your Position   Your Points               │
+│  #2 of 18        112                       │
+│                                            │
+│  Leader: Gabi (130 pts)                    │
+├────────────────────────────────────────────┤
+│          [View Standings]                  │
+└────────────────────────────────────────────┘
+```
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `migrations/20260417000000_create_user_favorite_groups.sql` | DB table |
+| `app/db/favorite-groups-repository.ts` | DB operations |
+| `app/actions/favorite-group-actions.ts` | Server actions |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/db/tables-definition.ts` | Add `UserFavoriteGroupTable` |
+| `app/db/database.ts` | Add `user_favorite_groups` to `DB` |
+| `app/actions/prode-group-actions.ts` | Add favorites to `getGroupsForUser()` return |
+| `app/definitions.ts` | Add `isFavorite?`, `isMainGroup?` to `TournamentGroupStats` |
+| `app/components/tournament-page/friend-groups-list.tsx` | Star/crown icons, sort, call actions |
+| `app/components/tournament-page/tournament-group-card.tsx` | Star icon, title as Link |
+| `app/components/tournament-page/tournament-groups-list.tsx` | Sort, pass props, optimistic state |
+| `app/[locale]/tournaments/[id]/friend-groups/page.tsx` | Pass favorites to list |
+| `app/[locale]/tournaments/[id]/layout.tsx` | Pass favorites through sidebar props |
+| `app/components/tournament-page/tournament-sidebar.tsx` | Update `prodeGroups` type |
+| `locales/es/groups.json` | Translation fixes + new favorite keys |
+| `locales/en/groups.json` | New favorite keys |
+| `docs/code-structure/db.md` | Document new repository |
+| `docs/code-structure/actions.md` | Document new actions |
+| `docs/code-structure/components-friend-groups.md` | No new file, but update tournament-group-card entry |
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+**Modified flows:**
+- **Flow: Sidebar prode groups** — `layout.tsx` → `getGroupsForUser()` now also returns `favoriteGroupIds` + `mainGroupId` → passed through `TournamentSidebar` → `FriendGroupsList`
+- **Flow: Friend Groups page** — `tournament/friend-groups/page.tsx` → `getGroupsForUser()` → `favoriteGroupIds`/`mainGroupId` passed to `TournamentGroupsList` → `TournamentGroupCard`
+
+**New flows:**
+- `FriendGroupsList` → `toggleFavoriteGroupAction(groupId)` → `addFavoriteGroup/removeFavoriteGroup`
+- `FriendGroupsList` → `setMainGroupAction(groupId)` → `setMainGroup/clearMainGroup`
+- `TournamentGroupsList` → `toggleFavoriteGroupAction(groupId)` → `addFavoriteGroup/removeFavoriteGroup`
+
+---
+
+### `migrations/20260417000000_create_user_favorite_groups.sql` *(new)*
+
+SQL migration creating the `user_favorite_groups` table with partial unique index for main group constraint.
+
+---
+
+### `app/db/favorite-groups-repository.ts` *(new)*
+
+- **`getFavoriteGroupIds(userId: string)`**: `Promise<string[]>`
+  Returns IDs of all groups the user has favorited.
+  Tests:
+  - returns empty array when user has no favorites
+  - returns correct group IDs for user with favorites
+  - does not return groups from other users
+
+- **`getMainGroupId(userId: string)`**: `Promise<string | null>`
+  Returns the ID of the user's designated main group, or null if none.
+  Tests:
+  - returns null when no main group is set
+  - returns the correct group ID when main group is set
+  - returns null after the main group is cleared
+
+- **`addFavoriteGroup(userId: string, groupId: string)`**: `Promise<void>`
+  Inserts a row. No-op if already exists (ON CONFLICT DO NOTHING).
+  Tests:
+  - inserts a new favorite row
+  - does not throw when called with an already-favorited group (idempotent)
+  - does not insert favorite for a different user (user isolation verified)
+
+- **`removeFavoriteGroup(userId: string, groupId: string)`**: `Promise<void>`
+  Deletes the row. Also clears main group if that row had is_main=true.
+  Tests:
+  - removes the favorite row
+  - no-op when group is not favorited
+  - removing a main group also clears the main designation
+
+- **`setMainGroup(userId: string, groupId: string)`**: `Promise<void>`
+  Upserts the row with is_main=true; clears is_main from the previous main group.
+  Tests:
+  - sets the specified group as main
+  - previous main group loses its main status
+  - requires the group to be in the favorites table (throws if not favorited)
+
+- **`clearMainGroup(userId: string)`**: `Promise<void>`
+  Sets is_main=false for the user's current main group.
+  Tests:
+  - clears the main group flag
+  - no-op when no main group is set
+  - does not clear another user's main group (user isolation)
+
+---
+
+### `app/actions/favorite-group-actions.ts` *(new)*
+
+- **`toggleFavoriteGroupAction(groupId: string)`**: `Promise<{ isFavorite: boolean }>`
+  Server Action. Adds or removes the group from the authenticated user's favorites.
+  Calls: getLoggedInUser, getFavoriteGroupIds, addFavoriteGroup | removeFavoriteGroup, revalidatePath
+  Tests:
+  - throws Unauthorized when no active session
+  - adds group to favorites when not currently favorited, returns `{ isFavorite: true }`
+  - removes group from favorites when currently favorited, returns `{ isFavorite: false }`
+  - removing a favorited main group also clears the main designation
+
+- **`setMainGroupAction(groupId: string)`**: `Promise<void>`
+  Server Action. Designates the given group as the user's main group (must already be a favorite).
+  Calls: getLoggedInUser, getFavoriteGroupIds, setMainGroup, revalidatePath
+  Tests:
+  - throws Unauthorized when no active session
+  - throws when groupId is not in user's favorites
+  - sets the group as main for a valid favorited group
+
+- **`clearMainGroupAction()`**: `Promise<void>`
+  Server Action. Clears the user's main group designation.
+  Calls: getLoggedInUser, clearMainGroup, revalidatePath
+  Tests:
+  - throws Unauthorized when no active session
+  - clears the main group when one is set
+  - no-op when no main group is set
+
+---
+
+### `app/actions/prode-group-actions.ts` — `getGroupsForUser` *(modified)*
+
+- **`getGroupsForUser()`**: `Promise<{ userGroups, participantGroups, pendingRequests, favoriteGroupIds: string[], mainGroupId: string | null } | undefined>` *(was: no favorite fields)*
+  Now also fetches favorite and main group data in parallel.
+  Calls: getLoggedInUser, findProdeGroupsByOwner, findProdeGroupsByParticipant, findJoinRequestsByUser, getFavoriteGroupIds, getMainGroupId
+  Tests:
+  - (existing tests unchanged)
+  - new: returned object includes `favoriteGroupIds` as empty array when user has no favorites
+  - new: returned object includes correct `mainGroupId` when user has a main group
+
+---
+
+### `app/components/tournament-page/friend-groups-list.tsx` *(modified)*
+
+New props: `favoriteGroupIds?: string[]`, `mainGroupId?: string | null`
+
+Key behavior:
+- Sorts all groups: main first, then favorites (alpha), then others
+- Renders `StarIcon` (amber, filled) for favorited groups, `StarBorderIcon` for others
+- Renders a crown-style secondary icon (`WorkspacePremiumIcon`) on the main group row
+- Calls `toggleFavoriteGroupAction` and `setMainGroupAction` via `startTransition`
+- Uses local optimistic state (`useState` for local `favoriteGroupIds`/`mainGroupId`)
+
+---
+
+### `app/components/tournament-page/tournament-group-card.tsx` *(modified)*
+
+New props on `MyGroupsCardProps`:
+- `isFavorite?: boolean`
+- `isMainGroup?: boolean`
+- `onToggleFavorite?: (groupId: string) => void`
+- `onSetMainGroup?: (groupId: string) => void`
+
+Changes:
+- Group name `Typography` is wrapped in a MUI `Link` (Next.js `Link`) pointing to the group detail page
+- Star icon button (amber when favorite) added to the header actions area
+- Crown icon appears next to star only when `isMainGroup=true`
+
+---
+
+### `app/components/tournament-page/tournament-groups-list.tsx` *(modified)*
+
+New props: `favoriteGroupIds?: string[]`, `mainGroupId?: string | null`
+
+Key behavior:
+- Sorts `groups` by: main → favorites → others
+- Maintains local `favoriteGroupIds`/`mainGroupId` state for optimistic updates
+- Passes `isFavorite`, `isMainGroup`, `onToggleFavorite`, `onSetMainGroup` to each `TournamentGroupCard`
+- `onToggleFavorite` calls `toggleFavoriteGroupAction` via `startTransition` + updates local state
+- `onSetMainGroup` calls `setMainGroupAction` via `startTransition` + updates local state
+
+---
+
+## Testing Strategy
+
+**Project test utilities to use:**
+- `renderWithTheme(component)` — all React component tests
+- `testFactories.user()`, `testFactories.prodeGroup()` — for generating typed test data
+- `vi.mock('@/app/actions/...')` — for mocking server actions in component tests
+- `createMockSelectQuery()` (if applicable) — for mocking Kysely queries at the DB layer
+
+**Test coverage plan:**
+- Unit tests for `favorite-groups-repository.ts`: mock Kysely DB, test add/remove/setMain/clearMain including user isolation (different userId never affects results)
+- Unit tests for `favorite-group-actions.ts`: mock auth (`getLoggedInUser`) + repository functions; test toggle behavior, auth errors, and permission checks (user can only affect their own favorites)
+- Unit tests for updated `FriendGroupsList`: use `renderWithTheme`, verify sort order (main → favorites → others), verify star/crown icons render correctly, verify `toggleFavoriteGroupAction` is called on star click
+- Unit tests for `TournamentGroupCard`: verify star renders when `isFavorite=true`, verify name is wrapped in a `Link`, verify `onToggleFavorite` fires on click
+- Unit tests for `TournamentGroupsList`: verify optimistic sort update when `onToggleFavorite` fires
+- **Edge cases to test explicitly:** concurrent toggle (DB-level idempotency), cascade when main group is deleted by another user (DB ON DELETE CASCADE removes the row), removing a main favorite also clears the main designation
+- Existing `friend-groups-list.test.tsx` tests should still pass (new props are optional)
+- Coverage target: ≥80% on new/modified files
+
+---
+
+## Validation
+
+1. Create worktree: `./scripts/github-projects-helper story start 332 --project 1`
+2. Run migration manually (with user permission)
+3. Run `npm run test` — all tests pass
+4. Run `npm run lint` — no ESLint errors
+5. Run `npm run build` — clean build
+6. Deploy to Vercel Preview
+7. Manual test: star a group → it sorts to top in sidebar and Friend Groups page
+8. Manual test: star two groups, set one as main → main appears first
+9. Manual test: click group name in Friend Groups page → navigates to group
+10. Manual test: check "Ver Posiciones" in Spanish locale
+
+---
+
+## Open Questions
+
+None — scope is well-defined. No limit on number of favorites (per issue). Main group is implicitly part of favorites (is_main row lives in user_favorite_groups).

--- a/plans/STORY-332-tasks.md
+++ b/plans/STORY-332-tasks.md
@@ -1,0 +1,66 @@
+# Story 332 Tasks
+
+## Wave Summary
+- Wave 1 (Sequential): Task 1 (DB schema + types)
+- Wave 2 (Parallel): Task 2 (DB repo) + Task 8 (translations)
+- Wave 3 (Parallel): Task 3 (server actions) + Task 4 (TournamentGroupCard)
+- Wave 4 (Parallel): Task 5 (FriendGroupsList) + Task 6 (TournamentGroupsList)
+- Wave 5 (Sequential): Task 7 (data flow wiring)
+
+## Tasks
+
+### Task 1 — Create DB migration and add UserFavoriteGroupTable type definitions
+**Status:** pending
+**Owner:**
+**Wave:** 1
+**Blocked by:** —
+**Files:** migrations/20260417000000_create_user_favorite_groups.sql, app/db/tables-definition.ts, app/db/database.ts
+
+### Task 2 — Implement favorite-groups-repository.ts
+**Status:** pending
+**Owner:**
+**Wave:** 2
+**Blocked by:** Task 1
+**Files:** app/db/favorite-groups-repository.ts
+
+### Task 3 — Implement favorite-group-actions.ts and update getGroupsForUser
+**Status:** pending
+**Owner:**
+**Wave:** 3
+**Blocked by:** Task 2
+**Files:** app/actions/favorite-group-actions.ts, app/actions/prode-group-actions.ts
+
+### Task 4 — Update TournamentGroupCard — add star/crown icons and clickable title link
+**Status:** pending
+**Owner:**
+**Wave:** 3
+**Blocked by:** —
+**Files:** app/components/tournament-page/tournament-group-card.tsx
+
+### Task 5 — Update FriendGroupsList — add star/crown icons, sort logic, and optimistic state
+**Status:** pending
+**Owner:**
+**Wave:** 4
+**Blocked by:** Task 3
+**Files:** app/components/tournament-page/friend-groups-list.tsx
+
+### Task 6 — Update TournamentGroupsList — add sort, optimistic state, pass favorites props to cards
+**Status:** pending
+**Owner:**
+**Wave:** 4
+**Blocked by:** Tasks 3, 4
+**Files:** app/components/tournament-page/tournament-groups-list.tsx
+
+### Task 7 — Wire favorites data through layout, page, and sidebar
+**Status:** pending
+**Owner:**
+**Wave:** 5
+**Blocked by:** Tasks 3, 5, 6
+**Files:** app/[locale]/tournaments/[id]/layout.tsx, app/components/tournament-page/tournament-sidebar.tsx, app/[locale]/tournaments/[id]/friend-groups/page.tsx, app/definitions.ts
+
+### Task 8 — Fix Spanish translations and add favorites i18n keys
+**Status:** pending
+**Owner:**
+**Wave:** 2
+**Blocked by:** —
+**Files:** locales/es/groups.json, locales/en/groups.json


### PR DESCRIPTION
## Plan

This PR contains the implementation plan for story #332.

Fixes #332

## Summary
- New `user_favorite_groups` DB table (user_id, group_id, is_main)
- New `favorite-groups-repository.ts` and `favorite-group-actions.ts`
- Star icon toggle on sidebar rows and Friend Groups page cards
- Sort: main group → favorites → non-favorites in both views
- Group name in TournamentGroupCard is a clickable Link
- Spanish: 'Ver Marcador' → 'Ver Posiciones'

## Review Checklist
- [ ] DB migration approach looks correct
- [ ] UX for main group designation (crown icon) is clear
- [ ] Optimistic update strategy is acceptable
- [ ] Translation fix scope is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)