### PR TITLE
Plan: [Story 7] Dashboard: Logged-Off Routing & Navigation #360

### DIFF
--- a/__tests__/components/groups-page/group-selector.test.tsx
+++ b/__tests__/components/groups-page/group-selector.test.tsx
@@ -126,7 +126,7 @@ describe('GroupSelector', () => {
   });
 
   describe('Tab States - Unauthenticated User', () => {
-    it('Hub tab is disabled when user is undefined', () => {
+    it('Hub tab is enabled when user is undefined', () => {
       renderWithTheme(
         <GroupSelector
           groups={mockGroups}
@@ -136,8 +136,8 @@ describe('GroupSelector', () => {
       );
 
       const hubTab = screen.getByRole('tab', { name: /HUB/i });
-      expect(hubTab).toHaveAttribute('aria-disabled', 'true');
-      expect(hubTab).toHaveClass('Mui-disabled');
+      expect(hubTab).not.toHaveAttribute('aria-disabled', 'true');
+      expect(hubTab).not.toHaveClass('Mui-disabled');
     });
 
     it('Matches tab is always enabled when user is undefined', () => {

--- a/app/[locale]/tournaments/[id]/__tests__/page-metadata.test.tsx
+++ b/app/[locale]/tournaments/[id]/__tests__/page-metadata.test.tsx
@@ -1,30 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { screen, cleanup } from '@testing-library/react';
 import { render } from '@testing-library/react';
 import TournamentHubPage from '../page';
-
-const mockRedirect = vi.fn()
-const mockGetLoggedInUser = vi.fn()
-
-// Mock next/navigation
-vi.mock('next/navigation', () => ({
-  redirect: (url: string) => mockRedirect(url),
-}));
-
-// Mock next-intl/server
-vi.mock('next-intl/server', () => ({
-  getLocale: vi.fn().mockResolvedValue('en'),
-}));
-
-// Mock locale-utils
-vi.mock('@/app/utils/locale-utils', () => ({
-  toLocale: vi.fn((v: string) => v),
-}));
-
-// Mock user-actions
-vi.mock('@/app/actions/user-actions', () => ({
-  getLoggedInUser: () => mockGetLoggedInUser(),
-}));
 
 // Mock MUI icons used in page.tsx
 vi.mock('@mui/icons-material/SportsSoccer', () => ({ default: () => <span data-testid="icon-soccer" /> }))
@@ -33,32 +10,24 @@ vi.mock('@mui/icons-material/Groups', () => ({ default: () => <span data-testid=
 vi.mock('@mui/icons-material/History', () => ({ default: () => <span data-testid="icon-history" /> }))
 
 describe('TournamentHubPage (root landing page)', () => {
-  const mockParams = Promise.resolve({ id: 'tournament-1' });
-  const mockUser = { id: 'user-1', email: 'test@example.com' };
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetLoggedInUser.mockResolvedValue(mockUser);
-  });
-
   afterEach(() => {
     cleanup();
   });
 
-  it('renders the hub page without errors when logged in', async () => {
-    const result = await TournamentHubPage({ params: mockParams });
+  it('renders the hub page without errors', async () => {
+    const result = await TournamentHubPage();
     expect(result).toBeTruthy();
   });
 
-  it('renders the Banner Area placeholder when logged in', async () => {
-    const page = await TournamentHubPage({ params: mockParams });
+  it('renders the Banner Area placeholder', async () => {
+    const page = await TournamentHubPage();
     render(page as Parameters<typeof render>[0]);
 
     expect(screen.getByText(/Banner Area/)).toBeInTheDocument();
   });
 
-  it('renders all four mock DashboardCard titles when logged in', async () => {
-    const page = await TournamentHubPage({ params: mockParams });
+  it('renders all four mock DashboardCard titles', async () => {
+    const page = await TournamentHubPage();
     render(page as Parameters<typeof render>[0]);
 
     expect(screen.getByText('Games')).toBeInTheDocument();
@@ -67,11 +36,11 @@ describe('TournamentHubPage (root landing page)', () => {
     expect(screen.getByText('Results')).toBeInTheDocument();
   });
 
-  it('redirects to /games when user is not logged in', async () => {
-    mockGetLoggedInUser.mockResolvedValue(null);
+  it('renders for unauthenticated users without redirecting', async () => {
+    const page = await TournamentHubPage();
+    render(page as Parameters<typeof render>[0]);
 
-    await TournamentHubPage({ params: mockParams });
-
-    expect(mockRedirect).toHaveBeenCalledWith('/en/tournaments/tournament-1/games');
+    // Page renders normally for guests — no redirect, all content visible
+    expect(screen.getByText(/Banner Area/)).toBeInTheDocument();
   });
 });

--- a/app/[locale]/tournaments/[id]/page.tsx
+++ b/app/[locale]/tournaments/[id]/page.tsx
@@ -5,20 +5,9 @@ import SportsSoccerIcon from '@mui/icons-material/SportsSoccer'
 import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
 import GroupsIcon from '@mui/icons-material/Groups'
 import HistoryIcon from '@mui/icons-material/History'
-import { getLocale } from 'next-intl/server'
-import { toLocale } from '@/app/utils/locale-utils'
 import { DashboardCard } from '@/app/components/tournament-hub/dashboard-card'
 
-type Props = {
-  readonly params: Promise<{
-    id: string
-  }>
-}
-
-export default async function TournamentHubPage(props: Props) {
-  const { id } = await props.params
-  const locale = toLocale(await getLocale())
-
+export default async function TournamentHubPage() {
   return (
     <Box sx={{ pt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
 

--- a/app/[locale]/tournaments/[id]/page.tsx
+++ b/app/[locale]/tournaments/[id]/page.tsx
@@ -6,9 +6,7 @@ import EmojiEventsIcon from '@mui/icons-material/EmojiEvents'
 import GroupsIcon from '@mui/icons-material/Groups'
 import HistoryIcon from '@mui/icons-material/History'
 import { getLocale } from 'next-intl/server'
-import { redirect } from 'next/navigation'
 import { toLocale } from '@/app/utils/locale-utils'
-import { getLoggedInUser } from '@/app/actions/user-actions'
 import { DashboardCard } from '@/app/components/tournament-hub/dashboard-card'
 
 type Props = {
@@ -20,11 +18,6 @@ type Props = {
 export default async function TournamentHubPage(props: Props) {
   const { id } = await props.params
   const locale = toLocale(await getLocale())
-
-  const user = await getLoggedInUser()
-  if (!user) {
-    redirect(`/${locale}/tournaments/${id}/games`)
-  }
 
   return (
     <Box sx={{ pt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/app/components/groups-page/__tests__/group-selector-i18n.test.tsx
+++ b/app/components/groups-page/__tests__/group-selector-i18n.test.tsx
@@ -32,11 +32,11 @@ describe('GroupSelector i18n', () => {
     expect(screen.getByRole('tab', { name: /awards/i })).toBeInTheDocument()
   })
 
-  it('hub tab is disabled when user is not provided', () => {
+  it('hub tab is enabled when user is not provided', () => {
     renderWithTheme(<GroupSelector {...defaultProps} />)
 
     const hubTab = screen.getByRole('tab', { name: /hub/i })
-    expect(hubTab).toHaveAttribute('aria-disabled', 'true')
+    expect(hubTab).not.toHaveAttribute('aria-disabled', 'true')
   })
 
   it('hub tab is enabled when user is provided', () => {
@@ -45,6 +45,42 @@ describe('GroupSelector i18n', () => {
 
     const hubTab = screen.getByRole('tab', { name: /hub/i })
     expect(hubTab).not.toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('qualified-teams tab is disabled when user is not provided', () => {
+    renderWithTheme(<GroupSelector {...defaultProps} />)
+
+    const qualifiedTab = screen.getByRole('tab', { name: /qualified/i })
+    expect(qualifiedTab).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('awards tab is disabled when user is not provided', () => {
+    renderWithTheme(<GroupSelector {...defaultProps} />)
+
+    const awardsTab = screen.getByRole('tab', { name: /awards/i })
+    expect(awardsTab).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('qualified-teams tab is enabled when user is provided', () => {
+    const mockUser = { id: 'user-1', email: 'test@example.com', name: 'Test' }
+    renderWithTheme(<GroupSelector {...defaultProps} user={mockUser as any} />)
+
+    const qualifiedTab = screen.getByRole('tab', { name: /qualified/i })
+    expect(qualifiedTab).not.toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('awards tab is enabled when user is provided', () => {
+    const mockUser = { id: 'user-1', email: 'test@example.com', name: 'Test' }
+    renderWithTheme(<GroupSelector {...defaultProps} user={mockUser as any} />)
+
+    const awardsTab = screen.getByRole('tab', { name: /awards/i })
+    expect(awardsTab).not.toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('all four tabs are rendered regardless of auth state', () => {
+    renderWithTheme(<GroupSelector {...defaultProps} />)
+
+    expect(screen.getAllByRole('tab')).toHaveLength(4)
   })
 
   it('translates aria-label for accessibility', () => {

--- a/app/components/groups-page/group-selector.tsx
+++ b/app/components/groups-page/group-selector.tsx
@@ -85,7 +85,6 @@ const GroupSelector = ({ groups, tournamentId, backgroundColor, textColor, user 
         component={Link}
         href={`/${locale}/tournaments/${tournamentId}`}
         sx={tabSx}
-        disabled={!user}
       />
       <Tab
         label={t('matches')}

--- a/docs/code-structure/components/components-tournament-games.md
+++ b/docs/code-structure/components/components-tournament-games.md
@@ -199,8 +199,8 @@ Dropdown menu to switch between tournaments while preserving current page path.
 - **TournamentSwitcher** (FC) - `[Client]` - Calls: `setLastSelectedTournamentId` - Uses: `useRouter, usePathname, useLocale, useState` - Renders: `IconButton, Menu, MenuItem, ListItemIcon, CheckIcon`
 
 **File:** `app/components/groups-page/group-selector.tsx`
-Tab navigation for tournament pages: Hub, Matches, Qualified Teams, Individual Awards. Hub tab always rendered with Dashboard icon, linking to tournament root. Matches tab links to `/games`. Disables tabs for non-authenticated users.
-- **GroupSelector** (FC) - `[Client]` - Calls: none - Uses: `useLocale, useTranslations, usePathname, useTheme` - Renders: `Tabs, Tab, Link, DashboardIcon, SportsSoccerIcon, AccountTreeIcon, EmojiEventsIcon`. Hub tab disabled when `!user` (same pattern as Qualified/Awards).
+Tab navigation for tournament pages: Hub, Matches, Qualified Teams, Individual Awards. Hub tab always rendered with Dashboard icon, linking to tournament root. Matches tab links to `/games`. Qualified Teams and Awards tabs are disabled for non-authenticated users; Hub tab is always enabled.
+- **GroupSelector** (FC) - `[Client]` - Calls: none - Uses: `useLocale, useTranslations, usePathname, useTheme` - Renders: `Tabs, Tab, Link, DashboardIcon, SportsSoccerIcon, AccountTreeIcon, EmojiEventsIcon`. Hub tab always enabled; Qualified Teams and Awards tabs disabled when `!user`.
 - **getTabSx** (fn) - Helper for tab styling
 - **getSelectedTab(pathname, tournamentId)** (fn) - Helper to determine active tab: `/games` → `'matches'`; root path → `'hub'`; `/qualified-teams` → `'qualified-teams'`; `/awards` → `'individual_awards'`
 

--- a/docs/code-structure/pages.md
+++ b/docs/code-structure/pages.md
@@ -144,8 +144,8 @@ Offline fallback page shown when service worker catches offline navigation.
 ### app/[locale]/tournaments/[id]/page.tsx
 Tournament Hub landing page — two-zone layout foundation (Story #354 UX Audit 2026 iteration).
 
-- **TournamentHubPage(props: Props)**: `JSX.Element` — [Server] Hub landing page. Resolves `id` from params, derives locale via `toLocale`. Renders for all users (authenticated and guest) — no auth redirect. Renders a full-width Banner Area (dashed `Paper` placeholder in a `Stack`) and a CSS Grid Widget Area with four mock `DashboardCard` instances. No old hub component imports.
-  Calls: getLocale, toLocale
+- **TournamentHubPage()**: `JSX.Element` — [Server] Hub landing page. Renders for all users (authenticated and guest) — no auth redirect, no params needed. Renders a full-width Banner Area (dashed `Paper` placeholder in a `Stack`) and a CSS Grid Widget Area with four mock `DashboardCard` instances. No old hub component imports.
+  Calls: (none)
   Renders: DashboardCard (×4)
 
 ### app/[locale]/tournaments/[id]/games/page.tsx

--- a/docs/code-structure/pages.md
+++ b/docs/code-structure/pages.md
@@ -144,8 +144,8 @@ Offline fallback page shown when service worker catches offline navigation.
 ### app/[locale]/tournaments/[id]/page.tsx
 Tournament Hub landing page — two-zone layout foundation (Story #354 UX Audit 2026 iteration).
 
-- **TournamentHubPage(props: Props)**: `JSX.Element` — [Server] Hub landing page. Resolves `id` from params, derives locale via `toLocale`, redirects to `/games` if user is not logged in. Renders a full-width Banner Area (dashed `Paper` placeholder in a `Stack`) and a CSS Grid Widget Area with four mock `DashboardCard` instances. No old hub component imports.
-  Calls: getLocale, toLocale, getLoggedInUser, redirect
+- **TournamentHubPage(props: Props)**: `JSX.Element` — [Server] Hub landing page. Resolves `id` from params, derives locale via `toLocale`. Renders for all users (authenticated and guest) — no auth redirect. Renders a full-width Banner Area (dashed `Paper` placeholder in a `Stack`) and a CSS Grid Widget Area with four mock `DashboardCard` instances. No old hub component imports.
+  Calls: getLocale, toLocale
   Renders: DashboardCard (×4)
 
 ### app/[locale]/tournaments/[id]/games/page.tsx

--- a/plans/STORY-360-context.md
+++ b/plans/STORY-360-context.md
@@ -10,7 +10,7 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/362
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** review-ready
 - **Plan File:** plans/STORY-360-plan.md
 - **Task File:** (fill when implementation starts)
 

--- a/plans/STORY-360-context.md
+++ b/plans/STORY-360-context.md
@@ -6,8 +6,8 @@
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-360
 - **Branch:** feature/story-360
 - **Base Branch:** feature/story-354
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 362
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/362
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-360-context.md
+++ b/plans/STORY-360-context.md
@@ -1,0 +1,18 @@
+# Story 360 Context
+
+## Metadata
+- **Story Number:** 360
+- **Story Title:** [Story 7] Dashboard: Logged-Off Routing & Navigation
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-360
+- **Branch:** feature/story-360
+- **Base Branch:** feature/story-354
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-360-plan.md
+- **Task File:** (fill when implementation starts)
+
+## Quick Summary
+Story #360 enables unauthenticated users to access the Tournament Hub page by: (1) removing the auth redirect from `app/[locale]/tournaments/[id]/page.tsx` that sent guests to `/games`, and (2) removing `disabled={!user}` from the Hub nav tab in `GroupSelector`. The Qualified Teams and Awards tabs keep their auth guards. Three source files change plus one CODE-STRUCTURE update; one test gets inverted and several guard tests get added.

--- a/plans/STORY-360-plan.md
+++ b/plans/STORY-360-plan.md
@@ -166,3 +166,12 @@ No call graph changes. No new cross-layer calls are introduced. One existing cal
 - Run `npm run test` — should pass with updated test assertions
 - Run `npm run lint` and `npm run build` — no new errors
 - SonarCloud: 0 new issues (small targeted change)
+
+---
+
+## Implementation Amendments
+
+### Amendment 1: TournamentHubPage signature simplified further than planned
+**Date:** 2026-04-21
+**Reason:** After removing the auth redirect, lint revealed that `locale`, `id`, `getLocale`, `toLocale`, and the `Props` type were now unused — they had only been used to construct the redirect URL. A follow-up cleanup commit removed them.
+**Change:** `TournamentHubPage(props: Props): Promise<JSX.Element>` (Calls: getLocale, toLocale) → `TournamentHubPage(): JSX.Element` (no params, no calls). The CODE-STRUCTURE pages.md entry was updated accordingly.

--- a/plans/STORY-360-plan.md
+++ b/plans/STORY-360-plan.md
@@ -1,0 +1,168 @@
+# Story 360 Plan: Dashboard: Logged-Off Routing & Navigation
+
+## Story Context
+
+**Issue:** [#360](https://github.com/gvinokur/qatar-prode/issues/360)
+**Title:** [Story 7] Dashboard: Logged-Off Routing & Navigation
+**Branch:** `feature/story-360` (branched from `feature/story-354`)
+**Worktree:** `/Users/gvinokur/Personal/qatar-prode-story-360`
+
+> **Dependency note:** This story builds directly on Story #354 (`feature/story-354`).
+> The worktree MUST be created from `feature/story-354`, not `main`.
+> Manual creation:
+> ```
+> cd /Users/gvinokur/Personal/qatar-prode-story-354
+> git checkout -b feature/story-360
+> git worktree add /Users/gvinokur/Personal/qatar-prode-story-360 feature/story-360
+> ```
+> Then copy `.env.local` and `.claude/` into the new worktree.
+
+---
+
+## Objective
+
+Enable unauthenticated users to access the Tournament Hub page (`/tournaments/[id]`) and ensure the 'Central' (Hub) navigation tab is visible and clickable for guest users.
+
+Currently:
+- `page.tsx` redirects logged-off users to `/games`
+- `GroupSelector` disables the Hub tab for guests (`disabled={!user}`)
+
+After this story, guests land on the Hub page and can navigate to it freely.
+
+---
+
+## Acceptance Criteria
+
+- [ ] **No Redirect**: Logged-off users accessing `/tournaments/[id]` (or `/hub`) land on the Hub page instead of being redirected to `/games`.
+- [ ] **Nav Visibility**: The Hub tab in `GroupSelector` is enabled and clickable for guest users.
+- [ ] **State Consistency**: The Hub page renders its layout (placeholder DashboardCards from Story #354) for all users regardless of auth state.
+
+---
+
+## Technical Approach
+
+### Changes
+
+#### 1. Remove auth redirect from `app/[locale]/tournaments/[id]/page.tsx`
+
+Remove the `getLoggedInUser()` call and the `!user` redirect entirely. The page renders its placeholder DashboardCard layout for all users — no user-specific data is fetched in this page (that was removed in Story #354's rewrite).
+
+Also remove the now-unused `redirect` import and `getLoggedInUser` import.
+
+**Before:**
+```typescript
+const user = await getLoggedInUser()
+if (!user) {
+  redirect(`/${locale}/tournaments/${id}/games`)
+}
+```
+
+**After:** (lines deleted entirely, `getLoggedInUser` and `redirect` imports also removed)
+
+#### 2. Remove `disabled={!user}` from Hub tab in `app/components/groups-page/group-selector.tsx`
+
+Only the Hub tab gets this change. Qualified Teams and Awards tabs keep their `disabled={!user}` guards since those routes are auth-protected at the page level.
+
+**Before:**
+```typescript
+<Tab
+  label={t('hub')}
+  ...
+  disabled={!user}
+/>
+```
+
+**After:**
+```typescript
+<Tab
+  label={t('hub')}
+  ...
+/>
+```
+
+#### 3. Update test in `app/components/groups-page/__tests__/group-selector-i18n.test.tsx`
+
+The test "hub tab is disabled when user is not provided" now asserts the **opposite** — hub tab is enabled when no user is provided.
+
+**Before:**
+```typescript
+it('hub tab is disabled when user is not provided', () => {
+  renderWithTheme(<GroupSelector {...defaultProps} />)
+  const hubTab = screen.getByRole('tab', { name: /hub/i })
+  expect(hubTab).toHaveAttribute('aria-disabled', 'true')
+})
+```
+
+**After:**
+```typescript
+it('hub tab is enabled when user is not provided', () => {
+  renderWithTheme(<GroupSelector {...defaultProps} />)
+  const hubTab = screen.getByRole('tab', { name: /hub/i })
+  expect(hubTab).not.toHaveAttribute('aria-disabled', 'true')
+})
+```
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+No call graph changes. No new cross-layer calls are introduced. One existing call (`getLoggedInUser` in `TournamentHubPage`) is removed.
+
+### `app/[locale]/tournaments/[id]/page.tsx` *(modified)*
+
+**Changed component:**
+
+- **TournamentHubPage(props)**: `Promise<JSX.Element>` *(was: redirected to /games when user is null)*
+  Now renders the hub layout unconditionally for all users (authenticated and guest).
+  Calls: `getLocale`, `toLocale` — (removed: `getLoggedInUser`, `redirect`)
+  Tests:
+  - This is a Next.js Server Component; covered by manual acceptance testing in Vercel Preview
+  - No unit-testable behavior change (removal of redirect is an integration concern)
+
+### `app/components/groups-page/group-selector.tsx` *(modified)*
+
+**Changed component:**
+
+- **GroupSelector({ groups, tournamentId, backgroundColor, textColor, user })**: `JSX.Element` *(was: Hub tab disabled when no user)*
+  Hub tab is now always enabled; Qualified Teams and Awards tabs remain `disabled={!user}`.
+  Tests:
+  - hub tab is enabled when no user is provided *(was: expected disabled, now expects not-disabled)*
+  - hub tab is enabled when user is provided (unchanged — still passes)
+  - qualified-teams tab remains disabled when no user is provided
+  - awards tab remains disabled when no user is provided
+  - all four tabs are rendered regardless of auth state
+  - qualified-teams tab is enabled when user IS provided *(guard: only auth behavior for hub has changed)*
+  - awards tab is enabled when user IS provided *(guard: only auth behavior for hub has changed)*
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/[locale]/tournaments/[id]/page.tsx` | Remove `getLoggedInUser` call, `redirect`, and their imports |
+| `app/components/groups-page/group-selector.tsx` | Remove `disabled={!user}` from Hub Tab only |
+| `app/components/groups-page/__tests__/group-selector-i18n.test.tsx` | Flip assertion for hub-tab-disabled test |
+| `docs/code-structure/pages.md` | Update `TournamentHubPage` description: remove mention of auth redirect |
+
+---
+
+## Testing Strategy
+
+1. **Unit test update**: Flip the existing group-selector test for hub tab disabled state.
+2. **Add guards test**: Add assertions that qualified-teams and awards tabs remain disabled without user (to prevent regression).
+3. **Manual (Vercel Preview)**:
+   - Open incognito → navigate to `/en/tournaments/[id]` → verify landing on Hub page (no redirect to games)
+   - Verify Hub tab in nav is clickable and active
+   - Verify Qualified Teams and Awards tabs are still grayed out/disabled for guests
+   - Verify that logged-in users still see the Hub page normally
+
+---
+
+## Validation
+
+- Run `npm run test` — should pass with updated test assertions
+- Run `npm run lint` and `npm run build` — no new errors
+- SonarCloud: 0 new issues (small targeted change)


### PR DESCRIPTION
Fixes #360

## Summary
- Remove auth redirect from `app/[locale]/tournaments/[id]/page.tsx` — guests now land on the Hub instead of being redirected to `/games`
- Remove `disabled={!user}` from Hub tab in `GroupSelector` — Hub nav item is now clickable for unauthenticated users
- Qualified Teams and Awards tabs keep their auth guards unchanged

## Plan Document
See `plans/STORY-360-plan.md` for full details.

## Dependency
Branched from `feature/story-354` — must be merged after Story #354.

## Next Steps
- Review and approve plan
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)