### PR TITLE
Plan: [Story 5] Dashboard: Dynamic Friend Group Widgets #358

### DIFF
--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -655,18 +655,22 @@ Key flows:
         → renders games list (✅/❌/🕐 per gameStatus) with 5 visual states
         → "View full statistics" button → /${locale}/tournaments/${tournamentId}/stats
 
-32. Leaderboard Peek data flow (Story #319; updated #342)
-    TournamentHubLeaderboardPeek (Server) → getLeaderboardPeekData(tournamentId, locale)
-      → getLoggedInUser
-      → findProdeGroupsByOwner(userId) + findProdeGroupsByParticipant(userId) + getFavoriteGroupIds(userId)
-      → getLatestRankingsForGroup(groupId, tournamentId) ×N groups (concurrent)
-      → getLatestTwoGroupRankingSnapshots(userId, groupId, tournamentId) ×3 groups (concurrent)
-      → returns LeaderboardPeekResult { groups: GroupPeekData[], userHasGroups, allGroupNames }
-    → [branch: !userHasGroups] SocialHubCard [Client]
-    → [branch: userHasGroups && no ranking data] PreTournamentGroupsPreview [Client]
-    → [branch: groups.length > 0] LeaderboardPeekCard [Client] ×N
-        → LeaderboardCard (compact=true) ×3
-        → RankChangeIndicator (header momentum chip)
+32. Leaderboard Peek data flow (Story #319; updated #342, #358)
+    TournamentHubPage (hub page) [renders via Suspense] TournamentHubLeaderboardPeek (Server)
+      isAuthenticated={!!user} passed as prop (user already fetched by hub page)
+    TournamentHubLeaderboardPeek (Server):
+      → [branch 0: !isAuthenticated] → DashboardCard [Server] → SocialHubCard(loginHref) [Client]
+      → calls getLeaderboardPeekData(tournamentId, locale) only when isAuthenticated
+          → getLoggedInUser
+          → findProdeGroupsByOwner(userId) + findProdeGroupsByParticipant(userId) + getFavoriteGroupIds(userId)
+          → getLatestRankingsForGroup(groupId, tournamentId) ×N groups (concurrent)
+          → getLatestTwoGroupRankingSnapshots(userId, groupId, tournamentId) ×3 groups (concurrent)
+          → returns LeaderboardPeekResult { groups: GroupPeekData[], userHasGroups, allGroupNames }
+      → [branch 1: !userHasGroups] DashboardCard → SocialHubCard [Client]
+      → [branch 2: userHasGroups && no ranking data] DashboardCard → PreTournamentGroupsPreview [Client]
+      → [branch 3: groups.length > 0] Fragment → LeaderboardPeekCard [Client] ×N (each is own grid cell)
+          → LeaderboardCard (compact=true) ×3
+          → RankChangeIndicator (header momentum chip)
 
     Modified flows (Story #316; updated Story #338):
     - TournamentRedirect [Client] always redirects to /${locale}/tournaments/${id} (hub root; Story #338 removed feature flag)

--- a/app/[locale]/tournaments/[id]/page.tsx
+++ b/app/[locale]/tournaments/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense } from 'react'
 import { Box } from '@mui/material'
 import HistoryIcon from '@mui/icons-material/History'
+import GroupsIcon from '@mui/icons-material/Groups'
 import { getLocale, getTranslations } from 'next-intl/server'
 import { toLocale } from '@/app/utils/locale-utils'
 import { getLoggedInUser } from '@/app/actions/user-actions'
@@ -11,6 +12,7 @@ import { PREDICTION_LOCK_OFFSET_MS } from '@/app/utils/prediction-constants'
 import { DashboardCard } from '@/app/components/tournament-hub/dashboard-card'
 import { DashboardBanner } from '@/app/components/tournament-hub/dashboard-banner'
 import { TournamentHubRecentResults } from '@/app/components/tournament-hub/tournament-hub-recent-results'
+import { TournamentHubLeaderboardPeek } from '@/app/components/tournament-hub/tournament-hub-leaderboard-peek'
 import { GamesPredictionWidget } from '@/app/components/tournament-hub/games-prediction-widget'
 import { QualifiedTeamsWidget } from '@/app/components/tournament-hub/qualified-teams-widget'
 import { AwardsWidget } from '@/app/components/tournament-hub/awards-widget'
@@ -92,6 +94,9 @@ export default async function TournamentHubPage(props: Props) {
             />
           </>
         )}
+        <Suspense fallback={<DashboardCard title="Groups" icon={<GroupsIcon fontSize="small" />} />}>
+          <TournamentHubLeaderboardPeek tournamentId={id} locale={locale} isAuthenticated={!!user} />
+        </Suspense>
         {timing?.tournamentHasStarted && (
           <Suspense fallback={<DashboardCard title="Results" icon={<HistoryIcon fontSize="small" />} />}>
             <TournamentHubRecentResults tournamentId={id} locale={locale} />

--- a/app/components/tournament-hub/__tests__/leaderboard-peek-card.test.tsx
+++ b/app/components/tournament-hub/__tests__/leaderboard-peek-card.test.tsx
@@ -10,7 +10,6 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
 }))
 
-// Mock next-intl
 vi.mock('next-intl', async () => {
   const actual = await vi.importActual('next-intl')
   return {
@@ -19,7 +18,6 @@ vi.mock('next-intl', async () => {
   }
 })
 
-// Mock framer-motion
 vi.mock('framer-motion', () => ({
   motion: {
     div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
@@ -58,7 +56,18 @@ describe('LeaderboardPeekCard', () => {
     expect(screen.getByText('Group Alpha')).toBeInTheDocument()
   })
 
-  it('renders 3 LeaderboardCard rows for a normal 3-row window', () => {
+  it('renders rank label with correct rank number', () => {
+    renderWithTheme(
+      <LeaderboardPeekCard
+        data={makeGroupData({ userRank: 7 })}
+        groupLeaderboardHref="/en/tournaments/t1/friend-groups/group-1"
+      />
+    )
+
+    expect(screen.getByText('#7')).toBeInTheDocument()
+  })
+
+  it('renders exactly data.rows.length LeaderboardCard rows', () => {
     renderWithTheme(
       <LeaderboardPeekCard
         data={makeGroupData()}
@@ -66,25 +75,24 @@ describe('LeaderboardPeekCard', () => {
       />
     )
 
-    // Each row shows its score
     expect(screen.getByText('892 pts')).toBeInTheDocument()
     expect(screen.getByText('800 pts')).toBeInTheDocument()
     expect(screen.getByText('750 pts')).toBeInTheDocument()
   })
 
-  it('the current user row shows "You" text (isCurrentUser=true triggers bold text)', () => {
-    renderWithTheme(
+  it('applies height: 100% style on the root Card', () => {
+    const { container } = renderWithTheme(
       <LeaderboardPeekCard
         data={makeGroupData()}
         groupLeaderboardHref="/en/tournaments/t1/friend-groups/group-1"
       />
     )
 
-    // LeaderboardCard renders "You" for current user
-    expect(screen.getByText('You')).toBeInTheDocument()
+    const card = container.firstChild as HTMLElement
+    expect(card).toHaveStyle({ height: '100%' })
   })
 
-  it('navigates to groupLeaderboardHref when card is clicked', () => {
+  it('calls router.push with groupLeaderboardHref when CardActionArea is clicked', () => {
     renderWithTheme(
       <LeaderboardPeekCard
         data={makeGroupData()}
@@ -98,19 +106,19 @@ describe('LeaderboardPeekCard', () => {
     expect(mockPush).toHaveBeenCalledWith('/en/tournaments/t1/friend-groups/group-1')
   })
 
-  it('renders rank chip in header with correct rank number', () => {
+  it('renders zero LeaderboardCard rows when data.rows is an empty array', () => {
     renderWithTheme(
       <LeaderboardPeekCard
-        data={makeGroupData({ userRank: 7 })}
+        data={makeGroupData({ rows: [] })}
         groupLeaderboardHref="/en/tournaments/t1/friend-groups/group-1"
       />
     )
 
-    // #7 is unique — only appears in the header (rows have ranks 2,3,4)
-    expect(screen.getByText('#7')).toBeInTheDocument()
+    expect(screen.queryByText('pts')).not.toBeInTheDocument()
+    expect(screen.getByText('Group Alpha')).toBeInTheDocument()
   })
 
-  it('renders RankChangeIndicator in header when rankChange is null (no change)', () => {
+  it('renders without crashing when rankChange is null', () => {
     renderWithTheme(
       <LeaderboardPeekCard
         data={makeGroupData({ rankChange: null })}
@@ -118,7 +126,6 @@ describe('LeaderboardPeekCard', () => {
       />
     )
 
-    // Component renders without crashing when rankChange is null (treated as 0)
     expect(screen.getByText('Group Alpha')).toBeInTheDocument()
   })
 })

--- a/app/components/tournament-hub/__tests__/pre-tournament-groups-preview.test.tsx
+++ b/app/components/tournament-hub/__tests__/pre-tournament-groups-preview.test.tsx
@@ -56,14 +56,14 @@ describe('PreTournamentGroupsPreview', () => {
     expect(screen.getByText('groupsPreview.andOthers({"count":2})')).toBeInTheDocument()
   })
 
-  it('renders exactly 3 CTA buttons (Your Groups, Create Group, Discover Groups)', () => {
+  it('renders a single "see all groups" CTA button', () => {
     render(
       <PreTournamentGroupsPreview {...defaultProps} allGroupNames={makeGroups(1)} />
     )
 
-    expect(screen.getByText('groupsPreview.goToGroups')).toBeInTheDocument()
-    expect(screen.getByText('groupsPreview.createGroup')).toBeInTheDocument()
-    expect(screen.getByText('groupsPreview.discoverGroups')).toBeInTheDocument()
+    expect(screen.getByText('seeAllGroups')).toBeInTheDocument()
+    expect(screen.queryByText('groupsPreview.createGroup')).not.toBeInTheDocument()
+    expect(screen.queryByText('groupsPreview.discoverGroups')).not.toBeInTheDocument()
   })
 
   it('group chips link to the correct group href', () => {

--- a/app/components/tournament-hub/__tests__/social-hub-card.test.tsx
+++ b/app/components/tournament-hub/__tests__/social-hub-card.test.tsx
@@ -15,47 +15,74 @@ vi.mock('next/link', () => ({
 describe('SocialHubCard', () => {
   const defaultProps = { locale: 'en' as const, tournamentId: 'tour-42' }
 
-  it('renders the Create Group button linking to friend-groups page', () => {
-    render(<SocialHubCard {...defaultProps} />)
+  describe('default mode (no loginHref)', () => {
+    it('renders the Create Group button linking to friend-groups page', () => {
+      render(<SocialHubCard {...defaultProps} />)
 
-    const createButton = screen.getByText('socialHub.createGroup')
-    expect(createButton).toBeInTheDocument()
-    const link = createButton.closest('a')
-    expect(link).toHaveAttribute('href', '/en/tournaments/tour-42/friend-groups')
-  })
+      const createButton = screen.getByText('socialHub.createGroup')
+      expect(createButton).toBeInTheDocument()
+      const link = createButton.closest('a')
+      expect(link).toHaveAttribute('href', '/en/tournaments/tour-42/friend-groups')
+    })
 
-  it('renders the Find Public Group button', () => {
-    render(<SocialHubCard {...defaultProps} />)
-    expect(screen.getByText('socialHub.findGroup')).toBeInTheDocument()
-  })
+    it('renders the Find Public Group button', () => {
+      render(<SocialHubCard {...defaultProps} />)
+      expect(screen.getByText('socialHub.findGroup')).toBeInTheDocument()
+    })
 
-  it('renders GroupAddIcon (SVG element present)', () => {
-    const { container } = render(<SocialHubCard {...defaultProps} />)
-    expect(container.querySelector('svg')).toBeInTheDocument()
-  })
+    it('renders GroupAddIcon (SVG element present)', () => {
+      const { container } = render(<SocialHubCard {...defaultProps} />)
+      expect(container.querySelector('svg')).toBeInTheDocument()
+    })
 
-  it('renders the social hub title and description text', () => {
-    render(<SocialHubCard {...defaultProps} />)
-    expect(screen.getByText('socialHub.title')).toBeInTheDocument()
-    expect(screen.getByText('socialHub.description')).toBeInTheDocument()
-  })
+    it('renders the social hub title and description text', () => {
+      render(<SocialHubCard {...defaultProps} />)
+      expect(screen.getByText('socialHub.title')).toBeInTheDocument()
+      expect(screen.getByText('socialHub.description')).toBeInTheDocument()
+    })
 
-  it('uses the correct locale in the friend-groups URL', () => {
-    render(<SocialHubCard locale="es" tournamentId="tour-42" />)
-    const links = screen.getAllByRole('link')
-    links.forEach((link) => {
-      expect(link).toHaveAttribute('href', expect.stringContaining('/es/'))
+    it('uses the correct locale in the friend-groups URL', () => {
+      render(<SocialHubCard locale="es" tournamentId="tour-42" />)
+      const links = screen.getAllByRole('link')
+      links.forEach((link) => {
+        expect(link).toHaveAttribute('href', expect.stringContaining('/es/'))
+      })
+    })
+
+    it('renders the "Learn more" link below the main CTAs', () => {
+      render(<SocialHubCard {...defaultProps} />)
+      expect(screen.getByText('newUser.socialHub.learnMore')).toBeInTheDocument()
     })
   })
 
-  it('renders the "Learn more" link below the main CTAs', () => {
-    render(<SocialHubCard {...defaultProps} />)
-    expect(screen.getByText('newUser.socialHub.learnMore')).toBeInTheDocument()
-  })
+  describe('login mode (loginHref provided)', () => {
+    const loginProps = { ...defaultProps, loginHref: '/en/auth/signin' }
 
-  it('"Learn more" link points to the friend-groups page URL', () => {
-    render(<SocialHubCard {...defaultProps} />)
-    const learnMoreLink = screen.getByText('newUser.socialHub.learnMore').closest('a')
-    expect(learnMoreLink).toHaveAttribute('href', '/en/tournaments/tour-42/friend-groups')
+    it('renders a single login button linking to loginHref', () => {
+      render(<SocialHubCard {...loginProps} />)
+
+      const loginButton = screen.getByText('socialHub.login')
+      expect(loginButton).toBeInTheDocument()
+      const link = loginButton.closest('a')
+      expect(link).toHaveAttribute('href', '/en/auth/signin')
+    })
+
+    it('does not render Create Group or Find Group buttons', () => {
+      render(<SocialHubCard {...loginProps} />)
+
+      expect(screen.queryByText('socialHub.createGroup')).not.toBeInTheDocument()
+      expect(screen.queryByText('socialHub.findGroup')).not.toBeInTheDocument()
+    })
+
+    it('does not render the Learn more link', () => {
+      render(<SocialHubCard {...loginProps} />)
+      expect(screen.queryByText('newUser.socialHub.learnMore')).not.toBeInTheDocument()
+    })
+
+    it('still renders the same icon and title in login mode', () => {
+      const { container } = render(<SocialHubCard {...loginProps} />)
+      expect(container.querySelector('svg')).toBeInTheDocument()
+      expect(screen.getByText('socialHub.title')).toBeInTheDocument()
+    })
   })
 })

--- a/app/components/tournament-hub/__tests__/tournament-hub-leaderboard-peek.test.tsx
+++ b/app/components/tournament-hub/__tests__/tournament-hub-leaderboard-peek.test.tsx
@@ -19,8 +19,21 @@ vi.mock('next/link', () => ({
 }))
 
 vi.mock('../social-hub-card', () => ({
-  SocialHubCard: ({ locale, tournamentId }: { locale: string; tournamentId: string }) => (
-    <div data-testid="social-hub-card" data-locale={locale} data-tournament-id={tournamentId}>
+  SocialHubCard: ({
+    locale,
+    tournamentId,
+    loginHref,
+  }: {
+    locale: string
+    tournamentId: string
+    loginHref?: string
+  }) => (
+    <div
+      data-testid="social-hub-card"
+      data-locale={locale}
+      data-tournament-id={tournamentId}
+      data-login-href={loginHref ?? ''}
+    >
       SocialHubCard
     </div>
   ),
@@ -35,12 +48,6 @@ vi.mock('../pre-tournament-groups-preview', () => ({
     <div data-testid="pre-tournament-groups-preview" data-count={allGroupNames.length}>
       PreTournamentGroupsPreview
     </div>
-  ),
-}))
-
-vi.mock('./leaderboard-peek-card', () => ({
-  LeaderboardPeekCard: ({ data }: { data: GroupPeekData }) => (
-    <div data-testid={`leaderboard-peek-card-${data.groupId}`}>{data.groupName}</div>
   ),
 }))
 
@@ -75,27 +82,54 @@ const makeGroupPeekData = (id: string, name: string): GroupPeekData => ({
 })
 
 const hasRankingResult: LeaderboardPeekResult = {
-  groups: [makeGroupPeekData('g-1', 'Alpha'), makeGroupPeekData('g-2', 'Beta')],
+  groups: [
+    makeGroupPeekData('g-1', 'Alpha'),
+    makeGroupPeekData('g-2', 'Beta'),
+    makeGroupPeekData('g-3', 'Gamma'),
+  ],
   userHasGroups: true,
   allGroupNames: [
     { id: 'g-1', name: 'Alpha' },
     { id: 'g-2', name: 'Beta' },
+    { id: 'g-3', name: 'Gamma' },
   ],
 }
+
+const defaultProps = { tournamentId: 'tour-42', locale: 'en' as const }
 
 describe('TournamentHubLeaderboardPeek', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('renders SocialHubCard when userHasGroups is false', async () => {
+  it('renders DashboardCard with SocialHubCard and login href when isAuthenticated is false', async () => {
+    render(
+      await TournamentHubLeaderboardPeek({ ...defaultProps, isAuthenticated: false })
+    )
+
+    const card = screen.getByTestId('social-hub-card')
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveAttribute('data-login-href', '/en/auth/signin')
+  })
+
+  it('does not call getLeaderboardPeekData when isAuthenticated is false', async () => {
+    render(
+      await TournamentHubLeaderboardPeek({ ...defaultProps, isAuthenticated: false })
+    )
+
+    expect(hubActions.getLeaderboardPeekData).not.toHaveBeenCalled()
+  })
+
+  it('renders SocialHubCard without loginHref when authenticated but userHasGroups is false', async () => {
     vi.mocked(hubActions.getLeaderboardPeekData).mockResolvedValue(noGroupsResult)
 
     render(
-      await TournamentHubLeaderboardPeek({ tournamentId: 'tour-42', locale: 'en' })
+      await TournamentHubLeaderboardPeek({ ...defaultProps, isAuthenticated: true })
     )
 
-    expect(screen.getByTestId('social-hub-card')).toBeInTheDocument()
+    const card = screen.getByTestId('social-hub-card')
+    expect(card).toBeInTheDocument()
+    expect(card).toHaveAttribute('data-login-href', '')
     expect(screen.queryByTestId('pre-tournament-groups-preview')).not.toBeInTheDocument()
   })
 
@@ -103,29 +137,18 @@ describe('TournamentHubLeaderboardPeek', () => {
     vi.mocked(hubActions.getLeaderboardPeekData).mockResolvedValue(hasGroupsNoRankingResult)
 
     render(
-      await TournamentHubLeaderboardPeek({ tournamentId: 'tour-42', locale: 'en' })
+      await TournamentHubLeaderboardPeek({ ...defaultProps, isAuthenticated: true })
     )
 
     expect(screen.getByTestId('pre-tournament-groups-preview')).toBeInTheDocument()
     expect(screen.queryByTestId('social-hub-card')).not.toBeInTheDocument()
   })
 
-  it('passes allGroupNames to PreTournamentGroupsPreview', async () => {
-    vi.mocked(hubActions.getLeaderboardPeekData).mockResolvedValue(hasGroupsNoRankingResult)
-
-    render(
-      await TournamentHubLeaderboardPeek({ tournamentId: 'tour-42', locale: 'en' })
-    )
-
-    const preview = screen.getByTestId('pre-tournament-groups-preview')
-    expect(preview).toHaveAttribute('data-count', '2')
-  })
-
-  it('renders LeaderboardPeekCards when groups is non-empty', async () => {
+  it('renders one LeaderboardPeekCard per group when groups is non-empty', async () => {
     vi.mocked(hubActions.getLeaderboardPeekData).mockResolvedValue(hasRankingResult)
 
     render(
-      await TournamentHubLeaderboardPeek({ tournamentId: 'tour-42', locale: 'en' })
+      await TournamentHubLeaderboardPeek({ ...defaultProps, isAuthenticated: true })
     )
 
     expect(screen.getByTestId('leaderboard-peek-card-g-1')).toBeInTheDocument()
@@ -134,13 +157,13 @@ describe('TournamentHubLeaderboardPeek', () => {
     expect(screen.queryByTestId('pre-tournament-groups-preview')).not.toBeInTheDocument()
   })
 
-  it('renders the section header regardless of branch', async () => {
-    vi.mocked(hubActions.getLeaderboardPeekData).mockResolvedValue(noGroupsResult)
+  it('renders exactly 3 LeaderboardPeekCard components when groups has 3 items', async () => {
+    vi.mocked(hubActions.getLeaderboardPeekData).mockResolvedValue(hasRankingResult)
 
     render(
-      await TournamentHubLeaderboardPeek({ tournamentId: 'tour-42', locale: 'en' })
+      await TournamentHubLeaderboardPeek({ ...defaultProps, isAuthenticated: true })
     )
 
-    expect(screen.getByText('yourStandings')).toBeInTheDocument()
+    expect(screen.getAllByTestId(/^leaderboard-peek-card-/)).toHaveLength(3)
   })
 })

--- a/app/components/tournament-hub/leaderboard-peek-card.tsx
+++ b/app/components/tournament-hub/leaderboard-peek-card.tsx
@@ -35,7 +35,7 @@ export function LeaderboardPeekCard({ data, groupLeaderboardHref }: Readonly<Lea
   const theme = useTheme()
 
   return (
-    <Card sx={{ borderRadius: 2, overflow: 'hidden' }}>
+    <Card variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden', height: '100%' }}>
       <CardActionArea onClick={() => router.push(groupLeaderboardHref)}>
         {/* Header: group name + rank + momentum */}
         <Box

--- a/app/components/tournament-hub/pre-tournament-groups-preview.tsx
+++ b/app/components/tournament-hub/pre-tournament-groups-preview.tsx
@@ -25,11 +25,21 @@ export function PreTournamentGroupsPreview({
   const groupsUrl = `/${locale}/tournaments/${tournamentId}/friend-groups`
 
   return (
-    <Box>
-      {/* Card showing group memberships + ranking pending empty state */}
+    <Stack spacing={1.5} sx={{ height: '100%', justifyContent: 'space-between' }}>
+      {/* Card showing group memberships + ranking pending empty state — fills remaining height */}
       <Paper
         variant="outlined"
-        sx={{ p: 2, textAlign: 'center', borderRadius: 2 }}
+        sx={{
+          p: 2,
+          textAlign: 'center',
+          borderRadius: 2,
+          flexGrow: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 1,
+        }}
       >
         {/* Group chips */}
         <Box
@@ -39,7 +49,6 @@ export function PreTournamentGroupsPreview({
             justifyContent: 'center',
             alignItems: 'center',
             gap: 0.75,
-            mb: 2,
           }}
         >
           <Typography variant="body2" component="span">
@@ -63,31 +72,15 @@ export function PreTournamentGroupsPreview({
         </Box>
 
         {/* Ranking pending empty state */}
-        <EmojiEventsIcon sx={{ fontSize: 36, color: 'text.disabled', mb: 0.5 }} />
+        <EmojiEventsIcon sx={{ fontSize: 36, color: 'text.disabled' }} />
         <Typography variant="body2" color="text.secondary">
           {t('groupsPreview.rankingPending')}
         </Typography>
       </Paper>
 
-      {/* CTAs outside the card */}
-      <Stack
-        direction="row"
-        spacing={1}
-        flexWrap="wrap"
-        useFlexGap
-        justifyContent="center"
-        sx={{ mt: 2 }}
-      >
-        <Button variant="outlined" size="small" component={Link} href={groupsUrl}>
-          {t('groupsPreview.goToGroups')}
-        </Button>
-        <Button variant="outlined" size="small" component={Link} href={groupsUrl}>
-          {t('groupsPreview.createGroup')}
-        </Button>
-        <Button variant="outlined" size="small" component={Link} href={groupsUrl}>
-          {t('groupsPreview.discoverGroups')}
-        </Button>
-      </Stack>
-    </Box>
+      <Button variant="outlined" size="small" component={Link} href={groupsUrl} fullWidth>
+        {t('seeAllGroups')}
+      </Button>
+    </Stack>
   )
 }

--- a/app/components/tournament-hub/social-hub-card.tsx
+++ b/app/components/tournament-hub/social-hub-card.tsx
@@ -10,9 +10,10 @@ import type { Locale } from '../../../i18n.config'
 interface SocialHubCardProps {
   readonly locale: Locale
   readonly tournamentId: string
+  readonly loginHref?: string
 }
 
-export function SocialHubCard({ locale, tournamentId }: SocialHubCardProps) {
+export function SocialHubCard({ locale, tournamentId, loginHref }: SocialHubCardProps) {
   const t = useTranslations('hub')
 
   const friendGroupsUrl = `/${locale}/tournaments/${tournamentId}/friend-groups`
@@ -34,33 +35,46 @@ export function SocialHubCard({ locale, tournamentId }: SocialHubCardProps) {
         <Typography variant="body2" color="text.secondary">
           {t('socialHub.description')}
         </Typography>
-        <Stack direction="row" spacing={1} justifyContent="center" flexWrap="wrap">
+        {loginHref ? (
           <Button
             variant="contained"
             color="secondary"
             component={Link}
-            href={friendGroupsUrl}
+            href={loginHref}
           >
-            {t('socialHub.createGroup')}
+            {t('socialHub.login')}
           </Button>
-          <Button
-            variant="outlined"
-            color="secondary"
-            component={Link}
-            href={friendGroupsUrl}
-          >
-            {t('socialHub.findGroup')}
-          </Button>
-        </Stack>
-        <Button
-          variant="text"
-          color="secondary"
-          size="small"
-          component={Link}
-          href={friendGroupsUrl}
-        >
-          {t('newUser.socialHub.learnMore')}
-        </Button>
+        ) : (
+          <>
+            <Stack direction="row" spacing={1} justifyContent="center" flexWrap="wrap">
+              <Button
+                variant="contained"
+                color="secondary"
+                component={Link}
+                href={friendGroupsUrl}
+              >
+                {t('socialHub.createGroup')}
+              </Button>
+              <Button
+                variant="outlined"
+                color="secondary"
+                component={Link}
+                href={friendGroupsUrl}
+              >
+                {t('socialHub.findGroup')}
+              </Button>
+            </Stack>
+            <Button
+              variant="text"
+              color="secondary"
+              size="small"
+              component={Link}
+              href={friendGroupsUrl}
+            >
+              {t('newUser.socialHub.learnMore')}
+            </Button>
+          </>
+        )}
       </Stack>
     </Paper>
   )

--- a/app/components/tournament-hub/social-hub-card.tsx
+++ b/app/components/tournament-hub/social-hub-card.tsx
@@ -19,14 +19,17 @@ export function SocialHubCard({ locale, tournamentId, loginHref }: SocialHubCard
   const friendGroupsUrl = `/${locale}/tournaments/${tournamentId}/friend-groups`
 
   return (
-    <Stack spacing={1.5} sx={{ flexGrow: 1 }}>
-      <Stack direction="column" alignItems="center" spacing={1}>
+    <Stack spacing={1.5} sx={{ flexGrow: 1, height: '100%', justifyContent: 'space-between' }}>
+      <Stack direction="column" alignItems="center" justifyContent="center" spacing={1} sx={{ flexGrow: 1 }}>
         <GroupAddIcon sx={{ fontSize: 40, color: 'secondary.main' }} />
         <Typography variant="subtitle2" fontWeight={700} textAlign="center">
           {t('socialHub.title')}
         </Typography>
         <Typography variant="body2" color="text.secondary" textAlign="center">
           {t('socialHub.description')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center">
+          {t('socialHub.joinHint')}
         </Typography>
       </Stack>
       {loginHref ? (

--- a/app/components/tournament-hub/social-hub-card.tsx
+++ b/app/components/tournament-hub/social-hub-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React from 'react'
-import { Button, Paper, Stack, Typography } from '@mui/material'
+import { Button, Stack, Typography } from '@mui/material'
 import { GroupAdd as GroupAddIcon } from '@mui/icons-material'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
@@ -19,63 +19,62 @@ export function SocialHubCard({ locale, tournamentId, loginHref }: SocialHubCard
   const friendGroupsUrl = `/${locale}/tournaments/${tournamentId}/friend-groups`
 
   return (
-    <Paper
-      variant="outlined"
-      sx={{
-        p: 3,
-        textAlign: 'center',
-        borderStyle: 'dashed',
-        borderColor: 'secondary.main',
-        borderRadius: 2,
-      }}
-    >
-      <Stack direction="column" alignItems="center" spacing={2}>
-        <GroupAddIcon sx={{ fontSize: 48, color: 'secondary.main' }} />
-        <Typography variant="h6">{t('socialHub.title')}</Typography>
-        <Typography variant="body2" color="text.secondary">
+    <Stack spacing={1.5} sx={{ flexGrow: 1 }}>
+      <Stack direction="column" alignItems="center" spacing={1}>
+        <GroupAddIcon sx={{ fontSize: 40, color: 'secondary.main' }} />
+        <Typography variant="subtitle2" fontWeight={700} textAlign="center">
+          {t('socialHub.title')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" textAlign="center">
           {t('socialHub.description')}
         </Typography>
-        {loginHref ? (
-          <Button
-            variant="contained"
-            color="secondary"
-            component={Link}
-            href={loginHref}
-          >
-            {t('socialHub.login')}
-          </Button>
-        ) : (
-          <>
-            <Stack direction="row" spacing={1} justifyContent="center" flexWrap="wrap">
-              <Button
-                variant="contained"
-                color="secondary"
-                component={Link}
-                href={friendGroupsUrl}
-              >
-                {t('socialHub.createGroup')}
-              </Button>
-              <Button
-                variant="outlined"
-                color="secondary"
-                component={Link}
-                href={friendGroupsUrl}
-              >
-                {t('socialHub.findGroup')}
-              </Button>
-            </Stack>
+      </Stack>
+      {loginHref ? (
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          fullWidth
+          component={Link}
+          href={loginHref}
+        >
+          {t('socialHub.login')}
+        </Button>
+      ) : (
+        <>
+          <Stack direction="row" spacing={1}>
             <Button
-              variant="text"
-              color="secondary"
+              variant="contained"
+              color="primary"
               size="small"
+              sx={{ flex: 1 }}
               component={Link}
               href={friendGroupsUrl}
             >
-              {t('newUser.socialHub.learnMore')}
+              {t('socialHub.createGroup')}
             </Button>
-          </>
-        )}
-      </Stack>
-    </Paper>
+            <Button
+              variant="outlined"
+              color="primary"
+              size="small"
+              sx={{ flex: 1 }}
+              component={Link}
+              href={friendGroupsUrl}
+            >
+              {t('socialHub.findGroup')}
+            </Button>
+          </Stack>
+          <Button
+            variant="text"
+            color="secondary"
+            size="small"
+            component={Link}
+            href={friendGroupsUrl}
+          >
+            {t('newUser.socialHub.learnMore')}
+          </Button>
+        </>
+      )}
+    </Stack>
   )
 }

--- a/app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx
+++ b/app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx
@@ -1,7 +1,7 @@
-import { Box, Button, Typography } from '@mui/material'
-import Link from 'next/link'
 import { getTranslations } from 'next-intl/server'
+import GroupsIcon from '@mui/icons-material/Groups'
 import { getLeaderboardPeekData } from '../../actions/hub-actions'
+import { DashboardCard } from './dashboard-card'
 import { LeaderboardPeekCard } from './leaderboard-peek-card'
 import { SocialHubCard } from './social-hub-card'
 import { PreTournamentGroupsPreview } from './pre-tournament-groups-preview'
@@ -10,65 +10,59 @@ import type { Locale } from '../../../i18n.config'
 interface TournamentHubLeaderboardPeekProps {
   readonly tournamentId: string
   readonly locale: Locale
+  readonly isAuthenticated: boolean
 }
 
 export async function TournamentHubLeaderboardPeek({
   tournamentId,
   locale,
+  isAuthenticated,
 }: TournamentHubLeaderboardPeekProps) {
-  const result = await getLeaderboardPeekData(tournamentId, locale)
-  const { groups, userHasGroups, allGroupNames } = result
   const t = await getTranslations({ locale, namespace: 'hub' })
 
-  return (
-    <Box>
-      {/* Header — centered, matching Action Center style */}
-      <Box sx={{ mb: 1, textAlign: 'center' }}>
-        <Typography variant="h6">{t('yourStandings')}</Typography>
-        <Typography variant="body2" color="text.secondary">
-          {t('yourStandingsSubtitle')}
-        </Typography>
-      </Box>
+  if (!isAuthenticated) {
+    return (
+      <DashboardCard title={t('groups')} icon={<GroupsIcon fontSize="small" />}>
+        <SocialHubCard
+          locale={locale}
+          tournamentId={tournamentId}
+          loginHref={`/${locale}/auth/signin`}
+        />
+      </DashboardCard>
+    )
+  }
 
-      {/* Branch 1: No groups at all (or unauthenticated) */}
-      {!userHasGroups && (
+  const { groups, userHasGroups, allGroupNames } = await getLeaderboardPeekData(tournamentId, locale)
+
+  if (!userHasGroups) {
+    return (
+      <DashboardCard title={t('groups')} icon={<GroupsIcon fontSize="small" />}>
         <SocialHubCard locale={locale} tournamentId={tournamentId} />
-      )}
+      </DashboardCard>
+    )
+  }
 
-      {/* Branch 2: Has groups but no ranking data yet */}
-      {userHasGroups && groups.length === 0 && (
+  if (groups.length === 0) {
+    return (
+      <DashboardCard title={t('yourStandings')} icon={<GroupsIcon fontSize="small" />}>
         <PreTournamentGroupsPreview
           allGroupNames={allGroupNames}
           locale={locale}
           tournamentId={tournamentId}
         />
-      )}
+      </DashboardCard>
+    )
+  }
 
-      {/* Branch 3: Has ranking data — existing leaderboard cards */}
-      {groups.length > 0 && (
-        <>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-            {groups.map((group) => (
-              <LeaderboardPeekCard
-                key={group.groupId}
-                data={group}
-                groupLeaderboardHref={`/${locale}/tournaments/${tournamentId}/friend-groups/${group.groupId}`}
-              />
-            ))}
-          </Box>
-          <Box sx={{ mt: 1.5, textAlign: 'center' }}>
-            <Button
-              component={Link}
-              href={`/${locale}/tournaments/${tournamentId}/friend-groups`}
-              variant="text"
-              size="small"
-              color="primary"
-            >
-              {t('seeAllGroups')}
-            </Button>
-          </Box>
-        </>
-      )}
-    </Box>
+  return (
+    <>
+      {groups.map((group) => (
+        <LeaderboardPeekCard
+          key={group.groupId}
+          data={group}
+          groupLeaderboardHref={`/${locale}/tournaments/${tournamentId}/friend-groups/${group.groupId}`}
+        />
+      ))}
+    </>
   )
 }

--- a/docs/code-structure/components/components-tournament-hub.md
+++ b/docs/code-structure/components/components-tournament-hub.md
@@ -60,7 +60,7 @@ Client Component celebration banner shown above the Action Center carousel for 4
 ### app/components/tournament-hub/social-hub-card.tsx
 Client Component social CTA shown in the Leaderboard widget when the user belongs to 0 groups.
 
-- **SocialHubCard({ locale, tournamentId })**: `JSX.Element` — [Client] Outlined dashed Paper (secondary-tinted border). Renders GroupAddIcon (48px), h6 title, body2 description, two buttons ("Create Group" contained, "Find Public Group" outlined), and a text-variant "Learn more about groups" link below the buttons — all linking to the friend-groups page.
+- **SocialHubCard({ locale, tournamentId, loginHref? })**: `JSX.Element` — [Client] Outlined dashed Paper (secondary-tinted border). Renders GroupAddIcon (48px), h6 title, body2 description. When `loginHref` is provided (logged-off mode): renders a single "Log in" Button linking to `loginHref`. Otherwise (default mode): renders two buttons ("Create Group" contained, "Find Public Group" outlined) and a text "Learn more about groups" link — all linking to the friend-groups page.
   Uses: useTranslations, Paper, Stack, Typography, Button, GroupAddIcon, Link
 
 ### app/components/tournament-hub/pre-tournament-groups-preview.tsx
@@ -79,14 +79,14 @@ Client Component for the Action Center carousel. Manages card edit state (one ca
 ### app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx
 Async Server Component for the Leaderboard Peek widget. Fetches the current user's friend-group standings and branches on group membership and ranking state.
 
-- **TournamentHubLeaderboardPeek({ tournamentId, locale })**: `JSX.Element` — [Server] Calls `getLeaderboardPeekData` (returns `LeaderboardPeekResult`). Three branches: (1) `!userHasGroups` → header + `SocialHubCard`; (2) `userHasGroups && groups.length === 0` → header + `PreTournamentGroupsPreview`; (3) `groups.length > 0` → header + `LeaderboardPeekCard` per group + "See all groups" link.
+- **TournamentHubLeaderboardPeek({ tournamentId, locale, isAuthenticated })**: `JSX.Element` — [Server] Four branches — skips `getLeaderboardPeekData` when `!isAuthenticated`. (0) `!isAuthenticated` → single `DashboardCard` wrapping `SocialHubCard` with `loginHref`; (1) `!userHasGroups` → single `DashboardCard` wrapping `SocialHubCard` (default mode); (2) `userHasGroups && groups.length === 0` → single `DashboardCard` wrapping `PreTournamentGroupsPreview`; (3) `groups.length > 0` → React Fragment with one `LeaderboardPeekCard` per group (each renders as its own CSS Grid cell). Integrated into the hub page widget grid via `Suspense`.
   Calls: getLeaderboardPeekData
-  Renders: SocialHubCard, PreTournamentGroupsPreview, LeaderboardPeekCard
+  Renders: DashboardCard, SocialHubCard, PreTournamentGroupsPreview, LeaderboardPeekCard
 
 ### app/components/tournament-hub/leaderboard-peek-card.tsx
 Client Component for a single group card in the Leaderboard Peek widget. Tappable card showing group name, user rank, momentum indicator, and a 3-row compact mini-leaderboard.
 
-- **LeaderboardPeekCard({ data, groupLeaderboardHref })**: `JSX.Element` — [Client] Renders a tappable MUI `CardActionArea` that navigates to `groupLeaderboardHref` on click. Header row shows group name (with Groups icon), `#N` rank chip, and `RankChangeIndicator`. Below a divider, renders up to 3 `LeaderboardCard compact=true` rows converted from `GroupPeekData.rows` (all point-breakdown fields set to 0).
+- **LeaderboardPeekCard({ data, groupLeaderboardHref })**: `JSX.Element` — [Client] Outlined Card with `height: '100%'` for CSS Grid alignment. Renders a tappable `CardActionArea` that navigates to `groupLeaderboardHref` on click. Header row shows group name (with Groups icon), `#N` rank chip, and `RankChangeIndicator`. Below a divider, renders up to 3 `LeaderboardCard compact=true` rows converted from `GroupPeekData.rows` (all point-breakdown fields set to 0).
   Uses: useRouter, useTheme, RankChangeIndicator
   Renders: LeaderboardCard (compact=true)
 

--- a/docs/code-structure/components/components-tournament-hub.md
+++ b/docs/code-structure/components/components-tournament-hub.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-04-23 (Story 357 — Status Widgets)
+**Last updated:** 2026-04-24 (Story 358 — Dynamic Friend Group Widgets)
 
 ---
 
@@ -60,14 +60,14 @@ Client Component celebration banner shown above the Action Center carousel for 4
 ### app/components/tournament-hub/social-hub-card.tsx
 Client Component social CTA shown in the Leaderboard widget when the user belongs to 0 groups.
 
-- **SocialHubCard({ locale, tournamentId, loginHref? })**: `JSX.Element` — [Client] Outlined dashed Paper (secondary-tinted border). Renders GroupAddIcon (48px), h6 title, body2 description. When `loginHref` is provided (logged-off mode): renders a single "Log in" Button linking to `loginHref`. Otherwise (default mode): renders two buttons ("Create Group" contained, "Find Public Group" outlined) and a text "Learn more about groups" link — all linking to the friend-groups page.
-  Uses: useTranslations, Paper, Stack, Typography, Button, GroupAddIcon, Link
+- **SocialHubCard({ locale, tournamentId, loginHref? })**: `JSX.Element` — [Client] Full-height `Stack` (`flexGrow: 1`, `justifyContent: 'space-between'`). Content area is an inner Stack with `flexGrow: 1` + `justifyContent: 'center'` so it stretches to fill remaining grid cell height. Renders `GroupAddIcon` (40px, secondary), subtitle2 title, two body2 description lines (description + joinHint). When `loginHref` is provided (logged-off mode): renders a single full-width contained "Log in" Button. Otherwise (default mode): renders a row of two size="small" Buttons (Create Group contained + Find Public Group outlined, each `flex: 1`) and a text-secondary "Learn more about groups" link below.
+  Uses: useTranslations, Stack, Typography, Button, GroupAddIcon, Link
 
 ### app/components/tournament-hub/pre-tournament-groups-preview.tsx
 Client Component shown in the Leaderboard widget when the user has groups but no ranking data yet (pre-tournament). Shows group name chips and 3 CTAs.
 
-- **PreTournamentGroupsPreview({ allGroupNames, locale, tournamentId })**: `JSX.Element` — [Client] Renders "You're in" text followed by up to 3 group name `Chip` links; appends "and N others." text when `allGroupNames.length > 3`. Below that, 3 CTA buttons (Your Groups, Create Group, Discover Groups) linking to the friend-groups page.
-  Uses: useTranslations, Box, Stack, Typography, Button, Chip, Link
+- **PreTournamentGroupsPreview({ allGroupNames, locale, tournamentId })**: `JSX.Element` — [Client] Outer `Stack` with `height: '100%'` + `justifyContent: 'space-between'` to pin CTA to bottom. Outlined `Paper` with `flexGrow: 1` fills remaining height; inner content is flex-centered (`justifyContent: 'center'`). Paper renders "You're in" text + up to 3 group name `Chip` links (each linking to that group's page); appends "and N others." when `allGroupNames.length > 3`; below that, `EmojiEventsIcon` + "Rankings pending" text. Single full-width outlined "See all your groups" Button (`seeAllGroups` key) anchored to the bottom outside the Paper.
+  Uses: useTranslations, Box, Stack, Paper, Typography, Button, Chip, EmojiEventsIcon, Link
 
 ### app/components/tournament-hub/action-center-carousel.tsx
 Client Component for the Action Center carousel. Manages card edit state (one card open at a time) and wires FlippableGameCard instances with GuessesContextProvider for inline prediction saving.

--- a/docs/code-structure/pages.md
+++ b/docs/code-structure/pages.md
@@ -142,11 +142,11 @@ Offline fallback page shown when service worker catches offline navigation.
   Calls: getLocale
 
 ### app/[locale]/tournaments/[id]/page.tsx
-Tournament Hub landing page — real banner + Games widget + three placeholder DashboardCards (Story #355 banner, #356 Games widget).
+Tournament Hub landing page — banner + Games widget + dynamic friend-group widgets + placeholder Standings card (Story #358 wired leaderboard peek).
 
-- **TournamentHubPage(props: Props)**: `Promise<JSX.Element>` — [Server] Async. Resolves `id` from params, derives locale via `toLocale`. Runs `getTournamentHubPageData(id)` and `getLoggedInUser()` in parallel. Computes `scoringRules` via `getTranslations('rules.rules')` + `getRulesBySection`. Fetches `timing` (always, via `getPublicTournamentTiming`) and `data`/`actionCenterData` (only when `user && !isFinished`, via `getActionCenterGames`) in a second parallel call. Renders `DashboardBanner` (hero + secondary banners) and CSS Grid Widget Area with `GamesPredictionWidget` plus three placeholder `DashboardCard` instances (Standings, Groups, Results).
+- **TournamentHubPage(props: Props)**: `Promise<JSX.Element>` — [Server] Async. Resolves `id` from params, derives locale via `toLocale`. Runs `getTournamentHubPageData(id)` and `getLoggedInUser()` in parallel. Computes `scoringRules` via `getTranslations('rules.rules')` + `getRulesBySection`. Fetches `timing` (always, via `getPublicTournamentTiming`) and `data`/`actionCenterData` (only when `user && !isFinished`, via `getActionCenterGames`) in a second parallel call. Renders `DashboardBanner` (hero + secondary banners) and CSS Grid Widget Area with: `GamesPredictionWidget`; one placeholder `DashboardCard` (Standings); `TournamentHubLeaderboardPeek` in `Suspense` (passes `isAuthenticated={!!user}`); `TournamentHubRecentResults` in `Suspense`.
   Calls: getLocale, toLocale, getTournamentHubPageData, getLoggedInUser, getTranslations, getRulesBySection, getPublicTournamentTiming, getActionCenterGames (conditional)
-  Renders: DashboardBanner, GamesPredictionWidget, DashboardCard (×3)
+  Renders: DashboardBanner, GamesPredictionWidget, DashboardCard (×1 Standings placeholder), TournamentHubLeaderboardPeek, TournamentHubRecentResults
 
 ### app/[locale]/tournaments/[id]/games/page.tsx
 Games page (moved from root in Story #338). Shows match predictions for the tournament. Metadata is provided by the parent `layout.tsx`.

--- a/locales/en/hub.json
+++ b/locales/en/hub.json
@@ -85,6 +85,7 @@
   "socialHub": {
     "title": "Don't play alone!",
     "description": "The best way to enjoy the World Cup is in a group. Create yours and invite your friends.",
+    "joinHint": "Already have friends playing? Ask them for their group link to join.",
     "createGroup": "Create Group",
     "findGroup": "Find Public Group",
     "login": "Log in"

--- a/locales/en/hub.json
+++ b/locales/en/hub.json
@@ -5,6 +5,7 @@
   "yourStandings": "Your Standings",
   "yourStandingsSubtitle": "Your 3 most active groups",
   "noRankingData": "Rankings will appear once the tournament is underway.",
+  "groups": "Groups",
   "seeAllGroups": "See all your groups",
   "actionCenter": {
     "title": "Action Center",
@@ -85,7 +86,8 @@
     "title": "Don't play alone!",
     "description": "The best way to enjoy the World Cup is in a group. Create yours and invite your friends.",
     "createGroup": "Create Group",
-    "findGroup": "Find Public Group"
+    "findGroup": "Find Public Group",
+    "login": "Log in"
   },
   "newUser": {
     "tutorial": {

--- a/locales/en/hub.json
+++ b/locales/en/hub.json
@@ -5,7 +5,7 @@
   "yourStandings": "Your Standings",
   "yourStandingsSubtitle": "Your 3 most active groups",
   "noRankingData": "Rankings will appear once the tournament is underway.",
-  "groups": "Groups",
+  "groups": "Friend Groups",
   "seeAllGroups": "See all your groups",
   "actionCenter": {
     "title": "Action Center",

--- a/locales/es/hub.json
+++ b/locales/es/hub.json
@@ -85,6 +85,7 @@
   "socialHub": {
     "title": "¡No juegues solo!",
     "description": "La mejor manera de disfrutar el Mundial es en grupo. Creá el tuyo e invitá a tus amigos.",
+    "joinHint": "¿Tus amigos ya están jugando? Pediles el link de su grupo para unirte.",
     "createGroup": "Crear Grupo",
     "findGroup": "Encontrar Grupo Público",
     "login": "Iniciar sesión"

--- a/locales/es/hub.json
+++ b/locales/es/hub.json
@@ -5,6 +5,7 @@
   "yourStandings": "Tus Posiciones",
   "yourStandingsSubtitle": "Tus 3 grupos más activos",
   "noRankingData": "Las posiciones aparecerán cuando el torneo esté en marcha.",
+  "groups": "Grupos",
   "seeAllGroups": "Ver todos tus grupos",
   "actionCenter": {
     "title": "Centro de Acción",
@@ -85,7 +86,8 @@
     "title": "¡No juegues solo!",
     "description": "La mejor manera de disfrutar el Mundial es en grupo. Creá el tuyo e invitá a tus amigos.",
     "createGroup": "Crear Grupo",
-    "findGroup": "Encontrar Grupo Público"
+    "findGroup": "Encontrar Grupo Público",
+    "login": "Iniciar sesión"
   },
   "newUser": {
     "tutorial": {

--- a/locales/es/hub.json
+++ b/locales/es/hub.json
@@ -5,7 +5,7 @@
   "yourStandings": "Tus Posiciones",
   "yourStandingsSubtitle": "Tus 3 grupos más activos",
   "noRankingData": "Las posiciones aparecerán cuando el torneo esté en marcha.",
-  "groups": "Grupos",
+  "groups": "Grupos de Amigos",
   "seeAllGroups": "Ver todos tus grupos",
   "actionCenter": {
     "title": "Centro de Acción",

--- a/plans/STORY-358-context.md
+++ b/plans/STORY-358-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** [Story 5] Dashboard: Dynamic Friend Group Widgets
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-358
 - **Branch:** feature/story-358
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 379
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/379
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-358-context.md
+++ b/plans/STORY-358-context.md
@@ -1,0 +1,16 @@
+# Story 358 Context
+
+## Metadata
+- **Story Number:** 358
+- **Story Title:** [Story 5] Dashboard: Dynamic Friend Group Widgets
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-358
+- **Branch:** feature/story-358
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-358-plan.md
+
+## Quick Summary
+Activates the "Groups" slot on the Tournament Hub dashboard by replacing the static Lorem ipsum placeholder card with dynamic per-group leaderboard peek cards. Each active friend group gets its own separate card in the dashboard CSS Grid (up to 3). Edge states (no groups, pre-tournament) render as a single consolidated card. Requires refactoring `TournamentHubLeaderboardPeek` to return a React Fragment for active groups, updating `LeaderboardPeekCard` styling for grid consistency, and wiring both into the hub page via Suspense.

--- a/plans/STORY-358-context.md
+++ b/plans/STORY-358-context.md
@@ -9,7 +9,7 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/379
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** implementing
 - **Plan File:** plans/STORY-358-plan.md
 
 ## Quick Summary

--- a/plans/STORY-358-plan.md
+++ b/plans/STORY-358-plan.md
@@ -195,6 +195,23 @@ No new exported functions — JSX-only changes (remove Groups DashboardCard, add
 - Task D: Write tests for `tournament-hub-leaderboard-peek.tsx`
 - Task E: Write/update tests for `leaderboard-peek-card.tsx`
 
+## Implementation Amendments
+
+### Amendment 1: SocialHubCard layout and button polish
+**Date:** 2026-04-24
+**Reason:** After initial implementation, the SocialHubCard inside DashboardCard had a redundant inner Paper border and button sizing/color didn't match the rest of the dashboard.
+**Change:** Removed inner dashed Paper border; resized buttons to `size="small"`; applied `contained` primary for main CTA and `outlined` secondary; split two-button row with `flex: 1` each; added `learnMore` text-link below; renamed translation key `groups` to "Friend Groups" / "Grupos de Amigos" to match redesigned copy. Also added vertical centering (`flexGrow: 1`, `justifyContent: 'center'`) to the content Stack so it fills remaining height when grid siblings are taller.
+
+### Amendment 2: Added `joinHint` copy to SocialHubCard
+**Date:** 2026-04-24
+**Reason:** User requested additional context about how to join existing groups ("ask your friend for their link").
+**Change:** Added `socialHub.joinHint` translation key to both `locales/en/hub.json` and `locales/es/hub.json`; rendered it as a second `body2` Typography below the description in `SocialHubCard`.
+
+### Amendment 3: Pre-tournament groups preview layout overhaul
+**Date:** 2026-04-24
+**Reason:** Plan said "No changes to `pre-tournament-groups-preview.tsx`", but after visual review the layout had the same height/centering problem as SocialHubCard, and the 3-button design (Your Groups + Create Group + Discover Groups) was redundant given the group chips already link to specific groups.
+**Change:** Switched outer wrapper from `Box` to `Stack` with `height: '100%'` + `justifyContent: 'space-between'`; added `flexGrow: 1`, `display: 'flex'`, and inner flex centering to the outlined Paper so it fills remaining height and vertically centers chips + ranking-pending icon; replaced 3 CTAs with a single full-width "See all your groups" (`seeAllGroups` key) Button anchored to the bottom. Updated test accordingly.
+
 ## Validation
 
 - `npm run test` — ≥ 80% coverage on changed files

--- a/plans/STORY-358-plan.md
+++ b/plans/STORY-358-plan.md
@@ -10,15 +10,17 @@ The story activates the "Groups" slot by integrating `TournamentHubLeaderboardPe
 
 | File | Action |
 |------|--------|
-| `app/actions/hub-actions.ts` | Add `isAuthenticated` field to `LeaderboardPeekResult`; set it from `user?.id` check |
-| `app/[locale]/tournaments/[id]/page.tsx` | Remove "Groups" placeholder; add `TournamentHubLeaderboardPeek` in Suspense |
-| `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` | Add logged-off branch; refactor remaining branches |
+| `app/[locale]/tournaments/[id]/page.tsx` | Remove "Groups" placeholder; pass `isAuthenticated={!!user}` prop; add `TournamentHubLeaderboardPeek` in Suspense |
+| `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` | Add `isAuthenticated` prop; add logged-off branch; refactor remaining branches |
+| `app/components/tournament-hub/social-hub-card.tsx` | Add optional `loginHref?: string` prop; render single login Button when provided |
 | `app/components/tournament-hub/leaderboard-peek-card.tsx` | Style update: add `variant="outlined"` + `height: '100%'` for grid consistency |
 | `app/components/tournament-hub/__tests__/tournament-hub-leaderboard-peek.test.tsx` | New: unit tests for 4 branches |
 | `app/components/tournament-hub/__tests__/leaderboard-peek-card.test.tsx` | New or updated: rendering + click tests |
+| `app/components/tournament-hub/__tests__/social-hub-card.test.tsx` | New or updated: login mode vs default mode |
 
 **No changes to:**
-- `app/components/tournament-hub/social-hub-card.tsx`
+- `app/actions/hub-actions.ts` — data fetching unchanged; auth state flows from hub page as a prop
+- `app/components/tournament-hub/social-hub-card.tsx` — gains optional `loginHref` prop (see below)
 - `app/components/tournament-hub/pre-tournament-groups-preview.tsx`
 - `app/components/tournament-hub/dashboard-card.tsx`
 
@@ -90,32 +92,21 @@ The Suspense wraps the component as a whole. When resolved, if it returns a Frag
 
 Keep the "Standings" DashboardCard placeholder unchanged (different story scope).
 
-### `hub-actions.ts` — `LeaderboardPeekResult` update
-
-Add `isAuthenticated: boolean` to the interface and populate it in `getLeaderboardPeekData`:
-
-```ts
-// Current early return when unauthenticated:
-if (!user?.id) return { groups: [], userHasGroups: false, allGroupNames: [] }
-
-// Updated:
-if (!user?.id) return { groups: [], userHasGroups: false, allGroupNames: [], isAuthenticated: false }
-
-// At the end (authenticated path):
-return { groups, userHasGroups, allGroupNames, isAuthenticated: true }
-```
-
 ### `TournamentHubLeaderboardPeek` refactor
 
 **Before:** Single `<Box>` wrapper with shared header → 3 branches inside.
 
 **After (4 branches):**
-- Branch 0 (`!isAuthenticated`): Return `<DashboardCard>` with a login CTA (sign-in prompt + link to sign-in page)
-- Branch 1 (`isAuthenticated && !userHasGroups`): Return `<DashboardCard title={t('groups')} icon={<GroupsIcon />}><SocialHubCard .../></DashboardCard>`
+- Branch 0 (`!isAuthenticated` prop): Return `<DashboardCard>` with a login CTA (sign-in prompt + link to sign-in page)
+- Branch 1 (`!userHasGroups`): Return `<DashboardCard title={t('groups')} icon={<GroupsIcon />}><SocialHubCard .../></DashboardCard>`
 - Branch 2 (`userHasGroups && groups.length === 0`): Return `<DashboardCard title={t('yourStandings')} icon={<GroupsIcon />}><PreTournamentGroupsPreview .../></DashboardCard>`
 - Branch 3 (`groups.length > 0`): Return `<>{groups.map(g => <LeaderboardPeekCard key={g.groupId} ... />)}</>`
 
-**Login CTA card content (Branch 0):** A centered state inside a DashboardCard showing a brief message ("Sign in to see your group standings") and a Button linking to the sign-in page (`/${locale}/auth/signin`). No new component needed — rendered inline in the branch.
+**`isAuthenticated` prop source:** The hub page already fetches `user` via `getLoggedInUser()`. It passes `isAuthenticated={!!user}` to `TournamentHubLeaderboardPeek` — no changes to `hub-actions.ts` or `LeaderboardPeekResult`.
+
+**Login CTA card content (Branch 0):** Reuses `SocialHubCard` with a new optional `loginHref` prop. When `loginHref` is provided, the component renders in "logged-off mode": same `GroupAddIcon`, title, and description as the normal state, but replaces the two action buttons ("Create Group" + "Find Group") with a single "Log in" Button linking to `loginHref`. The hub component passes `loginHref={`/${locale}/auth/signin`}`.
+
+This avoids duplicating the Paper/Stack layout and keeps both states in one component.
 
 Remove the "See all groups" link (navigation is via card click, which is already in LeaderboardPeekCard's CardActionArea).
 
@@ -141,22 +132,26 @@ This ensures visual consistency with other DashboardCard-style widgets in the gr
 - `TournamentHubLeaderboardPeek` no longer wraps in a Box; returns Fragment (active) or DashboardCard (logged-off/no-groups/pre-tournament)
 - `getLeaderboardPeekData` now returns `isAuthenticated` flag to distinguish logged-off from no-groups state
 
-### `app/actions/hub-actions.ts` *(modified)*
+### `app/components/tournament-hub/social-hub-card.tsx` *(modified)*
 
-**Changed types:**
+**Changed functions:**
 
-- **`LeaderboardPeekResult`** — adds `isAuthenticated: boolean` field
-  - `isAuthenticated: false` when `getLoggedInUser()` returns null (unauthenticated)
-  - `isAuthenticated: true` on all authenticated code paths
+- **`SocialHubCard({ locale, tournamentId, loginHref }): JSX.Element`** *(adds optional `loginHref?: string` prop; when provided renders a single login Button instead of "Create Group" + "Find Group" buttons)*
+  Tests:
+  - renders "Create Group" and "Find Group" buttons when `loginHref` is undefined
+  - renders a single "Log in" button linking to `loginHref` when `loginHref` is provided
+  - does NOT render the friend groups action buttons when in login mode
+  - renders the same icon and title text in both modes
 
 ### `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` *(modified)*
 
 **Changed functions:**
 
-- **`TournamentHubLeaderboardPeek({ tournamentId, locale }): JSX.Element`** *(adds logged-off branch; removes Box wrapper, shared header, and "See all groups" link; returns Fragment for active state, single DashboardCard for edge states)*
+- **`TournamentHubLeaderboardPeek({ tournamentId, locale, isAuthenticated }): JSX.Element`** *(adds `isAuthenticated: boolean` prop; adds logged-off branch; removes Box wrapper, shared header, and "See all groups" link; returns Fragment for active state, single DashboardCard for edge states)*
   Calls: `getLeaderboardPeekData`, `getTranslations`
   Tests:
   - renders a DashboardCard with a sign-in link when `isAuthenticated` is false
+  - does NOT call `getLeaderboardPeekData` when `isAuthenticated` is false
   - renders a DashboardCard containing SocialHubCard when `isAuthenticated` is true and `userHasGroups` is false
   - renders a DashboardCard containing PreTournamentGroupsPreview when `userHasGroups` is true and `groups` is empty
   - renders one LeaderboardPeekCard per group (not wrapped in a Box) when `groups` has items

--- a/plans/STORY-358-plan.md
+++ b/plans/STORY-358-plan.md
@@ -10,14 +10,14 @@ The story activates the "Groups" slot by integrating `TournamentHubLeaderboardPe
 
 | File | Action |
 |------|--------|
+| `app/actions/hub-actions.ts` | Add `isAuthenticated` field to `LeaderboardPeekResult`; set it from `user?.id` check |
 | `app/[locale]/tournaments/[id]/page.tsx` | Remove "Groups" placeholder; add `TournamentHubLeaderboardPeek` in Suspense |
-| `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` | Refactor: remove Box wrapper + shared header; return Fragment for active groups |
+| `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` | Add logged-off branch; refactor remaining branches |
 | `app/components/tournament-hub/leaderboard-peek-card.tsx` | Style update: add `variant="outlined"` + `height: '100%'` for grid consistency |
-| `app/components/tournament-hub/__tests__/tournament-hub-leaderboard-peek.test.tsx` | New: unit tests for 3 branches |
+| `app/components/tournament-hub/__tests__/tournament-hub-leaderboard-peek.test.tsx` | New: unit tests for 4 branches |
 | `app/components/tournament-hub/__tests__/leaderboard-peek-card.test.tsx` | New or updated: rendering + click tests |
 
 **No changes to:**
-- `app/actions/hub-actions.ts` — data fetching stays as-is
 - `app/components/tournament-hub/social-hub-card.tsx`
 - `app/components/tournament-hub/pre-tournament-groups-preview.tsx`
 - `app/components/tournament-hub/dashboard-card.tsx`
@@ -37,7 +37,18 @@ The story activates the "Groups" slot by integrating `TournamentHubLeaderboardPe
   (grid auto-fits: narrow screen stacks all cards vertically)
 ```
 
-**Empty state (no groups) — single card:**
+**Logged-off state — single card:**
+```
+┌──────────────────┬──────────────────┬──────────────────┐
+│ 🎮 Games         │ 🏆 Standings     │ 👥 Grupos        │
+│ [Prediction]     │ [placeholder]    │ [Login CTA]      │
+│                  │                  │ Inicia sesión    │
+│                  │                  │ para ver tu pos. │
+│                  │                  │ [Iniciar sesión] │
+└──────────────────┴──────────────────┴──────────────────┘
+```
+
+**Logged-in, no groups — single card:**
 ```
 ┌──────────────────┬──────────────────┬──────────────────┐
 │ 🎮 Games         │ 🏆 Standings     │ 👥 Grupos        │
@@ -79,14 +90,32 @@ The Suspense wraps the component as a whole. When resolved, if it returns a Frag
 
 Keep the "Standings" DashboardCard placeholder unchanged (different story scope).
 
+### `hub-actions.ts` — `LeaderboardPeekResult` update
+
+Add `isAuthenticated: boolean` to the interface and populate it in `getLeaderboardPeekData`:
+
+```ts
+// Current early return when unauthenticated:
+if (!user?.id) return { groups: [], userHasGroups: false, allGroupNames: [] }
+
+// Updated:
+if (!user?.id) return { groups: [], userHasGroups: false, allGroupNames: [], isAuthenticated: false }
+
+// At the end (authenticated path):
+return { groups, userHasGroups, allGroupNames, isAuthenticated: true }
+```
+
 ### `TournamentHubLeaderboardPeek` refactor
 
-**Before:** Single `<Box>` wrapper with shared header → all branches inside.
+**Before:** Single `<Box>` wrapper with shared header → 3 branches inside.
 
-**After:**
-- Branch 1 (`!userHasGroups`): Return `<DashboardCard title={t('groups')} icon={<GroupsIcon />}><SocialHubCard .../></DashboardCard>`
+**After (4 branches):**
+- Branch 0 (`!isAuthenticated`): Return `<DashboardCard>` with a login CTA (sign-in prompt + link to sign-in page)
+- Branch 1 (`isAuthenticated && !userHasGroups`): Return `<DashboardCard title={t('groups')} icon={<GroupsIcon />}><SocialHubCard .../></DashboardCard>`
 - Branch 2 (`userHasGroups && groups.length === 0`): Return `<DashboardCard title={t('yourStandings')} icon={<GroupsIcon />}><PreTournamentGroupsPreview .../></DashboardCard>`
 - Branch 3 (`groups.length > 0`): Return `<>{groups.map(g => <LeaderboardPeekCard key={g.groupId} ... />)}</>`
+
+**Login CTA card content (Branch 0):** A centered state inside a DashboardCard showing a brief message ("Sign in to see your group standings") and a Button linking to the sign-in page (`/${locale}/auth/signin`). No new component needed — rendered inline in the branch.
 
 Remove the "See all groups" link (navigation is via card click, which is already in LeaderboardPeekCard's CardActionArea).
 
@@ -109,19 +138,28 @@ This ensures visual consistency with other DashboardCard-style widgets in the gr
 
 **Flow 32 (Leaderboard Peek data flow)** — updated:
 - `TournamentHubPage` (hub page) now renders `TournamentHubLeaderboardPeek` directly inside the widget grid (it was previously unused in the hub page)
-- `TournamentHubLeaderboardPeek` no longer wraps in a Box; returns Fragment (active) or DashboardCard (empty/pre-tournament)
+- `TournamentHubLeaderboardPeek` no longer wraps in a Box; returns Fragment (active) or DashboardCard (logged-off/no-groups/pre-tournament)
+- `getLeaderboardPeekData` now returns `isAuthenticated` flag to distinguish logged-off from no-groups state
+
+### `app/actions/hub-actions.ts` *(modified)*
+
+**Changed types:**
+
+- **`LeaderboardPeekResult`** — adds `isAuthenticated: boolean` field
+  - `isAuthenticated: false` when `getLoggedInUser()` returns null (unauthenticated)
+  - `isAuthenticated: true` on all authenticated code paths
 
 ### `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` *(modified)*
 
 **Changed functions:**
 
-- **`TournamentHubLeaderboardPeek({ tournamentId, locale }): JSX.Element`** *(removes Box wrapper, shared header, and "See all groups" link; returns Fragment for active state, single DashboardCard for edge states)*
+- **`TournamentHubLeaderboardPeek({ tournamentId, locale }): JSX.Element`** *(adds logged-off branch; removes Box wrapper, shared header, and "See all groups" link; returns Fragment for active state, single DashboardCard for edge states)*
   Calls: `getLeaderboardPeekData`, `getTranslations`
   Tests:
-  - renders a DashboardCard containing SocialHubCard when `userHasGroups` is false
+  - renders a DashboardCard with a sign-in link when `isAuthenticated` is false
+  - renders a DashboardCard containing SocialHubCard when `isAuthenticated` is true and `userHasGroups` is false
   - renders a DashboardCard containing PreTournamentGroupsPreview when `userHasGroups` is true and `groups` is empty
   - renders one LeaderboardPeekCard per group (not wrapped in a Box) when `groups` has items
-  - does NOT render a shared "Your Standings" header Typography in the active state
   - renders exactly 3 LeaderboardPeekCard components when `groups` has 3 items
 
 ### `app/components/tournament-hub/leaderboard-peek-card.tsx` *(modified)*
@@ -167,7 +205,7 @@ No new exported functions — JSX-only changes (remove Groups DashboardCard, add
 - `npm run test` — ≥ 80% coverage on changed files
 - `npm run lint` — no ESLint errors
 - `npm run build` — no TypeScript errors
-- Visual check in Vercel Preview: verify 3 states (active groups / pre-tournament / no groups)
+- Visual check in Vercel Preview: verify 4 states (active groups / pre-tournament / no groups / logged off)
 
 ## CODE-STRUCTURE Files to Update
 

--- a/plans/STORY-358-plan.md
+++ b/plans/STORY-358-plan.md
@@ -1,0 +1,186 @@
+# Story #358: Dashboard: Dynamic Friend Group Widgets
+
+## Context
+
+The Tournament Hub dashboard has two static placeholder DashboardCards — "Standings" and "Groups" — both showing Lorem ipsum content. A `TournamentHubLeaderboardPeek` component already exists and fully implements the data fetching and rendering logic for up to 3 friend group leaderboard peek cards, but it is **not wired into the hub page**.
+
+The story activates the "Groups" slot by integrating `TournamentHubLeaderboardPeek` into the hub page with a key structural change: instead of wrapping all groups inside a single widget container, each active group gets its **own separate card** in the dashboard CSS Grid. Edge states (no groups, pre-tournament) still render as a single consolidated card.
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `app/[locale]/tournaments/[id]/page.tsx` | Remove "Groups" placeholder; add `TournamentHubLeaderboardPeek` in Suspense |
+| `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` | Refactor: remove Box wrapper + shared header; return Fragment for active groups |
+| `app/components/tournament-hub/leaderboard-peek-card.tsx` | Style update: add `variant="outlined"` + `height: '100%'` for grid consistency |
+| `app/components/tournament-hub/__tests__/tournament-hub-leaderboard-peek.test.tsx` | New: unit tests for 3 branches |
+| `app/components/tournament-hub/__tests__/leaderboard-peek-card.test.tsx` | New or updated: rendering + click tests |
+
+**No changes to:**
+- `app/actions/hub-actions.ts` — data fetching stays as-is
+- `app/components/tournament-hub/social-hub-card.tsx`
+- `app/components/tournament-hub/pre-tournament-groups-preview.tsx`
+- `app/components/tournament-hub/dashboard-card.tsx`
+
+## Visual Prototype
+
+**Active state — 3 groups (each its own grid cell):**
+```
+┌──────────────────┬──────────────────┬──────────────────┬────────────────────┐
+│ 🎮 Games         │ 🏆 Standings     │ 👥 Filial WA     │ 👥 El Grupo Vino   │
+│ [Prediction]     │ [placeholder]    │ #1 ↑1            │ #4 →               │
+│                  │                  │ ────────────────  │ ──────────────── │
+│                  │                  │ 1. Vos  42pts    │ 3. Gabriel 38pts   │
+│                  │                  │ 2. Gabi 38pts    │ 4. Vos    35pts    │
+│                  │                  │ 3. Lio  35pts    │ 5. Lio    30pts    │
+└──────────────────┴──────────────────┴──────────────────┴────────────────────┘
+  (grid auto-fits: narrow screen stacks all cards vertically)
+```
+
+**Empty state (no groups) — single card:**
+```
+┌──────────────────┬──────────────────┬──────────────────┐
+│ 🎮 Games         │ 🏆 Standings     │ 👥 Grupos        │
+│ [Prediction]     │ [placeholder]    │ [SocialHubCard]  │
+│                  │                  │ ¡No juegues solo!│
+│                  │                  │ [Crear] [Unirse] │
+└──────────────────┴──────────────────┴──────────────────┘
+```
+
+**Pre-tournament state — single card:**
+```
+┌──────────────────┬──────────────────┬──────────────────┐
+│ 🎮 Games         │ 🏆 Standings     │ 🏆 Tus Grupos    │
+│ [Prediction]     │ [placeholder]    │ [Group chips]    │
+│                  │                  │ Rankings pending │
+│                  │                  │ [Ver grupos]     │
+└──────────────────┴──────────────────┴──────────────────┘
+```
+
+## Technical Approach
+
+### Hub Page (`page.tsx`)
+
+Remove:
+```tsx
+<DashboardCard title="Groups" icon={<GroupsIcon />} count="2 groups">
+  <Typography ...>Lorem ipsum...</Typography>
+</DashboardCard>
+```
+
+Add (in the same grid Box, after the Standings card):
+```tsx
+<Suspense fallback={<DashboardCard title="Groups" icon={<GroupsIcon />} />}>
+  <TournamentHubLeaderboardPeek tournamentId={id} locale={locale} />
+</Suspense>
+```
+
+The Suspense wraps the component as a whole. When resolved, if it returns a Fragment with 3 group cards, all 3 appear as separate grid cells (React Fragment doesn't add DOM nodes, so children flow directly into the parent CSS Grid). If it returns a single DashboardCard (empty/pre-tournament), one cell appears.
+
+Keep the "Standings" DashboardCard placeholder unchanged (different story scope).
+
+### `TournamentHubLeaderboardPeek` refactor
+
+**Before:** Single `<Box>` wrapper with shared header → all branches inside.
+
+**After:**
+- Branch 1 (`!userHasGroups`): Return `<DashboardCard title={t('groups')} icon={<GroupsIcon />}><SocialHubCard .../></DashboardCard>`
+- Branch 2 (`userHasGroups && groups.length === 0`): Return `<DashboardCard title={t('yourStandings')} icon={<GroupsIcon />}><PreTournamentGroupsPreview .../></DashboardCard>`
+- Branch 3 (`groups.length > 0`): Return `<>{groups.map(g => <LeaderboardPeekCard key={g.groupId} ... />)}</>`
+
+Remove the "See all groups" link (navigation is via card click, which is already in LeaderboardPeekCard's CardActionArea).
+
+### `LeaderboardPeekCard` style update
+
+Change Card root from:
+```tsx
+<Card sx={{ borderRadius: 2, overflow: 'hidden' }}>
+```
+To:
+```tsx
+<Card variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden', height: '100%' }}>
+```
+
+This ensures visual consistency with other DashboardCard-style widgets in the grid (outlined border, full height for alignment).
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+**Flow 32 (Leaderboard Peek data flow)** — updated:
+- `TournamentHubPage` (hub page) now renders `TournamentHubLeaderboardPeek` directly inside the widget grid (it was previously unused in the hub page)
+- `TournamentHubLeaderboardPeek` no longer wraps in a Box; returns Fragment (active) or DashboardCard (empty/pre-tournament)
+
+### `app/components/tournament-hub/tournament-hub-leaderboard-peek.tsx` *(modified)*
+
+**Changed functions:**
+
+- **`TournamentHubLeaderboardPeek({ tournamentId, locale }): JSX.Element`** *(removes Box wrapper, shared header, and "See all groups" link; returns Fragment for active state, single DashboardCard for edge states)*
+  Calls: `getLeaderboardPeekData`, `getTranslations`
+  Tests:
+  - renders a DashboardCard containing SocialHubCard when `userHasGroups` is false
+  - renders a DashboardCard containing PreTournamentGroupsPreview when `userHasGroups` is true and `groups` is empty
+  - renders one LeaderboardPeekCard per group (not wrapped in a Box) when `groups` has items
+  - does NOT render a shared "Your Standings" header Typography in the active state
+  - renders exactly 3 LeaderboardPeekCard components when `groups` has 3 items
+
+### `app/components/tournament-hub/leaderboard-peek-card.tsx` *(modified)*
+
+**Changed functions:**
+
+- **`LeaderboardPeekCard({ data, groupLeaderboardHref }): JSX.Element`** *(style update: adds `variant="outlined"` and `height: "100%"` to Card)*
+  Tests:
+  - renders `data.groupName` in the card header
+  - renders `#${data.userRank}` rank label
+  - renders exactly `data.rows.length` LeaderboardCard rows
+  - applies `height: 100%` style on the root Card
+  - calls `router.push(groupLeaderboardHref)` when CardActionArea is clicked
+  - renders zero LeaderboardCard rows when `data.rows` is an empty array
+
+### `app/[locale]/tournaments/[id]/page.tsx` *(modified)*
+
+No new exported functions — JSX-only changes (remove Groups DashboardCard, add TournamentHubLeaderboardPeek in Suspense).
+
+### Test Utilities
+
+- Mock `getLeaderboardPeekData` with `vi.mock('../../actions/hub-actions')` returning `LeaderboardPeekResult` shaped data
+- Build test data inline using the `GroupPeekData` and `RankNeighborEntry` types (no factory exists yet for this domain — create test fixtures inline)
+- Mock `getTranslations` to return a simple `(key: string) => key` passthrough
+- Mock `useRouter` from `next/navigation` for click navigation tests
+- Wrap Client Component tests with `renderWithTheme` from project test utilities
+
+## Implementation Waves
+
+**Wave 1 — Component changes (parallel):**
+- Task A: Update `leaderboard-peek-card.tsx` (add `variant="outlined"`, `height: '100%'`)
+- Task B: Refactor `tournament-hub-leaderboard-peek.tsx` (remove wrapper, branch to Fragment/DashboardCard)
+
+**Wave 2 — Integration:**
+- Task C: Update `page.tsx` (remove placeholder, add TournamentHubLeaderboardPeek in Suspense) — depends on Task B being complete
+
+**Wave 3 — Tests (parallel):**
+- Task D: Write tests for `tournament-hub-leaderboard-peek.tsx`
+- Task E: Write/update tests for `leaderboard-peek-card.tsx`
+
+## Validation
+
+- `npm run test` — ≥ 80% coverage on changed files
+- `npm run lint` — no ESLint errors
+- `npm run build` — no TypeScript errors
+- Visual check in Vercel Preview: verify 3 states (active groups / pre-tournament / no groups)
+
+## CODE-STRUCTURE Files to Update
+
+- `docs/code-structure/components/components-tournament-hub.md` — update `TournamentHubLeaderboardPeek` entry (returns Fragment for active, single DashboardCard for edge states; integrated into hub page)
+- `docs/code-structure/components/components-tournament-hub.md` — update `LeaderboardPeekCard` entry (add `variant="outlined"`, `height: "100%"`)
+- `CODE-STRUCTURE.md` — update Flow 32 to show `TournamentHubPage` → `TournamentHubLeaderboardPeek` connection
+
+## Worktree
+
+New worktree needed: `/Users/gvinokur/Personal/qatar-prode-story-358`  
+Branch: `feature/story-358`
+
+Run before implementation:
+```bash
+./scripts/github-projects-helper story start 358 --project 1
+```


### PR DESCRIPTION
Fixes #358

## Summary
Implementation plan for replacing the static 'Groups' dashboard placeholder with dynamic per-group leaderboard peek cards.

## Plan Document
See `plans/STORY-358-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)