### PR TITLE
Plan: [Bug] Fix email verification overlay blocking tournament header and update branding #351

### DIFF
--- a/__tests__/app/template.test.tsx
+++ b/__tests__/app/template.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithTheme } from '../utils/test-utils';
+import Template from '../../app/template';
+
+describe('Template', () => {
+  it('renders children unconditionally', () => {
+    renderWithTheme(
+      <Template>
+        <div data-testid="child">content</div>
+      </Template>
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('does not render VerificationBanner', () => {
+    renderWithTheme(
+      <Template>
+        <div>content</div>
+      </Template>
+    );
+
+    expect(screen.queryByText('Email Not Verified')).not.toBeInTheDocument();
+  });
+
+  it('does not apply pointer-events:none to children', () => {
+    renderWithTheme(
+      <Template>
+        <div data-testid="child">content</div>
+      </Template>
+    );
+
+    const child = screen.getByTestId('child');
+    // Ancestor should not have pointerEvents: none style
+    expect(child.closest('[style*="pointer-events"]')).toBeNull();
+  });
+});

--- a/__tests__/components/header/header.test.tsx
+++ b/__tests__/components/header/header.test.tsx
@@ -55,8 +55,8 @@ vi.mock('next-intl/server', () => ({
     getTranslations: vi.fn(() => Promise.resolve((key: string) => {
         // Return realistic values for common translations used in Header
         const translations: Record<string, string> = {
-            'app.title': 'La Maquina Prode',
-            'app.logoAlt': 'la-maquina-prode',
+            'app.title': 'Prode Mundial',
+            'app.logoAlt': 'prode-mundial',
         };
         return translations[key] || key;
     })),
@@ -121,8 +121,8 @@ describe('Header', () => {
             await renderHeader();
 
             expect(screen.getByRole('banner')).toBeInTheDocument();
-            expect(screen.getByAltText('la-maquina-prode')).toBeInTheDocument();
-            expect(screen.getByText('La Maquina Prode')).toBeInTheDocument();
+            expect(screen.getByAltText('prode-mundial')).toBeInTheDocument();
+            expect(screen.getByText('Prode Mundial')).toBeInTheDocument();
             expect(screen.getByTestId('theme-switcher')).toBeInTheDocument();
             expect(screen.getByTestId('user-actions')).toBeInTheDocument();
         });
@@ -130,15 +130,15 @@ describe('Header', () => {
         it('renders the logo with correct src and alt attributes', async () => {
             await renderHeader();
 
-            const logo = screen.getByAltText('la-maquina-prode');
+            const logo = screen.getByAltText('prode-mundial');
             expect(logo).toHaveAttribute('src', '/logo.png');
-            expect(logo).toHaveAttribute('alt', 'la-maquina-prode');
+            expect(logo).toHaveAttribute('alt', 'prode-mundial');
         });
 
         it('renders the title with correct text', async () => {
             await renderHeader();
 
-            const title = screen.getByText('La Maquina Prode');
+            const title = screen.getByText('Prode Mundial');
             expect(title).toBeInTheDocument();
         });
 
@@ -156,21 +156,21 @@ describe('Header', () => {
         it('renders logo as clickable link to home', async () => {
             await renderHeader();
 
-            const logoLink = screen.getByAltText('la-maquina-prode').closest('a');
+            const logoLink = screen.getByAltText('prode-mundial').closest('a');
             expect(logoLink).toHaveAttribute('href', '/es');
         });
 
         it('renders title as clickable link to home', async () => {
             await renderHeader();
 
-            const titleLink = screen.getByText('La Maquina Prode').closest('a');
+            const titleLink = screen.getByText('Prode Mundial').closest('a');
             expect(titleLink).toHaveAttribute('href', '/es');
         });
 
         it('applies correct styles to logo', async () => {
             await renderHeader();
 
-            const logo = screen.getByAltText('la-maquina-prode');
+            const logo = screen.getByAltText('prode-mundial');
             expect(logo).toHaveAttribute('src', '/logo.png');
             // Avatar should have variant="rounded"
             expect(logo.closest('.MuiAvatar-root')).toHaveClass('MuiAvatar-rounded');
@@ -263,7 +263,7 @@ describe('Header', () => {
         it('renders left section with logo', async () => {
             await renderHeader();
 
-            const logo = screen.getByAltText('la-maquina-prode');
+            const logo = screen.getByAltText('prode-mundial');
             expect(logo).toBeInTheDocument();
             expect(logo.closest('a')).toHaveAttribute('href', '/es');
         });
@@ -271,7 +271,7 @@ describe('Header', () => {
         it('renders center section with title', async () => {
             await renderHeader();
 
-            const title = screen.getByText('La Maquina Prode');
+            const title = screen.getByText('Prode Mundial');
             expect(title).toBeInTheDocument();
         });
 
@@ -299,8 +299,8 @@ describe('Header', () => {
             await renderHeader();
 
             // All main elements should be present and spaced correctly
-            expect(screen.getByAltText('la-maquina-prode')).toBeInTheDocument();
-            expect(screen.getByText('La Maquina Prode')).toBeInTheDocument();
+            expect(screen.getByAltText('prode-mundial')).toBeInTheDocument();
+            expect(screen.getByText('Prode Mundial')).toBeInTheDocument();
             expect(screen.getByTestId('theme-switcher')).toBeInTheDocument();
             expect(screen.getByTestId('user-actions')).toBeInTheDocument();
         });
@@ -421,15 +421,15 @@ describe('Header', () => {
         it('has accessible logo with alt text', async () => {
             await renderHeader();
 
-            const logo = screen.getByAltText('la-maquina-prode');
+            const logo = screen.getByAltText('prode-mundial');
             expect(logo).toBeInTheDocument();
         });
 
         it('has accessible navigation links', async () => {
             await renderHeader();
 
-            const logoLink = screen.getByAltText('la-maquina-prode').closest('a');
-            const titleLink = screen.getByText('La Maquina Prode').closest('a');
+            const logoLink = screen.getByAltText('prode-mundial').closest('a');
+            const titleLink = screen.getByText('Prode Mundial').closest('a');
 
             expect(logoLink).toHaveAttribute('href', '/es');
             expect(titleLink).toHaveAttribute('href', '/es');
@@ -483,7 +483,7 @@ describe('Header', () => {
             await renderHeader();
 
             expect(screen.getByRole('banner')).toBeInTheDocument();
-            expect(screen.getByText('La Maquina Prode')).toBeInTheDocument();
+            expect(screen.getByText('Prode Mundial')).toBeInTheDocument();
         });
 
         it('handles server-side rendering with user data', async () => {

--- a/app/[locale]/tournaments/[id]/__tests__/layout.test.tsx
+++ b/app/[locale]/tournaments/[id]/__tests__/layout.test.tsx
@@ -11,6 +11,7 @@ import { findTournamentById } from '@/app/db/tournament-repository';
 import { getGameGuessStatisticsForUsers } from '@/app/db/game-guess-repository';
 import { redirect, notFound } from 'next/navigation';
 import { renderWithTheme } from '@/__tests__/utils/test-utils';
+import { findUserById } from '@/app/db/users-repository';
 
 // Mock server actions
 vi.mock('@/app/actions/tournament-actions', () => ({
@@ -50,6 +51,10 @@ vi.mock('@/app/db/tournament-repository', () => ({
 
 vi.mock('@/app/db/game-guess-repository', () => ({
   getGameGuessStatisticsForUsers: vi.fn()
+}));
+
+vi.mock('@/app/db/users-repository', () => ({
+  findUserById: vi.fn()
 }));
 
 vi.mock('next/navigation', () => ({
@@ -133,6 +138,9 @@ describe('TournamentLayout - Mobile Header Integration', () => {
     });
     (findTournamentById as any).mockResolvedValue(mockTournamentData.tournament);
     (getGameGuessStatisticsForUsers as any).mockResolvedValue([]);
+    (findUserById as any).mockResolvedValue({ email_verified: true });
+    // Default: verification not required
+    vi.stubEnv('REQUIRE_EMAIL_VERIFICATION', 'false');
   });
 
   it('renders tournament layout with all header components', async () => {
@@ -147,7 +155,7 @@ describe('TournamentLayout - Mobile Header Integration', () => {
     expect(screen.getByTestId('child-content')).toBeInTheDocument();
   });
 
-  it('includes La Maquina logo button for home navigation', async () => {
+  it('includes Prode Mundial logo button for home navigation', async () => {
     const params = Promise.resolve({ id: 'tournament-1' });
     const children = <div>Content</div>;
 
@@ -155,7 +163,7 @@ describe('TournamentLayout - Mobile Header Integration', () => {
     renderWithTheme(result as React.ReactElement);
 
     // Find logo by alt text
-    const logo = screen.getByAltText('La Maquina');
+    const logo = screen.getByAltText('Prode Mundial');
     expect(logo).toBeInTheDocument();
     expect(logo.tagName).toBe('IMG');
 
@@ -275,6 +283,80 @@ describe('TournamentLayout - Mobile Header Integration', () => {
     // Verify tournament data was fetched correctly
     expect(getTournamentAndGroupsData).toHaveBeenCalledWith('tournament-1');
     expect(getTournamentStartDate).toHaveBeenCalledWith('tournament-1');
+  });
+
+  describe('Email verification overlay', () => {
+    it('renders VerificationBanner below AppBar when user is unverified and verification required', async () => {
+      vi.stubEnv('REQUIRE_EMAIL_VERIFICATION', 'true');
+      (getLoggedInUser as any).mockResolvedValue({ ...mockUser, emailVerified: null });
+      (findUserById as any).mockResolvedValue({ email_verified: null });
+
+      const params = Promise.resolve({ id: 'tournament-1' });
+      const children = <div>Content</div>;
+
+      const result = await TournamentLayout({ params, children });
+      renderWithTheme(result as React.ReactElement);
+
+      expect(screen.getByText('Email Not Verified')).toBeInTheDocument();
+    });
+
+    it('does not render VerificationBanner when user is verified', async () => {
+      vi.stubEnv('REQUIRE_EMAIL_VERIFICATION', 'true');
+      (getLoggedInUser as any).mockResolvedValue({ ...mockUser, emailVerified: new Date() });
+      (findUserById as any).mockResolvedValue({ email_verified: true });
+
+      const params = Promise.resolve({ id: 'tournament-1' });
+      const children = <div>Content</div>;
+
+      const result = await TournamentLayout({ params, children });
+      renderWithTheme(result as React.ReactElement);
+
+      expect(screen.queryByText('Email Not Verified')).not.toBeInTheDocument();
+    });
+
+    it('does not render VerificationBanner when REQUIRE_EMAIL_VERIFICATION is false', async () => {
+      vi.stubEnv('REQUIRE_EMAIL_VERIFICATION', 'false');
+      (getLoggedInUser as any).mockResolvedValue({ ...mockUser, emailVerified: null });
+      (findUserById as any).mockResolvedValue({ email_verified: null });
+
+      const params = Promise.resolve({ id: 'tournament-1' });
+      const children = <div>Content</div>;
+
+      const result = await TournamentLayout({ params, children });
+      renderWithTheme(result as React.ReactElement);
+
+      expect(screen.queryByText('Email Not Verified')).not.toBeInTheDocument();
+    });
+
+    it('does not render VerificationBanner when no user is logged in', async () => {
+      vi.stubEnv('REQUIRE_EMAIL_VERIFICATION', 'true');
+      (getLoggedInUser as any).mockResolvedValue(null);
+
+      const params = Promise.resolve({ id: 'tournament-1' });
+      const children = <div>Content</div>;
+
+      const result = await TournamentLayout({ params, children });
+      renderWithTheme(result as React.ReactElement);
+
+      expect(screen.queryByText('Email Not Verified')).not.toBeInTheDocument();
+    });
+
+    it('AppBar is rendered outside the pointer-events:none wrapper (always interactive)', async () => {
+      vi.stubEnv('REQUIRE_EMAIL_VERIFICATION', 'true');
+      (getLoggedInUser as any).mockResolvedValue({ ...mockUser, emailVerified: null });
+      (findUserById as any).mockResolvedValue({ email_verified: null });
+
+      const params = Promise.resolve({ id: 'tournament-1' });
+      const children = <div data-testid="child-content">Content</div>;
+
+      const result = await TournamentLayout({ params, children });
+      renderWithTheme(result as React.ReactElement);
+
+      // AppBar should be present (always interactive — not wrapped in pointer-events:none)
+      const appBar = screen.getByRole('banner');
+      expect(appBar).toBeInTheDocument();
+      expect(appBar).not.toHaveStyle({ pointerEvents: 'none' });
+    });
   });
 
   it('shows dev tournament badge when tournament is dev_only', async () => {

--- a/app/[locale]/tournaments/[id]/layout.tsx
+++ b/app/[locale]/tournaments/[id]/layout.tsx
@@ -9,6 +9,9 @@ import NewTournamentSnackbar from "../../../components/tournament/new-tournament
 import {getGroupsForUser} from "../../../actions/prode-group-actions";
 import {findTournamentGuessByUserIdTournament} from "../../../db/tournament-guess-repository";
 import {getLoggedInUser} from "../../../actions/user-actions";
+import {findUserById} from "../../../db/users-repository";
+import VerificationBanner from "../../../components/verification/verification-banner";
+import {VerificationOverlay} from "../../../components/verification/verification-overlay";
 import Link from "next/link";
 import EmptyAwardsSnackbar from "../../../components/awards/empty-award-notification";
 import {getPlayersInTournament} from "../../../db/player-repository";
@@ -113,6 +116,11 @@ export default async function TournamentLayout(props: TournamentLayoutProps) {
   const children = props.children
   const locale = await getLocale()
   const user = await getLoggedInUser()
+  const isVerified = user &&
+    (user.emailVerified || (await findUserById(user.id))?.email_verified)
+  const requireEmailVerification = process.env.REQUIRE_EMAIL_VERIFICATION === 'true'
+  const isUnverified = requireEmailVerification && !!user && !isVerified
+
   const layoutData = await getTournamentAndGroupsData(params.id)
 
   // Get all active tournaments for switcher
@@ -196,12 +204,12 @@ export default async function TournamentLayout(props: TournamentLayoutProps) {
                 justifyContent: 'space-between',
                 gap: 1
               }}>
-            {/* La Maquina logo button (home navigation) */}
+            {/* Logo button (home navigation) */}
             <Link href={`/${locale}`} style={{ display: 'inline-flex', alignItems: 'center' }}>
               <Avatar
                 variant="rounded"
                 src="/logo.png"
-                alt="La Maquina"
+                alt="Prode Mundial"
                 sx={{
                   width: { xs: 32, md: 48 },
                   height: { xs: 32, md: 48 },
@@ -306,39 +314,44 @@ export default async function TournamentLayout(props: TournamentLayoutProps) {
           </Box>
         </Box>
       </AppBar>
+      {isUnverified && <VerificationBanner />}
       {/* Main content area */}
-      <Box sx={{
-        display: 'flow-root',
-        flexGrow: 1,
-        minHeight: 0,
-        px: 2
-      }}>
-        {/* Centered max-width container */}
+      <Box position="relative" sx={{ flexGrow: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+        {isUnverified && <VerificationOverlay />}
         <Box sx={{
-          maxWidth: '1200px',
-          mx: 'auto',
-          height: '100%'
+          ...(isUnverified ? { pointerEvents: 'none', userSelect: 'none' } : {}),
+          display: 'flow-root',
+          flexGrow: 1,
+          minHeight: 0,
+          px: 2
         }}>
-          <Grid container spacing={2} sx={{ height: '100%' }}>
-            {/* Main content - 9/12 on desktop, full on mobile */}
-            <Grid size={{ xs: 12, md: 9 }} sx={{ height: '100%' }}>
-              <ScrollableContentArea>
-                {children}
-              </ScrollableContentArea>
-            </Grid>
+          {/* Centered max-width container */}
+          <Box sx={{
+            maxWidth: '1200px',
+            mx: 'auto',
+            height: '100%'
+          }}>
+            <Grid container spacing={2} sx={{ height: '100%' }}>
+              {/* Main content - 9/12 on desktop, full on mobile */}
+              <Grid size={{ xs: 12, md: 9 }} sx={{ height: '100%' }}>
+                <ScrollableContentArea>
+                  {children}
+                </ScrollableContentArea>
+              </Grid>
 
-            {/* Sidebar - 4/12 on desktop, hidden on mobile */}
-            <TournamentSidebar
-              tournamentId={params.id}
-              scoringConfig={scoringConfig}
-              userGameStatistics={userGameStatistics?.[0]}
-              tournamentGuess={tournamentGuesses || undefined}
-              groupStandings={groupStandings}
-              prodeGroups={prodeGroups}
-              user={user ?? undefined}
-              groupRanks={groupRanks}
-            />
-          </Grid>
+              {/* Sidebar - 4/12 on desktop, hidden on mobile */}
+              <TournamentSidebar
+                tournamentId={params.id}
+                scoringConfig={scoringConfig}
+                userGameStatistics={userGameStatistics?.[0]}
+                tournamentGuess={tournamentGuesses || undefined}
+                groupStandings={groupStandings}
+                prodeGroups={prodeGroups}
+                user={user ?? undefined}
+                groupRanks={groupRanks}
+              />
+            </Grid>
+          </Box>
         </Box>
       </Box>
       {user &&

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,7 +1,7 @@
 export default function Template({
   children,
-}: {
+}: Readonly<{
   children: React.ReactNode
-}) {
+}>) {
   return <>{children}</>
 }

--- a/app/template.tsx
+++ b/app/template.tsx
@@ -1,49 +1,7 @@
-import {getLoggedInUser} from "./actions/user-actions";
-import VerificationBanner from "./components/verification/verification-banner";
-import {Box} from "@mui/material";
-import {findUserById} from "./db/users-repository";
-import {VerificationOverlay} from "./components/verification/verification-overlay";
-
-export default async function Template({
-                                         // Layouts must accept a children prop.
-                                         // This will be populated with nested layouts or pages
-                                         children,
-                                       }: {
+export default function Template({
+  children,
+}: {
   children: React.ReactNode
 }) {
-  const user = await getLoggedInUser();
-  const isVerified = user &&
-    //Solve use case in which the user has just been verified but the session is not updated
-    (user.emailVerified || (await findUserById(user.id))?.email_verified);
-
-  // Check if email verification is required
-  const requireEmailVerification = process.env.REQUIRE_EMAIL_VERIFICATION === 'true';
-
-  return (
-    <>
-      {requireEmailVerification && (user && !isVerified) && (
-        <VerificationBanner/>
-      )}
-
-      {/* Render children normally if verification is not required, user is verified, or not logged in */}
-      {(!requireEmailVerification || !user || isVerified) ? (
-        children
-      ) : (
-        /* Render a non-actionable overlay if user is not verified and verification is required */
-        (<Box position="relative">
-          {/* Apply a non-interactive overlay */}
-          <VerificationOverlay/>
-          {/* Render children but make them non-interactive */}
-          <Box
-            sx={{
-              pointerEvents: 'none',
-              userSelect: 'none'
-            }}
-          >
-            {children}
-          </Box>
-        </Box>)
-      )}
-    </>
-  );
+  return <>{children}</>
 }

--- a/docs/code-structure/pages.md
+++ b/docs/code-structure/pages.md
@@ -26,10 +26,9 @@ Dynamic XML sitemap via Next.js MetadataRoute. Fetches active tournaments and pu
   Calls: findAllActiveTournaments, findAllPublicGroupsForSitemap
 
 ### app/template.tsx
-Template component that applies email verification overlay and banner logic across all routes.
+Pure passthrough template. Renders children unconditionally with no verification logic.
 
-- **Template({ children })**: `JSX.Element` — [Server] Wraps children with verification banner and overlay based on user verification status and email verification requirement config.
-  Calls: getLoggedInUser, findUserById
+- **Template({ children })**: `JSX.Element` — [Server] Returns children directly with no side effects.
 
 ### app/transition.tsx
 Client-side page transition animation component using Framer Motion.
@@ -164,9 +163,9 @@ Tournament context layout with header, sidebar, and bottom navigation.
   Calls: hasUserPermission
 - **extractScoringConfig(tournament)**: `ScoringConfig | undefined` — [Server] Extracts scoring configuration from tournament object.
 - **isWithinFiveDaysOfStart(startDate)**: `boolean` — [Server] Checks if current time is within 5 days of tournament start.
-- **TournamentLayout(props: TournamentLayoutProps)**: `JSX.Element` — [Server] Renders two-column layout with main content (9/12) and sidebar (3/12 desktop, hidden mobile); handles tournament switcher, navigation, badges, SportsEvent JSON-LD structured data, and parallel group rank fetching. After `getGroupsForUser`, fetches ranks for all user groups in parallel via `getGroupRankingForUser`, derives `groupRanks: Record<string, number>`, and passes `prodeGroups` (including `favoriteGroupIds` and `mainGroupId`) to `TournamentSidebar → FriendGroupsList`.
-  Calls: getLocale, getLoggedInUser, getTournamentAndGroupsData, getTournaments, getTournamentStartDate, getGroupStandingsForTournament, getGroupsForUser, findTournamentGuessByUserIdTournament, getPlayersInTournament, findTournamentById, getGameGuessStatisticsForUsers, getThemeLogoUrl, isDevelopmentMode, buildSportsEventJsonLd, getGroupRankingForUser
-  Renders: JsonLd, TournamentSwitcher, GroupSelector, TournamentSidebar, ThemeSwitcher, LanguageSwitcher, UserActions, DevTournamentBadge, ScrollableContentArea, EmptyAwardsSnackbar, EnvironmentIndicator, TournamentBottomNavWrapper, NewTournamentSnackbar
+- **TournamentLayout(props: TournamentLayoutProps)**: `JSX.Element` — [Server] Renders two-column layout with main content (9/12) and sidebar (3/12 desktop, hidden mobile); handles tournament switcher, navigation, badges, SportsEvent JSON-LD structured data, and parallel group rank fetching. Also renders `VerificationBanner` between AppBar and main content (below header, always interactive), and wraps main content with `VerificationOverlay` + `pointerEvents:none` when user is unverified and `REQUIRE_EMAIL_VERIFICATION=true`.
+  Calls: getLocale, getLoggedInUser, findUserById, getTournamentAndGroupsData, getTournaments, getTournamentStartDate, getGroupStandingsForTournament, getGroupsForUser, findTournamentGuessByUserIdTournament, getPlayersInTournament, findTournamentById, getGameGuessStatisticsForUsers, getThemeLogoUrl, isDevelopmentMode, buildSportsEventJsonLd, getGroupRankingForUser
+  Renders: JsonLd, TournamentSwitcher, GroupSelector, TournamentSidebar, ThemeSwitcher, LanguageSwitcher, UserActions, DevTournamentBadge, ScrollableContentArea, EmptyAwardsSnackbar, EnvironmentIndicator, TournamentBottomNavWrapper, NewTournamentSnackbar, VerificationBanner, VerificationOverlay
 
 ### app/[locale]/tournaments/[id]/hub/page.tsx
 Backward-compatibility redirect for the old `/hub` route. Redirects to the tournament root.

--- a/docs/code-structure/pages.md
+++ b/docs/code-structure/pages.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-04-18
+**Last updated:** 2026-04-21
 
 ---
 

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -1,12 +1,12 @@
 {
   "app": {
     "name": "World Cup Predictions",
-    "title": "La Maquina Prode",
-    "logoAlt": "La Maquina Prode",
+    "title": "Prode Mundial",
+    "logoAlt": "Prode Mundial",
     "description": "Sports prediction platform",
     "loading": "Loading...",
     "error": "An error occurred",
-    "fullName": "La Maquina World Cup Predictions"
+    "fullName": "Prode Mundial"
   },
   "theme": {
     "switchTo": "Switch to {mode} mode",

--- a/locales/en/onboarding.json
+++ b/locales/en/onboarding.json
@@ -16,7 +16,7 @@
   },
   "steps": {
     "welcome": {
-      "title": "Welcome to La Maquina Prode!",
+      "title": "Welcome to Prode Mundial!",
       "description": "We'll guide you through the main features so you can start making your predictions and competing with your friends.",
       "durationInfo": "This tutorial will take approximately 2 minutes"
     },

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -1,12 +1,12 @@
 {
   "app": {
     "name": "Prode Mundial",
-    "title": "La Maquina Prode",
-    "logoAlt": "La Maquina Prode",
+    "title": "Prode Mundial",
+    "logoAlt": "Prode Mundial",
     "description": "Plataforma de pronósticos deportivos",
     "loading": "Cargando...",
     "error": "Ocurrió un error",
-    "fullName": "La Maquina Prode Mundial"
+    "fullName": "Prode Mundial"
   },
   "theme": {
     "switchTo": "Cambiar a modo {mode}",

--- a/locales/es/onboarding.json
+++ b/locales/es/onboarding.json
@@ -16,7 +16,7 @@
   },
   "steps": {
     "welcome": {
-      "title": "¡Bienvenido a La Maquina Prode!",
+      "title": "¡Bienvenido a Prode Mundial!",
       "description": "Te guiaremos a través de las funciones principales para que puedas empezar a hacer tus predicciones y competir con tus amigos.",
       "durationInfo": "Este tutorial tomará aproximadamente 2 minutos"
     },

--- a/mockups/pre-tournament-action-center-mockup-v2.html
+++ b/mockups/pre-tournament-action-center-mockup-v2.html
@@ -86,19 +86,21 @@
     });
 
     function StateToggle({ states, current, onChange }) {
+      const chips = states.map(s => html`
+        <${Chip}
+          key=${s}
+          label=${s.toUpperCase()}
+          size="small"
+          onClick=${() => onChange(s)}
+          variant=${current === s ? 'filled' : 'outlined'}
+          color=${current === s ? 'primary' : 'default'}
+          sx=${{ px: 1 }}
+        />
+      `);
+
       return html`
         <${Stack} direction="row" spacing=${1} sx=${{ mb: 3, justifyContent: 'center' }}>
-          ${states.map(s => html`
-            <${Chip}
-              key=${s}
-              label=${s.toUpperCase()}
-              size="small"
-              onClick=${() => onChange(s)}
-              variant=${current === s ? 'filled' : 'outlined'}
-              color=${current === s ? 'primary' : 'default'}
-              sx=${{ px: 1 }}
-            />
-          `)}
+          ${chips}
         <//>
       `;
     }
@@ -316,6 +318,10 @@
         ]
       };
 
+      const trackCards = tracks[state].map((track, i) => html`
+        <${TrackCard} key=${i} ...${track} />
+      `);
+
       return html`
         <${ThemeProvider} theme=${theme}>
           <${CssBaseline} />
@@ -339,9 +345,7 @@
             <//>
 
             <${Stack} spacing=${3}>
-              ${tracks[state].map((track, i) => html`
-                <${TrackCard} key=${i} ...${track} />
-              `)}
+              ${trackCards}
             <//>
 
             <${FriendGroupsSection} isEmpty=${state === 'incomplete'} />

--- a/mockups/pre-tournament-action-center-mockup-v2.html
+++ b/mockups/pre-tournament-action-center-mockup-v2.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Tournament Hub — Pre-Tournament Redesign</title>
+  <title>Pre-Tournament Action Center — Mockup</title>
   <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   
@@ -32,13 +32,11 @@
     import htm from 'htm';
     import { 
       ThemeProvider, createTheme, CssBaseline, 
-      Container, Box, Stack, Grid,
+      Container, Box, Stack,
       Card, CardContent, CardHeader, CardActions,
       Typography, Button, IconButton, Chip,
-      TextField, Divider, Avatar, List, ListItem,
-      ListItemText, ListItemAvatar, ListItemSecondaryAction,
-      Skeleton, Alert, Badge, Tooltip, LinearProgress, CircularProgress,
-      Paper, Icon
+      Divider, Avatar, LinearProgress, CircularProgress,
+      Paper, useTheme
     } from '@mui/material';
 
     const html = htm.bind(React.createElement);
@@ -48,18 +46,20 @@
         mode: 'dark',
         background: {
           default: '#0a0a0a',
-          paper:   '#1a1a1a',
+          paper: '#1a1a1a',
         },
-        primary:  { main: '#a78bfa' },
-        secondary: { main: '#3b82f6' },
-        error:    { main: '#f44336' },
-        success:  { main: '#4caf50' },
-        warning:  { main: '#ff9800' },
-        divider:  'rgba(255,255,255,0.08)',
+        primary: {
+          main: '#a78bfa',
+          contrastText: '#ffffff'
+        },
+        secondary: {
+          main: '#f43f5e', // Reddish for countdown
+        },
         text: {
-          primary:   '#e5e7eb',
+          primary: '#e5e7eb',
           secondary: '#9ca3af',
         },
+        divider: 'rgba(255, 255, 255, 0.08)'
       },
       typography: {
         fontFamily: "'Archivo', Roboto, sans-serif",
@@ -67,73 +67,87 @@
       shape: { borderRadius: 12 },
       components: {
         MuiCard: {
-          defaultProps: { elevation: 0 },
           styleOverrides: {
-            root: { border: '1px solid rgba(255,255,255,0.08)' },
-          },
+            root: {
+              backgroundImage: 'none',
+              border: '1px solid rgba(255, 255, 255, 0.08)'
+            }
+          }
         },
-      },
+        MuiButton: {
+          styleOverrides: {
+            root: {
+              textTransform: 'none',
+              fontWeight: 600,
+            }
+          }
+        }
+      }
     });
 
-    function CountdownHero() {
+    function StateToggle({ states, current, onChange }) {
       return html`
-        <${Paper} 
-          sx=${{ 
-            p: 4, 
-            textAlign: 'center', 
-            background: 'linear-gradient(135deg, rgba(167, 139, 250, 0.15) 0%, rgba(59, 130, 246, 0.1) 100%)',
-            border: '1px solid rgba(167, 139, 250, 0.3)',
-            borderRadius: 4,
-            mb: 4,
-            position: 'relative',
-            overflow: 'hidden'
-          }}
-        >
-          <${Typography} variant="overline" color="primary" sx=${{ letterSpacing: 2, fontWeight: 700 }}>
-            TOURNAMENT KICKOFF
+        <${Stack} direction="row" spacing=${1} sx=${{ mb: 3, justifyContent: 'center' }}>
+          ${states.map(s => html`
+            <${Chip}
+              key=${s}
+              label=${s.toUpperCase()}
+              size="small"
+              onClick=${() => onChange(s)}
+              variant=${current === s ? 'filled' : 'outlined'}
+              color=${current === s ? 'primary' : 'default'}
+              sx=${{ px: 1 }}
+            />
+          `)}
+        <//>
+      `;
+    }
+
+    function Countdown() {
+      return html`
+        <${Box} sx=${{ textAlign: 'center', py: 4 }}>
+          <${Stack} direction="row" spacing=${3} justifyContent="center" alignItems="center">
+            <${Box}>
+              <${Typography} variant="h3" sx=${{ fontWeight: 700, color: 'secondary.main' }}>51<//>
+              <${Typography} variant="caption" color="text.secondary">Días<//>
+            <//>
+            <${Box}>
+              <${Typography} variant="h3" sx=${{ fontWeight: 700, color: 'secondary.main' }}>21<//>
+              <${Typography} variant="caption" color="text.secondary">Horas<//>
+            <//>
+            <${Box}>
+              <${Typography} variant="h3" sx=${{ fontWeight: 700, color: 'secondary.main' }}>53<//>
+              <${Typography} variant="caption" color="text.secondary">Min<//>
+            <//>
           <//>
-          
-          <${Stack} direction="row" justifyContent="center" spacing=${{ xs: 2, sm: 4 }} sx=${{ mt: 2, mb: 1 }}>
-            <${Box}>
-              <${Typography} variant="h3" fontWeight=${800} sx=${{ color: 'primary.main' }}>52<//>
-              <${Typography} variant="caption" color="text.secondary">DAYS<//>
-            <//>
-            <${Typography} variant="h3" fontWeight=${300} color="text.disabled">:<//>
-            <${Box}>
-              <${Typography} variant="h3" fontWeight=${800} sx=${{ color: 'primary.main' }}>14<//>
-              <${Typography} variant="caption" color="text.secondary">HOURS<//>
-            <//>
-            <${Typography} variant="h3" fontWeight=${300} color="text.disabled">:<//>
-            <${Box}>
-              <${Typography} variant="h3" fontWeight=${800} sx=${{ color: 'primary.main' }}>28<//>
-              <${Typography} variant="caption" color="text.secondary">MINS<//>
-            <//>
+          <${Typography} variant="body2" color="text.secondary" sx=${{ mt: 2 }}>
+            Para que empiece el Mundial 2026
           <//>
         <//>
       `;
     }
 
-    function TournamentOpenerCard() {
+    function TutorialSection() {
       return html`
-        <${Card} variant="outlined" sx=${{ mb: 4, bgcolor: 'rgba(255,255,255,0.02)' }}>
+        <${Card} sx=${{ 
+          mb: 4, 
+          background: 'linear-gradient(45deg, #1a1a1a 30%, #2e2443 90%)',
+          position: 'relative',
+          overflow: 'hidden'
+        }}>
           <${CardContent} sx=${{ py: 3 }}>
-            <${Typography} variant="overline" color="text.secondary" sx=${{ display: 'block', textAlign: 'center', mb: 2 }}>
-              Opening Match • June 11, 20:00
-            <//>
-            <${Stack} direction="row" justifyContent="space-around" alignItems="center">
-              <${Stack} alignItems="center" spacing=${1} sx=${{ flex: 1 }}>
-                <${Avatar} sx=${{ width: 56, height: 56, fontSize: '2rem' }}>🇲🇽<//>
-                <${Typography} variant="subtitle1" fontWeight=${700}>Mexico<//>
+            <${Stack} direction="row" spacing=${2} alignItems="center">
+              <${Avatar} sx=${{ bgcolor: 'primary.main', width: 48, height: 48 }}>
+                <span className="material-icons">help_outline</span>
               <//>
-              <${Typography} variant="h5" color="text.disabled" sx=${{ px: 2 }}>VS<//>
-              <${Stack} alignItems="center" spacing=${1} sx=${{ flex: 1 }}>
-                <${Avatar} sx=${{ width: 56, height: 56, fontSize: '2rem' }}>🇫🇷<//>
-                <${Typography} variant="subtitle1" fontWeight=${700}>France<//>
+              <${Box} sx=${{ flexGrow: 1 }}>
+                <${Typography} variant="h6" sx=${{ fontWeight: 600 }}>¿Nuevo en el Prode?<//>
+                <${Typography} variant="body2" color="text.secondary">
+                  Aprendé cómo sumar puntos y ganar el torneo de tus amigos.
+                <//>
               <//>
-            <//>
-            <${Box} sx=${{ mt: 3, textAlign: 'center' }}>
-              <${Button} variant="contained" color="primary" disableElevation startIcon=${html`<${Icon}>edit<//>`}>
-                Predict Opener
+              <${Button} variant="contained" color="primary" sx=${{ borderRadius: 50 }}>
+                Ver Tutorial
               <//>
             <//>
           <//>
@@ -141,110 +155,197 @@
       `;
     }
 
-    function PredictionProgressGrid() {
+    function TrackCard({ title, icon, description, scoring, progress, total, cta, complete }) {
+      const percentage = Math.round((progress / total) * 100);
       return html`
-        <${Box} sx=${{ mb: 4 }}>
-          <${Typography} variant="overline" color="text.secondary" sx=${{ mb: 2, display: 'block' }}>
-            Tournament Predictions
-          <//>
-          <${Grid} container spacing=${2}>
-            <${Grid} size=${{ xs: 12, sm: 6 }}>
-              <${Card} variant="outlined" sx=${{ height: '100%' }}>
-                <${CardContent}>
-                  <${Stack} direction="row" spacing=${2} alignItems="center">
-                    <${Icon} color="primary">groups<//>
-                    <${Box} sx=${{ flexGrow: 1 }}>
-                      <${Typography} variant="subtitle2" fontWeight=${700}>Qualified Teams<//>
-                      <${Typography} variant="caption" color="text.secondary" sx=${{ display: 'block', mb: 1 }}>
-                        Top 2 of each group
-                      <//>
-                      <${LinearProgress} variant="determinate" value=${30} sx=${{ height: 6, borderRadius: 3, mb: 0.5 }} />
-                      <${Typography} variant="caption" color="primary" fontWeight=${600}>3/12 Groups<//>
-                    <//>
-                  <//>
-                <//>
+        <${Card} sx=${{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <${CardContent} sx=${{ flexGrow: 1 }}>
+            <${Stack} direction="row" justifyContent="space-between" alignItems="flex-start" sx=${{ mb: 2 }}>
+              <${Box} sx=${{ 
+                width: 40, height: 40, borderRadius: 2, 
+                bgcolor: 'rgba(167, 139, 250, 0.1)', 
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                color: 'primary.main'
+              }}>
+                <span className="material-icons">${icon}</span>
+              <//>
+              <${Box} sx=${{ textAlign: 'right' }}>
+                <${Typography} variant="h6" sx=${{ fontWeight: 700 }}>${percentage}%<//>
+                <${Typography} variant="caption" color="text.secondary">${progress} de ${total}<//>
               <//>
             <//>
-            <${Grid} size=${{ xs: 12, sm: 6 }}>
-              <${Card} variant="outlined" sx=${{ height: '100%' }}>
-                <${CardContent}>
-                  <${Stack} direction="row" spacing=${2} alignItems="center">
-                    <${Icon} color="primary">emoji_events<//>
-                    <${Box} sx=${{ flexGrow: 1 }}>
-                      <${Typography} variant="subtitle2" fontWeight=${700}>Individual Awards<//>
-                      <${Typography} variant="caption" color="text.secondary" sx=${{ display: 'block', mb: 1 }}>
-                        Golden Boot, MVP, etc.
-                      <//>
-                      <${LinearProgress} variant="determinate" value=${0} sx=${{ height: 6, borderRadius: 3, mb: 0.5 }} />
-                      <${Typography} variant="caption" color="warning.main" fontWeight=${600}>Pending<//>
-                    <//>
-                  <//>
-                <//>
+            
+            <${Typography} variant="h6" gutterBottom sx=${{ fontWeight: 600 }}>${title}<//>
+            <${Typography} variant="body2" color="text.secondary" sx=${{ mb: 2, minHeight: 40 }}>
+              ${description}
+            <//>
+
+            <${Box} sx=${{ mb: 2, p: 1.5, borderRadius: 1.5, bgcolor: 'rgba(255,255,255,0.03)', border: '1px dashed rgba(255,255,255,0.1)' }}>
+              <${Typography} variant="caption" color="primary.main" sx=${{ fontWeight: 700, display: 'block', mb: 0.5 }}>
+                REGLAS DE PUNTAJE:
+              <//>
+              <${Typography} variant="caption" color="text.primary">
+                ${scoring}
               <//>
             <//>
+
+            <${LinearProgress} 
+              variant="determinate" 
+              value=${percentage} 
+              sx=${{ height: 8, borderRadius: 4, mb: 1, bgcolor: 'rgba(255,255,255,0.05)' }} 
+              color=${complete ? 'success' : 'primary'}
+            />
           <//>
-          <${Box} sx=${{ mt: 2, p: 2, borderRadius: 2, bgcolor: 'rgba(167, 139, 250, 0.05)', border: '1px dashed rgba(167, 139, 250, 0.2)' }}>
-            <${Stack} direction="row" justifyContent="space-between" alignItems="center">
-              <${Box}>
-                <${Typography} variant="body2" fontWeight=${600}>Overall Completion<//>
-                <${Typography} variant="caption" color="text.secondary">12 of 104 games predicted<//>
-              <//>
-              <${CircularProgress} variant="determinate" value=${12} size=${32} thickness=${5} />
+          <${CardActions} sx=${{ p: 2, pt: 0 }}>
+            <${Button} 
+              fullWidth 
+              variant=${complete ? 'outlined' : 'contained'} 
+              color=${complete ? 'inherit' : 'primary'}
+            >
+              ${complete ? 'Revisar' : cta}
             <//>
           <//>
         <//>
       `;
     }
 
-    function SocialHubLeaderboardReplacement() {
-      return html`
-        <${Box} sx=${{ mt: 6 }}>
-          <${Typography} variant="h6" sx=${{ mb: 1, textAlign: 'center' }}>Your Standings<//>
-          <${Typography} variant="body2" color="text.secondary" sx=${{ mb: 2, textAlign: 'center' }}>
-            Compete with friends and colleagues
+    function FriendGroupsSection({ isEmpty }) {
+      if (isEmpty) {
+        return html`
+          <${Box} sx=${{ mt: 4, textAlign: 'center' }}>
+            <${Typography} variant="h5" align="center" gutterBottom sx=${{ fontWeight: 700 }}>Tus Posiciones<//>
+            <${Typography} variant="body2" color="text.secondary" align="center" sx=${{ mb: 3 }}>
+              Tus 3 grupos más activos
+            <//>
+            <${Paper} sx=${{ 
+              p: 4, textAlign: 'center', 
+              border: '2px dashed rgba(255, 255, 255, 0.05)',
+              bgcolor: 'transparent'
+            }}>
+              <${Box} sx=${{ color: 'secondary.main', mb: 2 }}>
+                <span className="material-icons" style=${{ fontSize: 48 }}>group_add</span>
+              <//>
+              <${Typography} variant="h6" gutterBottom>¡No juegues solo!<//>
+              <${Typography} variant="body2" color="text.secondary" sx=${{ mb: 3, maxWidth: 300, mx: 'auto' }}>
+                La mejor manera de disfrutar el Mundial es en grupo. Creá el tuyo e invitá a tus amigos.
+              <//>
+              <${Stack} direction="row" spacing={2} justifyContent="center" sx=${{ mb: 2 }}>
+                <${Button} variant="contained" color="primary">Crear Grupo<//>
+                <${Button} variant="outlined" color="primary">Encontrar Público<//>
+              <//>
+              <${Button} variant="text" size="small" sx=${{ color: 'text.secondary' }}>
+                Más información sobre los grupos
+              <//>
+            <//>
           <//>
-          <${Paper} 
-            sx=${{ 
-              p: 4, 
-              textAlign: 'center', 
-              bgcolor: 'rgba(59, 130, 246, 0.05)', 
-              border: '1px dashed rgba(59, 130, 246, 0.3)',
-              borderRadius: 3
-            }}
-          >
-            <${Icon} sx=${{ fontSize: 48, color: 'secondary.main', mb: 2 }}>group_add<//>
-            <${Typography} variant="h6" gutterBottom>Don't play alone!<//>
-            <${Typography} variant="body2" color="text.secondary" sx=${{ mb: 3, maxWidth: 300, mx: 'auto' }}>
-              The best way to enjoy the World Cup is in a group. Create yours now and invite your friends.
-            <//>
-            <${Stack} direction="row" spacing={2} justifyContent="center">
-              <${Button} variant="contained" color="secondary" disableElevation>Create Group<//>
-              <${Button} variant="outlined" color="secondary">Find Public Group<//>
-            <//>
+        `;
+      }
+
+      return html`
+        <${Box} sx=${{ mt: 4 }}>
+          <${Typography} variant="h5" align="center" gutterBottom sx=${{ fontWeight: 700 }}>Tus Posiciones<//>
+          <${Typography} variant="body2" color="text.secondary" align="center" sx=${{ mb: 3 }}>
+            Tus 3 grupos más activos
+          <//>
+          <${Card} sx=${{ p: 2, bgcolor: 'rgba(255,255,255,0.03)' }}>
+             <${Stack} direction="row" spacing=${1} justifyContent="center" sx=${{ mb: 2 }}>
+                <${Typography} variant="body2">Estás en<//>
+                <${Chip} label="Grupo Publico #1" size="small" variant="outlined" />
+                <${Chip} label="El grupo de Vino" size="small" variant="outlined" />
+                <${Typography} variant="body2" color="text.secondary">y 1 más.<//>
+             <//>
+             <${Box} sx=${{ textAlign: 'center', py: 2 }}>
+                <span className="material-icons" style=${{ color: '#FFD700', fontSize: 32 }}>emoji_events</span>
+                <${Typography} variant="body2" sx=${{ mt: 1 }}>
+                  Los rankings estarán disponibles una vez que comience el campeonato
+                <//>
+             <//>
+             <${Stack} direction="row" spacing=${1} justifyContent="center" sx=${{ mt: 2 }}>
+                <${Button} size="small" variant="outlined">Tus Grupos<//>
+                <${Button} size="small" variant="outlined">Crear Grupo<//>
+                <${Button} size="small" variant="outlined">Descubrir Grupos<//>
+             <//>
           <//>
         <//>
       `;
     }
 
     function MockupApp() {
+      const [state, setState] = React.useState('incomplete');
+
+      const tracks = {
+        incomplete: [
+          { 
+            title: 'Partidos', icon: 'sports_soccer', 
+            description: 'Pronosticá el resultado de los 104 partidos del mundial.',
+            scoring: '1pto por acierto de Ganador/Empate, +2ptos extra por resultado exacto.',
+            progress: 12, total: 104, cta: 'Empezar a Pronosticar'
+          },
+          { 
+            title: 'Equipos Clasificados', icon: 'account_tree', 
+            description: 'Armá tu llave. Elegí quiénes pasan de ronda y quién gana la final.',
+            scoring: '1pto por equipo clasificado, +1pto extra por posición exacta en el grupo.',
+            progress: 0, total: 32, cta: 'Armar mi Llave'
+          },
+          { 
+            title: 'Premios', icon: 'military_tech', 
+            description: 'Elegí al Campeón, Goleador, Mejor Arquero y más premios individuales.',
+            scoring: '1pto por cada premio correcto (Goleador, Guante de Oro, etc).',
+            progress: 1, total: 7, cta: 'Elegir Premios'
+          }
+        ],
+        complete: [
+          { 
+            title: 'Partidos', icon: 'sports_soccer', 
+            description: 'Pronosticá el resultado de los 104 partidos del mundial.',
+            scoring: '1pto por acierto de Ganador/Empate, +2ptos extra por resultado exacto.',
+            progress: 104, total: 104, cta: 'Revisar', complete: true
+          },
+          { 
+            title: 'Equipos Clasificados', icon: 'account_tree', 
+            description: 'Armá tu llave. Elegí quiénes pasan de ronda y quién gana la final.',
+            scoring: '1pto por equipo clasificado, +1pto extra por posición exacta en el grupo.',
+            progress: 32, total: 32, cta: 'Revisar', complete: true
+          },
+          { 
+            title: 'Premios', icon: 'military_tech', 
+            description: 'Elegí al Campeón, Goleador, Mejor Arquero y más premios individuales.',
+            scoring: '1pto por cada premio correcto (Goleador, Guante de Oro, etc).',
+            progress: 7, total: 7, cta: 'Revisar', complete: true
+          }
+        ]
+      };
+
       return html`
         <${ThemeProvider} theme=${theme}>
           <${CssBaseline} />
-          <${Box} sx=${{ bgcolor: 'background.default', minHeight: '100vh', py: 4 }}>
-            <${Container} maxWidth="sm">
-              <${Box} sx=${{ mb: 4, textAlign: 'center' }}>
-                <${Typography} variant="h5" fontWeight=${700} color="primary" gutterBottom>
-                  Action Center & Social Hub Redesign
-                <//>
+          <${Container} maxWidth="sm" sx=${{ py: 2, pb: 10 }}>
+
+            <${StateToggle}
+              states=${['incomplete', 'complete']}
+              current=${state}
+              onChange=${setState}
+            />
+
+            <${Countdown} />
+
+            <${TutorialSection} />
+
+            <${Box} sx=${{ mb: 2, textAlign: 'center' }}>
+              <${Typography} variant="h5" sx=${{ fontWeight: 700 }}>Centro de Acción<//>
+              <${Typography} variant="body2" color="text.secondary">
+                Todo al día — esto viene próximamente
               <//>
-
-              <${CountdownHero} />
-              <${TournamentOpenerCard} />
-              <${PredictionProgressGrid} />
-              
-              <${SocialHubLeaderboardReplacement} />
-
             <//>
+
+            <${Stack} spacing=${3}>
+              ${tracks[state].map((track, i) => html`
+                <${TrackCard} key=${i} ...${track} />
+              `)}
+            <//>
+
+            <${FriendGroupsSection} isEmpty=${state === 'incomplete'} />
+
           <//>
         <//>
       `;

--- a/plans/STORY-351-context.md
+++ b/plans/STORY-351-context.md
@@ -1,0 +1,16 @@
+# Story 351 Context
+
+## Metadata
+- **Story Number:** 351
+- **Story Title:** [Bug] Fix email verification overlay blocking tournament header and update branding
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-351
+- **Branch:** feature/story-351
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-351-plan.md
+
+## Quick Summary
+This story fixes two bugs: (1) moves email verification overlay logic to tournament-specific template so unverified users can still access header actions (logout, theme, language) in tournament views, and (2) replaces all remaining "La Maquina Prode" / "La Maquina Prode Mundial" branding with "Prode Mundial" across EN/ES locales, onboarding strings, and the tournament header alt text.

--- a/plans/STORY-351-context.md
+++ b/plans/STORY-351-context.md
@@ -9,7 +9,7 @@
 - **PR URL:** (fill after PR creation)
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** implementing
 - **Plan File:** plans/STORY-351-plan.md
 
 ## Quick Summary

--- a/plans/STORY-351-plan.md
+++ b/plans/STORY-351-plan.md
@@ -20,27 +20,21 @@ Two bugs:
 
 ### Fix 1: Verification Overlay
 
-**Root Cause:** `app/template.tsx` (a Next.js [Server Component template](https://nextjs.org/docs/app/api-reference/file-conventions/template)) wraps ALL nested content — including the tournament layout's `AppBar` — with:
-```tsx
-<Box position="relative">
-  <VerificationOverlay />
-  <Box sx={{ pointerEvents: 'none', userSelect: 'none' }}>
-    {children}  {/* ← tournament layout incl. header is inside here */}
-  </Box>
-</Box>
-```
+**Root Cause:** `app/template.tsx` wraps ALL nested content — including the tournament layout's `AppBar` — with `pointerEvents: none`, making the header non-interactive for unverified users.
 
-**Fix strategy:**
-1. Extract the `pointerEvents` gate into a new **client component** `VerificationGate` that reads `usePathname()`. On tournament pages it skips the overlay (delegates to the tournament template). On all other pages it applies the existing overlay.
-2. Create `app/[locale]/tournaments/[id]/template.tsx` — a **server component** that fetches the same user/verification data and applies the overlay only to `children` (the page content). Since `template.tsx` wraps only the page slot and NOT the layout's `AppBar`, the header remains fully interactive.
+**Fix strategy (simplified per user feedback):**
+1. **Remove the overlay entirely from `app/template.tsx`** — keep the `VerificationBanner` (globally useful) but delete the `<Box position="relative">` / `VerificationOverlay` / `pointerEvents: none` wrapping.
+2. **Create `app/[locale]/tournaments/[id]/template.tsx`** — server component that applies the overlay ONLY to `children` (the page content). Since `template.tsx` wraps only the page slot and NOT the layout's `AppBar`, the header remains fully interactive.
+
+No `VerificationGate` client component needed.
 
 **Next.js rendering order (why this works):**
 ```
 app/layout.tsx
-  app/template.tsx              ← wraps all content (uses VerificationGate)
+  app/template.tsx              ← banner only (no overlay)
     app/[locale]/layout.tsx     ← locale header/footer
       app/[locale]/tournaments/[id]/layout.tsx  ← tournament AppBar (HEADER IS HERE)
-        app/[locale]/tournaments/[id]/template.tsx  ← wraps ONLY page content
+        app/[locale]/tournaments/[id]/template.tsx  ← overlay wraps ONLY page content
           page.tsx              ← actual tournament page
 ```
 
@@ -70,13 +64,10 @@ Update locale strings and the hardcoded `alt` attribute:
 ## Files to Create / Modify
 
 **Create:**
-- `app/components/verification/verification-gate.tsx` — new client component
-
-**Create:**
 - `app/[locale]/tournaments/[id]/template.tsx` — new tournament-level template
 
 **Modify:**
-- `app/template.tsx` — use `VerificationGate` instead of inline Box
+- `app/template.tsx` — remove overlay/pointer-events wrapping; keep banner only
 - `locales/en/common.json` — branding strings
 - `locales/es/common.json` — branding strings
 - `locales/en/onboarding.json` — welcome string
@@ -93,26 +84,7 @@ Update locale strings and the hardcoded `alt` attribute:
 
 ### Call Graph Changes
 
-No call graph changes. No new cross-layer flows. The verification logic already exists; we are only restructuring which template renders it for which routes.
-
----
-
-### `app/components/verification/verification-gate.tsx` *(new)*
-
-**`VerificationGate({ children: ReactNode }): JSX.Element`**
-Client component. Reads `usePathname()` to determine if the current route is a tournament page (`/[locale]/tournaments/...`). On tournament pages, renders children unmodified (the tournament template handles the overlay). On all other pages, applies the existing `VerificationOverlay` + `pointerEvents: none` wrapper.
-
-```typescript
-'use client'
-// Props: children: React.ReactNode
-// Returns: children wrapped in overlay (non-tournament) or as-is (tournament)
-```
-
-Tests:
-- renders children with overlay wrapper on non-tournament route (`/en/groups`)
-- renders children without overlay or pointer-events on tournament route (`/en/tournaments/fifa-2026`)
-- overlay Box has `position: relative` on non-tournament pages
-- does not render `VerificationOverlay` on tournament pages
+No call graph changes. No new cross-layer flows. The verification logic already exists; we are only restructuring which template renders it.
 
 ---
 
@@ -134,25 +106,17 @@ Tests:
 
 ### `app/template.tsx` *(modified)*
 
-**`Template({ children: ReactNode }): Promise<JSX.Element>`** *(was: inline conditional)*
-Replace inline `<Box position="relative">` block with `<VerificationGate>`. The banner logic is unchanged.
+**`Template({ children: ReactNode }): Promise<JSX.Element>`**
+Remove the `<Box position="relative">` / `VerificationOverlay` / `pointerEvents: none` wrapping entirely. Keep only the `VerificationBanner` (unverified users still see the banner). Always render `children` directly.
 
 ```typescript
-// Before (inline):
-{isUnverified ? (
-  <Box position="relative">
-    <VerificationOverlay />
-    <Box sx={{ pointerEvents: 'none', ... }}>{children}</Box>
-  </Box>
-) : children}
-
-// After (uses VerificationGate):
-{isUnverified ? <VerificationGate>{children}</VerificationGate> : children}
+// Before: unverified users got overlay + pointer-events: none
+// After: unverified users see only the banner; children always rendered normally
 ```
 
 Tests:
-- renders `VerificationGate` (not inline Box) when user is unverified and verification required
 - renders `VerificationBanner` when user is unverified and verification required
+- renders children directly (no overlay Box) when user is unverified and verification required
 - renders children directly when `REQUIRE_EMAIL_VERIFICATION` is false
 - renders children directly when user is verified
 - renders children directly when no user is logged in
@@ -166,14 +130,12 @@ Tests:
 - Use `testFactories.createUser({ emailVerified: null })` for unverified users
 - Use `testFactories.createUser({ emailVerified: new Date() })` for verified users
 - Mock `getLoggedInUser` and `findUserById` via `vi.mock()`
-- Mock `next/navigation` `usePathname` for `VerificationGate` tests
 
 **What to test:**
-1. **New: `VerificationGate`** — 4 test cases (see Mid-Level Design)
-2. **New: `TournamentTemplate`** — 5 test cases (see Mid-Level Design)
-3. **Modified: `app/template.tsx`** — 5 test cases (see Mid-Level Design above), replacing the existing inline logic tests
-4. **Update existing tests** — fix expected branding strings in `header.test.tsx` and `layout.test.tsx`
-5. **Branding locale verification** — assert both `locales/en/common.json` and `locales/es/common.json` contain no "La Maquina" string (can be a simple grep-based snapshot test or manual Vercel verification)
+1. **New: `TournamentTemplate`** — 5 test cases (see Mid-Level Design)
+2. **Modified: `app/template.tsx`** — 5 test cases (see Mid-Level Design above), replacing the existing inline logic tests
+3. **Update existing tests** — fix expected branding strings in `header.test.tsx` and `layout.test.tsx`
+4. **Branding locale verification** — assert both `locales/en/common.json` and `locales/es/common.json` contain no "La Maquina" string (can be a simple grep-based snapshot test or manual Vercel verification)
 
 **Manual verification** (Vercel Preview):
 - Log in with unverified email, navigate to tournament page

--- a/plans/STORY-351-plan.md
+++ b/plans/STORY-351-plan.md
@@ -1,0 +1,191 @@
+# Story #351 Plan: Fix Email Verification Overlay Blocking Tournament Header & Update Branding
+
+## Context
+
+Two bugs:
+1. **Verification overlay blocks tournament header** — `app/template.tsx` is a global template that wraps ALL route content with a `pointerEvents: none` box and a `VerificationOverlay` when the user's email is unverified. Since this template wraps the tournament layout (including its `AppBar`), unverified users cannot interact with logout, theme switcher, or language switcher in tournament views.
+2. **Stale "La Maquina" branding** — The app has been rebranded to "Prode Mundial" but several locale strings still reference "La Maquina Prode" / "La Maquina Prode Mundial", including `app.title`, `app.logoAlt`, `app.fullName` in both locales, onboarding welcome strings, and an `alt` attribute in the tournament header.
+
+## Acceptance Criteria (from issue)
+
+- Verification overlay blocks tournament content/nav but NOT the header (logout, theme, language)
+- Overlay still prevents unauthorized prediction saves while unverified
+- All "La Maquina Prode" / "La Maquina Prode Mundial" instances replaced with "Prode Mundial"
+- Title and logo `alt` text updated in main header and tournament header
+- Both EN and ES locales updated
+
+---
+
+## Technical Approach
+
+### Fix 1: Verification Overlay
+
+**Root Cause:** `app/template.tsx` (a Next.js [Server Component template](https://nextjs.org/docs/app/api-reference/file-conventions/template)) wraps ALL nested content — including the tournament layout's `AppBar` — with:
+```tsx
+<Box position="relative">
+  <VerificationOverlay />
+  <Box sx={{ pointerEvents: 'none', userSelect: 'none' }}>
+    {children}  {/* ← tournament layout incl. header is inside here */}
+  </Box>
+</Box>
+```
+
+**Fix strategy:**
+1. Extract the `pointerEvents` gate into a new **client component** `VerificationGate` that reads `usePathname()`. On tournament pages it skips the overlay (delegates to the tournament template). On all other pages it applies the existing overlay.
+2. Create `app/[locale]/tournaments/[id]/template.tsx` — a **server component** that fetches the same user/verification data and applies the overlay only to `children` (the page content). Since `template.tsx` wraps only the page slot and NOT the layout's `AppBar`, the header remains fully interactive.
+
+**Next.js rendering order (why this works):**
+```
+app/layout.tsx
+  app/template.tsx              ← wraps all content (uses VerificationGate)
+    app/[locale]/layout.tsx     ← locale header/footer
+      app/[locale]/tournaments/[id]/layout.tsx  ← tournament AppBar (HEADER IS HERE)
+        app/[locale]/tournaments/[id]/template.tsx  ← wraps ONLY page content
+          page.tsx              ← actual tournament page
+```
+
+The tournament template wraps only the page, never the `AppBar`.
+
+### Fix 2: Branding Updates
+
+Update locale strings and the hardcoded `alt` attribute:
+
+| File | Key / Location | From | To |
+|------|---------------|------|----|
+| `locales/en/common.json` | `app.title` | "La Maquina Prode" | "Prode Mundial" |
+| `locales/en/common.json` | `app.logoAlt` | "La Maquina Prode" | "Prode Mundial" |
+| `locales/en/common.json` | `app.fullName` | "La Maquina World Cup Predictions" | "Prode Mundial" |
+| `locales/es/common.json` | `app.title` | "La Maquina Prode" | "Prode Mundial" |
+| `locales/es/common.json` | `app.logoAlt` | "La Maquina Prode" | "Prode Mundial" |
+| `locales/es/common.json` | `app.fullName` | "La Maquina Prode Mundial" | "Prode Mundial" |
+| `locales/en/onboarding.json` | welcome title | "Welcome to La Maquina Prode!" | "Welcome to Prode Mundial!" |
+| `locales/es/onboarding.json` | welcome title | "¡Bienvenido a La Maquina Prode!" | "¡Bienvenido a Prode Mundial!" |
+| `app/[locale]/tournaments/[id]/layout.tsx` | `alt` on Avatar | "La Maquina" | "Prode Mundial" |
+| `app/[locale]/tournaments/[id]/layout.tsx` | Comment | `{/* La Maquina logo button */}` | `{/* Logo button (home navigation) */}` |
+
+`app.name` values ("World Cup Predictions" / "Prode Mundial") are already correct — no change needed.
+
+---
+
+## Files to Create / Modify
+
+**Create:**
+- `app/components/verification/verification-gate.tsx` — new client component
+
+**Create:**
+- `app/[locale]/tournaments/[id]/template.tsx` — new tournament-level template
+
+**Modify:**
+- `app/template.tsx` — use `VerificationGate` instead of inline Box
+- `locales/en/common.json` — branding strings
+- `locales/es/common.json` — branding strings
+- `locales/en/onboarding.json` — welcome string
+- `locales/es/onboarding.json` — welcome string
+- `app/[locale]/tournaments/[id]/layout.tsx` — fix `alt` attribute and comment
+
+**Tests to update:**
+- `__tests__/components/header/header.test.tsx` — update expected branding strings
+- `app/[locale]/tournaments/[id]/__tests__/layout.test.tsx` — update expected alt text
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+No call graph changes. No new cross-layer flows. The verification logic already exists; we are only restructuring which template renders it for which routes.
+
+---
+
+### `app/components/verification/verification-gate.tsx` *(new)*
+
+**`VerificationGate({ children: ReactNode }): JSX.Element`**
+Client component. Reads `usePathname()` to determine if the current route is a tournament page (`/[locale]/tournaments/...`). On tournament pages, renders children unmodified (the tournament template handles the overlay). On all other pages, applies the existing `VerificationOverlay` + `pointerEvents: none` wrapper.
+
+```typescript
+'use client'
+// Props: children: React.ReactNode
+// Returns: children wrapped in overlay (non-tournament) or as-is (tournament)
+```
+
+Tests:
+- renders children with overlay wrapper on non-tournament route (`/en/groups`)
+- renders children without overlay or pointer-events on tournament route (`/en/tournaments/fifa-2026`)
+- overlay Box has `position: relative` on non-tournament pages
+- does not render `VerificationOverlay` on tournament pages
+
+---
+
+### `app/[locale]/tournaments/[id]/template.tsx` *(new)*
+
+**`TournamentTemplate({ children: ReactNode }): Promise<JSX.Element>`**
+Server component. Fetches user + email verification status (same logic as `app/template.tsx`). If unverified and verification required: wraps `children` (page content only, NOT layout header) with `VerificationOverlay` + `pointerEvents: none`. Otherwise renders children normally.
+
+Calls: `getLoggedInUser`, `findUserById`
+
+Tests:
+- renders children unmodified when `REQUIRE_EMAIL_VERIFICATION` is false
+- renders children unmodified when user is not logged in
+- renders children unmodified when user is email-verified
+- wraps children with overlay and `pointerEvents: none` when user is unverified and verification required
+- `VerificationOverlay` is rendered as sibling to (not parent of) children when unverified
+
+---
+
+### `app/template.tsx` *(modified)*
+
+**`Template({ children: ReactNode }): Promise<JSX.Element>`** *(was: inline conditional)*
+Replace inline `<Box position="relative">` block with `<VerificationGate>`. The banner logic is unchanged.
+
+```typescript
+// Before (inline):
+{isUnverified ? (
+  <Box position="relative">
+    <VerificationOverlay />
+    <Box sx={{ pointerEvents: 'none', ... }}>{children}</Box>
+  </Box>
+) : children}
+
+// After (uses VerificationGate):
+{isUnverified ? <VerificationGate>{children}</VerificationGate> : children}
+```
+
+Tests:
+- renders `VerificationGate` (not inline Box) when user is unverified and verification required
+- renders `VerificationBanner` when user is unverified and verification required
+- renders children directly when `REQUIRE_EMAIL_VERIFICATION` is false
+- renders children directly when user is verified
+- renders children directly when no user is logged in
+
+---
+
+## Testing Strategy
+
+**Test utilities:**
+- Use `renderWithTheme(component)` from `__tests__/utils/test-utils.tsx` for all component tests
+- Use `testFactories.createUser({ emailVerified: null })` for unverified users
+- Use `testFactories.createUser({ emailVerified: new Date() })` for verified users
+- Mock `getLoggedInUser` and `findUserById` via `vi.mock()`
+- Mock `next/navigation` `usePathname` for `VerificationGate` tests
+
+**What to test:**
+1. **New: `VerificationGate`** — 4 test cases (see Mid-Level Design)
+2. **New: `TournamentTemplate`** — 5 test cases (see Mid-Level Design)
+3. **Modified: `app/template.tsx`** — 5 test cases (see Mid-Level Design above), replacing the existing inline logic tests
+4. **Update existing tests** — fix expected branding strings in `header.test.tsx` and `layout.test.tsx`
+5. **Branding locale verification** — assert both `locales/en/common.json` and `locales/es/common.json` contain no "La Maquina" string (can be a simple grep-based snapshot test or manual Vercel verification)
+
+**Manual verification** (Vercel Preview):
+- Log in with unverified email, navigate to tournament page
+- Confirm: tournament content is blurred/non-interactive
+- Confirm: header logout/theme/language buttons are CLICKABLE
+- Confirm: clicking "Logout" in tournament header works
+- Confirm: non-tournament pages still block header (existing behavior)
+- Confirm: "Prode Mundial" shown in app title, logo alt, onboarding welcome
+
+## Validation Considerations
+
+- SonarCloud: 0 new issues — no logic changes, only refactoring + string updates
+- Coverage: `VerificationGate` and `TournamentTemplate` are new files → need ≥80% test coverage
+- No migrations needed
+- No new i18n namespaces needed (updating existing keys only)

--- a/plans/STORY-351-plan.md
+++ b/plans/STORY-351-plan.md
@@ -22,23 +22,26 @@ Two bugs:
 
 **Root Cause:** `app/template.tsx` wraps ALL nested content — including the tournament layout's `AppBar` — with `pointerEvents: none`, making the header non-interactive for unverified users.
 
-**Fix strategy (simplified per user feedback):**
-1. **Remove the overlay entirely from `app/template.tsx`** — keep the `VerificationBanner` (globally useful) but delete the `<Box position="relative">` / `VerificationOverlay` / `pointerEvents: none` wrapping.
-2. **Create `app/[locale]/tournaments/[id]/template.tsx`** — server component that applies the overlay ONLY to `children` (the page content). Since `template.tsx` wraps only the page slot and NOT the layout's `AppBar`, the header remains fully interactive.
+**Fix strategy (final per user feedback):**
+1. **Remove everything verification-related from `app/template.tsx`** — both the `VerificationBanner` AND the overlay/`pointerEvents` wrapping. The template becomes a simple passthrough.
+2. **Add banner + overlay inside the tournament layout** (`app/[locale]/tournaments/[id]/layout.tsx`): render `VerificationBanner` between the `AppBar` and the main content area, and wrap the main content area with `VerificationOverlay` + `pointerEvents: none` when the user is unverified.
 
-No `VerificationGate` client component needed.
+This keeps both elements entirely within the tournament context, below the header.
 
 **Next.js rendering order (why this works):**
 ```
 app/layout.tsx
-  app/template.tsx              ← banner only (no overlay)
+  app/template.tsx              ← passthrough only (no verification)
     app/[locale]/layout.tsx     ← locale header/footer
-      app/[locale]/tournaments/[id]/layout.tsx  ← tournament AppBar (HEADER IS HERE)
-        app/[locale]/tournaments/[id]/template.tsx  ← overlay wraps ONLY page content
-          page.tsx              ← actual tournament page
+      app/[locale]/tournaments/[id]/layout.tsx
+        ┣ AppBar (header — always interactive)
+        ┣ VerificationBanner (if unverified — below header)
+        ┗ Main content Box
+            ┣ VerificationOverlay (if unverified)
+            ┗ children (page content, pointer-events:none if unverified)
 ```
 
-The tournament template wraps only the page, never the `AppBar`.
+No new files needed — changes are confined to `app/template.tsx` (simplify) and `app/[locale]/tournaments/[id]/layout.tsx` (add verification).
 
 ### Fix 2: Branding Updates
 
@@ -63,11 +66,9 @@ Update locale strings and the hardcoded `alt` attribute:
 
 ## Files to Create / Modify
 
-**Create:**
-- `app/[locale]/tournaments/[id]/template.tsx` — new tournament-level template
-
 **Modify:**
-- `app/template.tsx` — remove overlay/pointer-events wrapping; keep banner only
+- `app/template.tsx` — remove all verification logic (becomes a simple passthrough)
+- `app/[locale]/tournaments/[id]/layout.tsx` — add `VerificationBanner` (below AppBar) + overlay wrapping on main content area
 - `locales/en/common.json` — branding strings
 - `locales/es/common.json` — branding strings
 - `locales/en/onboarding.json` — welcome string
@@ -84,42 +85,50 @@ Update locale strings and the hardcoded `alt` attribute:
 
 ### Call Graph Changes
 
-No call graph changes. No new cross-layer flows. The verification logic already exists; we are only restructuring which template renders it.
-
----
-
-### `app/[locale]/tournaments/[id]/template.tsx` *(new)*
-
-**`TournamentTemplate({ children: ReactNode }): Promise<JSX.Element>`**
-Server component. Fetches user + email verification status (same logic as `app/template.tsx`). If unverified and verification required: wraps `children` (page content only, NOT layout header) with `VerificationOverlay` + `pointerEvents: none`. Otherwise renders children normally.
-
-Calls: `getLoggedInUser`, `findUserById`
-
-Tests:
-- renders children unmodified when `REQUIRE_EMAIL_VERIFICATION` is false
-- renders children unmodified when user is not logged in
-- renders children unmodified when user is email-verified
-- wraps children with overlay and `pointerEvents: none` when user is unverified and verification required
-- `VerificationOverlay` is rendered as sibling to (not parent of) children when unverified
+No call graph changes. No new cross-layer flows. The verification logic already exists; we are only restructuring where it renders.
 
 ---
 
 ### `app/template.tsx` *(modified)*
 
 **`Template({ children: ReactNode }): Promise<JSX.Element>`**
-Remove the `<Box position="relative">` / `VerificationOverlay` / `pointerEvents: none` wrapping entirely. Keep only the `VerificationBanner` (unverified users still see the banner). Always render `children` directly.
+Remove all verification logic. Becomes a simple passthrough that renders `children` unconditionally. Remove imports: `getLoggedInUser`, `findUserById`, `VerificationBanner`, `VerificationOverlay`.
 
-```typescript
-// Before: unverified users got overlay + pointer-events: none
-// After: unverified users see only the banner; children always rendered normally
+Tests:
+- renders children unconditionally (no verification logic)
+- does not render `VerificationBanner`
+- does not render `VerificationOverlay`
+
+---
+
+### `app/[locale]/tournaments/[id]/layout.tsx` *(modified)*
+
+**`TournamentLayout(props): Promise<JSX.Element>`** *(add verification rendering)*
+Fetch user + email verification status (reuse the same `getLoggedInUser` + `findUserById` already called). Render `VerificationBanner` between the `AppBar` and the main content `Box`. Wrap the main content `Box` with `VerificationOverlay` + `pointerEvents: none` when user is unverified and `REQUIRE_EMAIL_VERIFICATION` is true.
+
+Calls: `getLoggedInUser` (already called), `findUserById` (new call — same pattern as template.tsx)
+
+Layout structure change:
+```tsx
+<Box> {/* outer flex column */}
+  <AppBar> ... </AppBar>         {/* unchanged — always interactive */}
+  {isUnverified && <VerificationBanner />}   {/* NEW — below header */}
+  <Box position="relative">      {/* NEW wrapper when unverified */}
+    {isUnverified && <VerificationOverlay />}
+    <Box sx={isUnverified ? { pointerEvents: 'none', userSelect: 'none' } : {}}>
+      {/* existing main content area */}
+    </Box>
+  </Box>
+</Box>
 ```
 
 Tests:
-- renders `VerificationBanner` when user is unverified and verification required
-- renders children directly (no overlay Box) when user is unverified and verification required
-- renders children directly when `REQUIRE_EMAIL_VERIFICATION` is false
-- renders children directly when user is verified
-- renders children directly when no user is logged in
+- renders `VerificationBanner` below `AppBar` when user is unverified and verification required
+- renders `VerificationOverlay` in main content area when user is unverified
+- main content `Box` has `pointerEvents: none` when user is unverified
+- does not render `VerificationBanner` when user is verified
+- does not render `VerificationOverlay` when `REQUIRE_EMAIL_VERIFICATION` is false
+- `AppBar` is rendered outside the `pointerEvents: none` wrapper (always interactive)
 
 ---
 
@@ -132,10 +141,10 @@ Tests:
 - Mock `getLoggedInUser` and `findUserById` via `vi.mock()`
 
 **What to test:**
-1. **New: `TournamentTemplate`** — 5 test cases (see Mid-Level Design)
-2. **Modified: `app/template.tsx`** — 5 test cases (see Mid-Level Design above), replacing the existing inline logic tests
+1. **Modified: `app/template.tsx`** — 3 test cases (passthrough, no banner, no overlay)
+2. **Modified: `app/[locale]/tournaments/[id]/layout.tsx`** — 6 test cases covering banner placement, overlay, pointer-events, and header always accessible
 3. **Update existing tests** — fix expected branding strings in `header.test.tsx` and `layout.test.tsx`
-4. **Branding locale verification** — assert both `locales/en/common.json` and `locales/es/common.json` contain no "La Maquina" string (can be a simple grep-based snapshot test or manual Vercel verification)
+4. **Branding locale verification** — assert both `locales/en/common.json` and `locales/es/common.json` contain no "La Maquina" string
 
 **Manual verification** (Vercel Preview):
 - Log in with unverified email, navigate to tournament page


### PR DESCRIPTION
Fixes #351

## Summary
Implementation plan for the story.

- Fix email verification overlay to not block tournament header (logout/theme/language)
- Create `VerificationGate` client component that skips overlay on tournament routes
- Create tournament-level `template.tsx` that applies overlay only to page content
- Update all "La Maquina Prode" branding to "Prode Mundial" across EN/ES locales

## Plan Document
See `plans/STORY-351-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)