### PR TITLE
fix: clear tournament award and podium references before deletion

### DIFF
--- a/__tests__/actions/backoffice-actions.test.ts
+++ b/__tests__/actions/backoffice-actions.test.ts
@@ -547,6 +547,15 @@ describe('Backoffice Actions', () => {
       await deleteDBTournamentTree(inactiveTournament);
 
       expect(mockRevalidatePath).toHaveBeenCalledWith(`/tournaments/${mockTournament.id}/backoffice`);
+      expect(mockUpdateTournament).toHaveBeenCalledWith(mockTournament.id, {
+        best_player_id: null,
+        best_goalkeeper_player_id: null,
+        top_goalscorer_player_id: null,
+        best_young_player_id: null,
+        champion_team_id: null,
+        runner_up_team_id: null,
+        third_place_team_id: null,
+      });
       expect(mockDeleteAllGameGuessesByTournamentId).toHaveBeenCalledWith(mockTournament.id);
       expect(mockDeleteAllTournamentGuessesByTournamentId).toHaveBeenCalledWith(mockTournament.id);
       expect(mockDeleteAllTournamentGroupPositionsPredictions).toHaveBeenCalledWith(mockTournament.id);

--- a/app/actions/backoffice-actions.ts
+++ b/app/actions/backoffice-actions.ts
@@ -117,6 +117,17 @@ export async function deleteDBTournamentTree(tournament: Tournament, locale: Loc
 
   revalidatePath(`/tournaments/${tournament.id}/backoffice`);
 
+  // Clear foreign key references to prevent constraint violations during deletion
+  await updateTournament(tournament.id, {
+    best_player_id: null,
+    best_goalkeeper_player_id: null,
+    top_goalscorer_player_id: null,
+    best_young_player_id: null,
+    champion_team_id: null,
+    runner_up_team_id: null,
+    third_place_team_id: null,
+  });
+
   // Delete all related entities in reverse order of dependencies
   // User-related data
   await deleteAllGameGuessesByTournamentId(tournament.id);

--- a/app/db/tables-definition.ts
+++ b/app/db/tables-definition.ts
@@ -45,10 +45,10 @@ export interface TournamentTable extends Identifiable{
   champion_team_id?: string | null
   runner_up_team_id?: string | null
   third_place_team_id?: string | null
-  best_player_id?: string
-  top_goalscorer_player_id?: string
-  best_goalkeeper_player_id?: string
-  best_young_player_id?: string
+  best_player_id?: string | null
+  top_goalscorer_player_id?: string | null
+  best_goalkeeper_player_id?: string | null
+  best_young_player_id?: string | null
   dev_only?: boolean
   display_name?: boolean
 
@@ -352,10 +352,10 @@ export interface TournamentGuessTable extends Identifiable{
   champion_team_id?: string | null
   runner_up_team_id?: string | null
   third_place_team_id?: string | null
-  best_player_id?: string
-  top_goalscorer_player_id?: string
-  best_goalkeeper_player_id?: string
-  best_young_player_id?: string
+  best_player_id?: string | null
+  top_goalscorer_player_id?: string | null
+  best_goalkeeper_player_id?: string | null
+  best_young_player_id?: string | null
   /**
    * undefined - No positions defined or did not calculate them
    * 5 points for champion guess

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -12,7 +12,7 @@ Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index
 Administrative tournament management — full lifecycle operations: tournament creation from seed data, score calculation, group standings, playoff bracket management, and permissions. Restricted to admin users.
 
 - **deleteDBTournamentTree(tournament, locale)**: `Promise<void>` — Deletes entire tournament tree (all games, guesses, groups, teams, results).
-  Calls: getLoggedInUser, deleteAllGameGuessesByTournamentId, deleteAllTournamentGuessesByTournamentId, deleteAllTournamentGroupPositionsPredictions, deleteAllPlayersInTournament, deleteAllTournamentVenues, deleteThirdPlaceRulesByTournament, deleteAllGameResultsByTournamentId, deleteAllGamesFromTournament, deleteAllPlayoffRoundsInTournament, deleteAllGroupsFromTournament, deleteTournamentTeams, deleteTournament
+  Calls: getLoggedInUser, updateTournament, deleteAllGameGuessesByTournamentId, deleteAllTournamentGuessesByTournamentId, deleteAllTournamentGroupPositionsPredictions, deleteAllPlayersInTournament, deleteAllTournamentVenues, deleteThirdPlaceRulesByTournament, deleteAllGameResultsByTournamentId, deleteAllGamesFromTournament, deleteAllPlayoffRoundsInTournament, deleteAllGroupsFromTournament, deleteTournamentTeams, deleteTournament
 - **generateDbTournamentTeamPlayers(tournamentName)**: `Promise<void>` — Populates players from seed data files.
   Calls: findTournamentByName, findTeamInTournament, createPlayer, updatePlayer
 - **generateDbTournament(name, deletePrevious)**: `Promise<void>` — Creates a full tournament from seed data.

--- a/migrations/20260424134000_update_matchdays_specific_tournament.sql
+++ b/migrations/20260424134000_update_matchdays_specific_tournament.sql
@@ -1,0 +1,17 @@
+-- Update matchdays for specific tournament
+-- Tournament ID: c8f074d5-bc1a-432e-83d8-5c37ef15b5bd
+
+UPDATE games 
+SET matchday = 1 
+WHERE tournament_id = 'c8f074d5-bc1a-432e-83d8-5c37ef15b5bd' 
+AND game_number BETWEEN 1 AND 4;
+
+UPDATE games 
+SET matchday = 2 
+WHERE tournament_id = 'c8f074d5-bc1a-432e-83d8-5c37ef15b5bd' 
+AND game_number BETWEEN 5 AND 8;
+
+UPDATE games 
+SET matchday = 3 
+WHERE tournament_id = 'c8f074d5-bc1a-432e-83d8-5c37ef15b5bd' 
+AND game_number BETWEEN 9 AND 12;

--- a/mockups/hub-nav-unification-mockup.html
+++ b/mockups/hub-nav-unification-mockup.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hub Navigation Unification — Mockup</title>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  
+  <script type="importmap">
+    {
+      "imports": {
+        "react": "https://esm.sh/react@19",
+        "react/": "https://esm.sh/react@19/",
+        "react-dom": "https://esm.sh/react-dom@19",
+        "react-dom/client": "https://esm.sh/react-dom@19/client",
+        "react/jsx-runtime": "https://esm.sh/react@19/jsx-runtime",
+        "@mui/material": "https://esm.sh/@mui/material@7.0.2?external=react,react-dom,@emotion/react,@emotion/styled",
+        "@mui/material/": "https://esm.sh/@mui/material@7.0.2/",
+        "@emotion/react": "https://esm.sh/@emotion/react@11",
+        "@emotion/styled": "https://esm.sh/@emotion/styled@11",
+        "htm": "https://esm.sh/htm@3",
+        "@mui/icons-material/": "https://esm.sh/@mui/icons-material@7.0.2/"
+      }
+    }
+  </script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module">
+    import React from 'react';
+    import { createRoot } from 'react-dom/client';
+    import htm from 'htm';
+    import { 
+      ThemeProvider, createTheme, CssBaseline, 
+      Container, Box, Stack,
+      Card, CardContent, CardHeader,
+      Typography, Button, IconButton, Chip,
+      Divider, List, ListItem,
+      Skeleton, Paper, Badge
+    } from '@mui/material';
+    import CheckCircleOutlineIcon from 'https://esm.sh/@mui/icons-material@7.0.2/CheckCircleOutline?external=react,react-dom';
+    import CancelOutlinedIcon from 'https://esm.sh/@mui/icons-material@7.0.2/CancelOutlined?external=react,react-dom';
+    import KeyboardArrowUpIcon from 'https://esm.sh/@mui/icons-material@7.0.2/KeyboardArrowUp?external=react,react-dom';
+    import KeyboardArrowDownIcon from 'https://esm.sh/@mui/icons-material@7.0.2/KeyboardArrowDown?external=react,react-dom';
+    import EmojiEventsIcon from 'https://esm.sh/@mui/icons-material@7.0.2/EmojiEvents?external=react,react-dom';
+    import SportsSoccerIcon from 'https://esm.sh/@mui/icons-material@7.0.2/SportsSoccer?external=react,react-dom';
+    import EditIcon from 'https://esm.sh/@mui/icons-material@7.0.2/Edit?external=react,react-dom';
+
+    const html = htm.bind(React.createElement);
+
+    const theme = createTheme({
+      palette: {
+        mode: 'dark',
+        background: {
+          default: '#0a0a0a',
+          paper: '#1a1a1a',
+        },
+        primary: {
+          main: '#a78bfa',
+          contrastText: '#ffffff'
+        },
+        success: {
+          main: '#4ade80',
+        },
+        error: {
+          main: '#f87171',
+        },
+        text: {
+          primary: '#e5e7eb',
+          secondary: '#9ca3af',
+        },
+        divider: 'rgba(255, 255, 255, 0.08)'
+      },
+      typography: {
+        fontFamily: "'Archivo', Roboto, sans-serif",
+      },
+      shape: { borderRadius: 12 },
+    });
+
+    // --- Vertical Nav Component ---
+    function VerticalNav({ current, total, onUp, onDown, sx = {} }) {
+      return html`
+        <${Stack} sx=${{ justifyContent: 'center', gap: 1, ...sx }}>
+          <${IconButton} 
+            size="small" 
+            disabled=${current === 0} 
+            onClick=${onUp}
+            sx=${{ border: '1px solid', borderColor: 'divider' }}
+          >
+            <${KeyboardArrowUpIcon} fontSize="small" />
+          <//>
+          <${Box} sx=${{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+            <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: current === 0 ? 'primary.main' : 'divider' }} />
+            <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: current > 0 && current < total - 1 ? 'primary.main' : 'divider' }} />
+            <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: current === total - 1 ? 'primary.main' : 'divider' }} />
+          <//>
+          <${IconButton} 
+            size="small" 
+            disabled=${current === total - 1} 
+            onClick=${onDown}
+            sx=${{ border: '1px solid', borderColor: 'divider' }}
+          >
+            <${KeyboardArrowDownIcon} fontSize="small" />
+          <//>
+        <//>
+      `;
+    }
+
+    // --- Action Center Widget ---
+    function ActionCenterWidget() {
+      return html`
+        <${Card} variant="outlined" sx=${{ bgcolor: 'background.paper' }}>
+          <${CardHeader} 
+            title="PRÓXIMOS PARTIDOS" 
+            avatar=${html`<${SportsSoccerIcon} color="primary" />`}
+            action=${html`<${Typography} variant="body2" sx=${{ mt: 1, mr: 1, fontWeight: 700 }}>2/64<//>`}
+          />
+          <${CardContent} sx=${{ pt: 0 }}>
+            <${Typography} variant="body2" color="text.secondary" align="center" sx=${{ mb: 2 }}>
+              Tus predicciones ayudan a ganar puntos
+            <//>
+            
+            <${Box} sx=${{ display: 'flex', gap: 1 }}>
+              <${Box} sx=${{ 
+                flex: 1, 
+                p: 2, 
+                borderRadius: 2, 
+                border: '1px solid', 
+                borderColor: 'rgba(167, 139, 250, 0.3)',
+                boxShadow: '0 0 15px rgba(167, 139, 250, 0.1)'
+              }}>
+                <${Typography} variant="caption" color="text.secondary" display="block" align="center" gutterBottom>
+                  24 Abr 19:00 • Closes in 5h 44m
+                <//>
+                <${Divider} sx=${{ my: 1.5 }} />
+                
+                <${Typography} variant="body2" align="center" sx=${{ mb: 1, fontWeight: 500 }}>Tu Predicción<//>
+                <${Box} sx=${{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 2, mb: 1 }}>
+                  <${Typography} variant="h6">Italy<//>
+                  <${Typography} variant="h5" sx=${{ fontWeight: 700 }}>1 – 2<//>
+                  <${Typography} variant="h6">USA<//>
+                <//>
+                
+                <${Divider} sx=${{ my: 1.5 }} />
+                <${Typography} variant="caption" color="text.secondary" display="block" align="center">
+                  Big Stadium • Third Place
+                <//>
+              <//>
+              
+              <${VerticalNav} current=${0} total=${3} />
+            <//>
+            
+            <${Box} sx=${{ mt: 2, textAlign: 'center' }}>
+              <${Button} color="primary" size="small">VER TODOS LOS PARTIDOS<//>
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    // --- Recent Results Widget ---
+    function RecentResultsWidget() {
+      return html`
+        <${Card} variant="outlined" sx=${{ bgcolor: 'background.paper', mt: 4 }}>
+          <${CardHeader} 
+            title="PARTIDOS RECIENTES" 
+            titleTypographyProps=${{ variant: 'overline', color: 'text.secondary' }}
+          />
+          <${CardContent} sx=${{ pt: 0 }}>
+            <${Box} sx=${{ display: 'flex', gap: 1 }}>
+              <${Box} sx=${{ flex: 1 }}>
+                <${Stack} spacing=${1} divider=${html`<${Divider} />`}>
+                  ${[1, 2, 3, 4, 5].map(i => html`
+                    <${Box} key=${i} sx=${{ display: 'flex', alignItems: 'flex-start', gap: 1.5, py: 0.5 }}>
+                      <${CheckCircleOutlineIcon} color="success" sx=${{ fontSize: 20, mt: 0.2 }} />
+                      <${Box} sx=${{ flex: 1 }}>
+                        <${Box} sx=${{ display: 'flex', justifyContent: 'space-between' }}>
+                          <${Typography} variant="body2">
+                            <b>Spain (pen)</b> 1–1 France
+                          <//>
+                          <${Typography} variant="body2" color="success.main" sx=${{ fontWeight: 700 }}>+1 pts<//>
+                        <//>
+                        <${Typography} variant="caption" color="text.secondary">
+                          Predicción correcta • Ganador penales: Spain
+                        <//>
+                      <//>
+                    <//>
+                  `)}
+                <//>
+              <//>
+              <${VerticalNav} current=${0} total=${2} />
+            <//>
+            
+            <${Box} sx=${{ mt: 2, textAlign: 'center' }}>
+              <${Button} color="primary" size="small">VER ESTADÍSTICAS COMPLETAS<//>
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    function MockupApp() {
+      return html`
+        <${ThemeProvider} theme=${theme}>
+          <${CssBaseline} />
+          <${Container} maxWidth="sm" sx=${{ py: 4 }}>
+            <${Box} sx=${{ mb: 4, textAlign: 'center' }}>
+              <${Typography} variant="h5" sx=${{ fontWeight: 700, mb: 1 }}>Hub Navigation Unification<//>
+              <${Typography} variant="body2" color="text.secondary">
+                Standardizing vertical navigation across Action Center and Recent Results
+              <//>
+            <//>
+
+            <${ActionCenterWidget} />
+            <${RecentResultsWidget} />
+
+            <${Box} sx=${{ mt: 4, p: 2, bgcolor: 'rgba(167, 139, 250, 0.05)', borderRadius: 2, border: '1px dashed', borderColor: 'primary.main' }}>
+              <${Typography} variant="subtitle2" color="primary" sx=${{ fontWeight: 700 }}>KEY UNIFICATIONS<//>
+              <${List} dense>
+                <${ListItem}><${Typography} variant="caption">• <b>Navigation:</b> Both widgets now use a vertical stack of arrows on the right.<//><//>
+                <${ListItem}><${Typography} variant="caption">• <b>Consistency:</b> Removes overlapping horizontal arrows from the Action Center card.<//><//>
+                <${ListItem}><${Typography} variant="caption">• <b>Layout:</b> Fixed height (5 items for list, 1 card for carousel) prevents vertical layout shifts.<//><//>
+              <//>
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    const root = createRoot(document.getElementById('root'));
+    root.render(html`<${MockupApp} />`);
+  </script>
+</body>
+</html>

--- a/mockups/penalty-score-format-mockup.html
+++ b/mockups/penalty-score-format-mockup.html
@@ -1,0 +1,210 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hub Navigation Unification — Mockup v3</title>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  
+  <script type="importmap">
+    {
+      "imports": {
+        "react": "https://esm.sh/react@19",
+        "react/": "https://esm.sh/react@19/",
+        "react-dom": "https://esm.sh/react-dom@19",
+        "react-dom/client": "https://esm.sh/react-dom@19/client",
+        "react/jsx-runtime": "https://esm.sh/react@19/jsx-runtime",
+        "@mui/material": "https://esm.sh/@mui/material@7.0.2?external=react,react-dom,@emotion/react,@emotion/styled",
+        "@mui/material/": "https://esm.sh/@mui/material@7.0.2/",
+        "@emotion/react": "https://esm.sh/@emotion/react@11",
+        "@emotion/styled": "https://esm.sh/@emotion/styled@11",
+        "htm": "https://esm.sh/htm@3",
+        "@mui/icons-material/": "https://esm.sh/@mui/icons-material@7.0.2/"
+      }
+    }
+  </script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module">
+    import React from 'react';
+    import { createRoot } from 'react-dom/client';
+    import htm from 'htm';
+    import { 
+      ThemeProvider, createTheme, CssBaseline, 
+      Container, Box, Stack,
+      Card, CardContent, CardHeader,
+      Typography, Button, IconButton, Chip,
+      Divider, List, ListItem,
+      Skeleton, Paper, Badge
+    } from '@mui/material';
+    import CheckCircleOutlineIcon from 'https://esm.sh/@mui/icons-material@7.0.2/CheckCircleOutline?external=react,react-dom';
+    import CancelOutlinedIcon from 'https://esm.sh/@mui/icons-material@7.0.2/CancelOutlined?external=react,react-dom';
+    import KeyboardArrowUpIcon from 'https://esm.sh/@mui/icons-material@7.0.2/KeyboardArrowUp?external=react,react-dom';
+    import KeyboardArrowDownIcon from 'https://esm.sh/@mui/icons-material@7.0.2/KeyboardArrowDown?external=react,react-dom';
+    import EmojiEventsIcon from 'https://esm.sh/@mui/icons-material@7.0.2/EmojiEvents?external=react,react-dom';
+    import SportsSoccerIcon from 'https://esm.sh/@mui/icons-material@7.0.2/SportsSoccer?external=react,react-dom';
+
+    const html = htm.bind(React.createElement);
+
+    const theme = createTheme({
+      palette: {
+        mode: 'dark',
+        background: {
+          default: '#0a0a0a',
+          paper: '#1a1a1a',
+        },
+        primary: {
+          main: '#a78bfa',
+          contrastText: '#ffffff'
+        },
+        success: {
+          main: '#4ade80',
+        },
+        error: {
+          main: '#f87171',
+        },
+        text: {
+          primary: '#e5e7eb',
+          secondary: '#9ca3af',
+        },
+        divider: 'rgba(255, 255, 255, 0.08)'
+      },
+      typography: {
+        fontFamily: "'Archivo', Roboto, sans-serif",
+      },
+      shape: { borderRadius: 12 },
+    });
+
+    function VerticalNav({ current, total, onUp, onDown, sx = {} }) {
+      return html`
+        <${Stack} sx=${{ justifyContent: 'center', gap: 1, ...sx }}>
+          <${IconButton} 
+            size="small" 
+            disabled=${current === 0} 
+            onClick=${onUp}
+            sx=${{ border: '1px solid', borderColor: 'divider' }}
+          >
+            <${KeyboardArrowUpIcon} fontSize="small" />
+          <//>
+          <${Box} sx=${{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+            <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: current === 0 ? 'primary.main' : 'divider' }} />
+            <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: current > 0 && current < total - 1 ? 'primary.main' : 'divider' }} />
+            <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: current === total - 1 ? 'primary.main' : 'divider' }} />
+          <//>
+          <${IconButton} 
+            size="small" 
+            disabled=${current === total - 1} 
+            onClick=${onDown}
+            sx=${{ border: '1px solid', borderColor: 'divider' }}
+          >
+            <${KeyboardArrowDownIcon} fontSize="small" />
+          <//>
+        <//>
+      `;
+    }
+
+    function RecentResultsWidget() {
+      const [startIndex, setStartIndex] = React.useState(0);
+      const totalSteps = 2; // Simulating 10 games total (2 pages of 5)
+
+      return html`
+        <${Card} variant="outlined" sx=${{ bgcolor: 'background.paper' }}>
+          <${CardHeader} 
+            title="PARTIDOS RECIENTES" 
+            titleTypographyProps=${{ variant: 'overline', color: 'text.secondary', sx: { letterSpacing: 1.5 } }}
+          />
+          <${CardContent} sx=${{ pt: 0 }}>
+            <${Box} sx=${{ display: 'flex', gap: 1 }}>
+              <${Box} sx=${{ flex: 1 }}>
+                <${Stack} spacing=${1} divider=${html`<${Divider} />`}>
+                  <${Box} sx=${{ display: 'flex', alignItems: 'flex-start', gap: 1.5, py: 0.5 }}>
+                    <${CheckCircleOutlineIcon} color="success" sx=${{ fontSize: 20, mt: 0.2 }} />
+                    <${Box} sx=${{ flex: 1 }}>
+                      <${Box} sx=${{ display: 'flex', justifyContent: 'space-between' }}>
+                        <${Typography} variant="body2">
+                          <b>Spain</b> 1 (4)–(2) 1 France
+                        <//>
+                        <${Typography} variant="body2" color="success.main" sx=${{ fontWeight: 700 }}>+1 pts<//>
+                      <//>
+                      <${Typography} variant="caption" color="text.secondary">
+                        Predicción correcta • Ganador penales: Spain
+                      <//>
+                    <//>
+                  <//>
+                  
+                  <${Box} sx=${{ display: 'flex', alignItems: 'flex-start', gap: 1.5, py: 0.5 }}>
+                    <${CancelOutlinedIcon} color="error" sx=${{ fontSize: 20, mt: 0.2 }} />
+                    <${Box} sx=${{ flex: 1 }}>
+                      <${Box} sx=${{ display: 'flex', justifyContent: 'space-between' }}>
+                        <${Typography} variant="body2">
+                          Italy 1 (3)–(5) 1 <b>Germany</b>
+                        <//>
+                        <${Typography} variant="body2" color="text.secondary" sx=${{ fontWeight: 700 }}>0 pts<//>
+                      <//>
+                      <${Typography} variant="caption" color="text.secondary">
+                        Tu predicción: 2–1
+                      <//>
+                    <//>
+                  <//>
+
+                  ${[3, 4, 5].map(i => html`
+                    <${Box} key=${i} sx=${{ display: 'flex', alignItems: 'flex-start', gap: 1.5, py: 0.5 }}>
+                      <${CheckCircleOutlineIcon} color="success" sx=${{ fontSize: 20, mt: 0.2 }} />
+                      <${Box} sx=${{ flex: 1 }}>
+                        <${Box} sx=${{ display: 'flex', justifyContent: 'space-between' }}>
+                          <${Typography} variant="body2">Argentina 2–0 Spain<//>
+                          <${Typography} variant="body2" color="success.main" sx=${{ fontWeight: 700 }}>+2 pts<//>
+                        <//>
+                        <${Typography} variant="caption" color="text.secondary">Resultado exacto<//>
+                      <//>
+                    <//>
+                  `)}
+                <//>
+              <//>
+              <${VerticalNav} 
+                current=${startIndex} 
+                total=${totalSteps} 
+                onUp=${() => setStartIndex(0)} 
+                onDown=${() => setStartIndex(1)} 
+              />
+            <//>
+            
+            <${Box} sx=${{ mt: 2, textAlign: 'center' }}>
+              <${Button} color="primary" size="small" sx=${{ fontWeight: 700 }}>VER ESTADÍSTICAS COMPLETAS<//>
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    function MockupApp() {
+      return html`
+        <${ThemeProvider} theme=${theme}>
+          <${CssBaseline} />
+          <${Container} maxWidth="sm" sx=${{ py: 4 }}>
+            <${Box} sx=${{ mb: 4, textAlign: 'center' }}>
+              <${Typography} variant="h5" sx=${{ fontWeight: 700, mb: 1 }}>Penalty Score Format Update<//>
+              <${Typography} variant="body2" color="text.secondary">
+                Using 1 (4)–(2) 1 format for shootout results
+              <//>
+            <//>
+
+            <${RecentResultsWidget} />
+
+            <${Box} sx=${{ mt: 4, p: 2, bgcolor: 'rgba(167, 139, 250, 0.05)', borderRadius: 2, border: '1px dashed', borderColor: 'primary.main' }}>
+              <${Typography} variant="subtitle2" color="primary" sx=${{ fontWeight: 700 }}>UI UPDATE<//>
+              <${Typography} variant="caption" display="block">• Shootout results now show penalty scores in parentheses: <b>Team A</b> Score (Pen)–(Pen) Score Team B.<//>
+              <${Typography} variant="caption" display="block">• Winner team name is bolded for clarity.<//>
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    const root = createRoot(document.getElementById('root'));
+    root.render(html`<${MockupApp} />`);
+  </script>
+</body>
+</html>

--- a/mockups/recent-results-carousel-mockup.html
+++ b/mockups/recent-results-carousel-mockup.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Recent Results Widget Carousel — Mockup</title>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  
+  <script type="importmap">
+    {
+      "imports": {
+        "react": "https://esm.sh/react@19",
+        "react/": "https://esm.sh/react@19/",
+        "react-dom": "https://esm.sh/react-dom@19",
+        "react-dom/client": "https://esm.sh/react-dom@19/client",
+        "react/jsx-runtime": "https://esm.sh/react@19/jsx-runtime",
+        "@mui/material": "https://esm.sh/@mui/material@7.0.2?external=react,react-dom,@emotion/react,@emotion/styled",
+        "@mui/material/": "https://esm.sh/@mui/material@7.0.2/",
+        "@emotion/react": "https://esm.sh/@emotion/react@11",
+        "@emotion/styled": "https://esm.sh/@emotion/styled@11",
+        "htm": "https://esm.sh/htm@3",
+        "@mui/icons-material/": "https://esm.sh/@mui/icons-material@7.0.2/"
+      }
+    }
+  </script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module">
+    import React from 'react';
+    import { createRoot } from 'react-dom/client';
+    import htm from 'htm';
+    import { 
+      ThemeProvider, createTheme, CssBaseline, 
+      Container, Box, Stack,
+      Card, CardContent, CardHeader,
+      Typography, Button, IconButton, Chip,
+      Divider, List, ListItem,
+      Skeleton, Paper
+    } from '@mui/material';
+    import CheckCircleOutlineIcon from 'https://esm.sh/@mui/icons-material@7.0.2/CheckCircleOutline?external=react,react-dom';
+    import CancelOutlinedIcon from 'https://esm.sh/@mui/icons-material@7.0.2/CancelOutlined?external=react,react-dom';
+    import KeyboardArrowUpIcon from 'https://esm.sh/@mui/icons-material@7.0.2/KeyboardArrowUp?external=react,react-dom';
+    import KeyboardArrowDownIcon from 'https://esm.sh/@mui/icons-material@7.0.2/KeyboardArrowDown?external=react,react-dom';
+    import EmojiEventsIcon from 'https://esm.sh/@mui/icons-material@7.0.2/EmojiEvents?external=react,react-dom';
+
+    const html = htm.bind(React.createElement);
+
+    const theme = createTheme({
+      palette: {
+        mode: 'dark',
+        background: {
+          default: '#0a0a0a',
+          paper: '#1a1a1a',
+        },
+        primary: {
+          main: '#a78bfa',
+          contrastText: '#ffffff'
+        },
+        success: {
+          main: '#4ade80',
+        },
+        error: {
+          main: '#f87171',
+        },
+        text: {
+          primary: '#e5e7eb',
+          secondary: '#9ca3af',
+        },
+        divider: 'rgba(255, 255, 255, 0.08)'
+      },
+      typography: {
+        fontFamily: "'Archivo', Roboto, sans-serif",
+      },
+      shape: { borderRadius: 12 },
+    });
+
+    const MOCK_GAMES = [
+      { id: '1', home: 'Spain', away: 'France', homeScore: 1, awayScore: 1, homePen: 4, awayPen: 2, guessHome: 2, guessAway: 2, guessPenWinner: 'home', points: 1, status: 'finished' },
+      { id: '2', home: 'Argentina', away: 'Germany', homeScore: 1, awayScore: 3, guessHome: 1, guessAway: 1, points: 3, boost: 'golden', status: 'finished' },
+      { id: '3', home: 'France', away: 'Germany', homeScore: 1, awayScore: 1, homePen: 5, awayPen: 4, guessHome: 3, guessAway: 1, points: 0, status: 'finished' },
+      { id: '4', home: 'Argentina', away: 'Spain', homeScore: 2, awayScore: 1, guessHome: 2, guessAway: 1, points: 2, status: 'finished' },
+      { id: '5', home: 'Italy', away: 'Netherlands', homeScore: 1, awayScore: 2, guessHome: 2, guessAway: 0, points: 0, status: 'finished' },
+      { id: '6', home: 'France', away: 'Netherlands', homeScore: 3, awayScore: 0, guessHome: 2, guessAway: 1, points: 2, boost: 'silver', status: 'finished' },
+      { id: '7', home: 'Italy', away: 'Spain', homeScore: 2, awayScore: 1, guessHome: 1, guessAway: 1, points: 0, status: 'finished' },
+      { id: '8', home: 'Argentina', away: 'Germany', homeScore: 1, awayScore: 1, homePen: 3, awayPen: 5, guessHome: 1, guessAway: 0, points: 0, status: 'finished' },
+      { id: '9', home: 'France', away: 'Spain', homeScore: 1, awayScore: 1, homePen: 4, awayPen: 3, guessHome: null, points: 0, status: 'finished' },
+      { id: '10', home: 'Brazil', away: 'Germany', homeScore: 2, awayScore: 0, guessHome: null, points: 0, status: 'finished' },
+    ];
+
+    function BoostBadge({ type }) {
+      const color = type === 'golden' ? '#fbbf24' : '#9ca3af';
+      return html`
+        <${Box} sx=${{ 
+          display: 'flex', 
+          alignItems: 'center', 
+          gap: 0.5, 
+          bgcolor: 'rgba(255,255,255,0.05)', 
+          px: 0.8, 
+          py: 0.2, 
+          borderRadius: 1,
+          border: '1px solid',
+          borderColor: 'rgba(255,255,255,0.1)'
+        }}>
+          <${EmojiEventsIcon} sx=${{ fontSize: 12, color }} />
+          <${Typography} variant="caption" sx=${{ fontSize: '10px', color, fontWeight: 700 }}>
+            ${type === 'golden' ? '3x' : '2x'}
+          <//>
+        <//>
+      `;
+    }
+
+    function GameItem({ game }) {
+      const isCorrect = game.points > 0;
+      const isExact = isCorrect && game.guessHome === game.homeScore && game.guessAway === game.awayScore;
+      const hasPenalties = game.homePen !== undefined;
+      const homeWinner = hasPenalties && game.homePen > game.awayPen;
+      const awayWinner = hasPenalties && game.awayPen > game.homePen;
+      
+      const homeName = html`
+        <${Box} component="span" sx=${{ fontWeight: homeWinner ? 700 : 400 }}>
+          ${game.home} ${homeWinner ? '(pen)' : ''}
+        <//>
+      `;
+      const awayName = html`
+        <${Box} component="span" sx=${{ fontWeight: awayWinner ? 700 : 400 }}>
+          ${game.away} ${awayWinner ? '(pen)' : ''}
+        <//>
+      `;
+
+      let subtext = '';
+      if (game.guessHome === null) {
+        subtext = 'No ingresaste una predicción';
+      } else {
+        const guessText = `Tu predicción: ${game.guessHome}–${game.guessAway}`;
+        const penText = game.guessPenWinner ? ` • Ganador penales: ${game.guessPenWinner === 'home' ? game.home : game.away}` : '';
+        subtext = isExact ? 'Resultado exacto' : `Predicción correcta • ${guessText}${penText}`;
+        if (!isCorrect) subtext = guessText;
+      }
+
+      return html`
+        <${Box} sx=${{ display: 'flex', alignItems: 'flex-start', gap: 1.5, py: 1 }}>
+          ${isCorrect 
+            ? html`<${CheckCircleOutlineIcon} color="success" sx=${{ fontSize: 20, mt: 0.2 }} />`
+            : html`<${CancelOutlinedIcon} color="error" sx=${{ fontSize: 20, mt: 0.2 }} />`
+          }
+          <${Box} sx=${{ flex: 1, minWidth: 0 }}>
+            <${Box} sx=${{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <${Typography} variant="body2" sx=${{ fontWeight: 500 }}>
+                ${homeName} ${game.homeScore}–${game.awayScore} ${awayName}
+              <//>
+              <${Box} sx=${{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <${Typography} variant="body2" color=${isCorrect ? 'success.main' : 'text.secondary'} sx=${{ fontWeight: 700 }}>
+                  ${isCorrect ? '+' : ''}${game.points} pts
+                <//>
+                ${game.boost && html`<${BoostBadge} type=${game.boost} />`}
+              <//>
+            <//>
+            <${Typography} variant="caption" color="text.secondary" sx=${{ display: 'block', mt: 0.2 }}>
+              ${subtext}
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    function PopulatedState() {
+      const [startIndex, setStartIndex] = React.useState(0);
+      const visibleGames = MOCK_GAMES.slice(startIndex, startIndex + 5);
+
+      const handleUp = () => setStartIndex(prev => Math.max(0, prev - 1));
+      const handleDown = () => setStartIndex(prev => Math.min(MOCK_GAMES.length - 5, prev + 1));
+
+      return html`
+        <${Card} variant="outlined" sx=${{ bgcolor: 'background.paper', borderColor: 'divider' }}>
+          <${CardHeader} 
+            title="PARTIDOS RECIENTES" 
+            titleTypographyProps=${{ variant: 'overline', color: 'text.secondary', sx: { letterSpacing: 1.5 } }}
+            sx=${{ pb: 1 }}
+          />
+          <${CardContent} sx=${{ position: 'relative', pt: 0, pb: '8px !important' }}>
+            <${Box} sx=${{ display: 'flex', gap: 1 }}>
+              <${Box} sx=${{ flex: 1, minWidth: 0 }}>
+                <${Stack} divider=${html`<${Divider} />`}>
+                  ${visibleGames.map(game => html`<${GameItem} key=${game.id} game=${game} />`)}
+                <//>
+              <//>
+              
+              <${Stack} sx=${{ justifyContent: 'center', gap: 1, ml: 0.5 }}>
+                <${IconButton} 
+                  size="small" 
+                  disabled=${startIndex === 0} 
+                  onClick=${handleUp}
+                  sx=${{ 
+                    border: '1px solid', 
+                    borderColor: 'divider',
+                    '&.Mui-disabled': { opacity: 0.3 }
+                  }}
+                >
+                  <${KeyboardArrowUpIcon} fontSize="small" />
+                <//>
+                <${Box} sx=${{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5 }}>
+                  <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: startIndex === 0 ? 'primary.main' : 'divider' }} />
+                  <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: startIndex > 0 && startIndex < MOCK_GAMES.length - 5 ? 'primary.main' : 'divider' }} />
+                  <${Box} sx=${{ width: 4, height: 4, borderRadius: '50%', bgcolor: startIndex === MOCK_GAMES.length - 5 ? 'primary.main' : 'divider' }} />
+                <//>
+                <${IconButton} 
+                  size="small" 
+                  disabled=${startIndex === MOCK_GAMES.length - 5} 
+                  onClick=${handleDown}
+                  sx=${{ 
+                    border: '1px solid', 
+                    borderColor: 'divider',
+                    '&.Mui-disabled': { opacity: 0.3 }
+                  }}
+                >
+                  <${KeyboardArrowDownIcon} fontSize="small" />
+                <//>
+              <//>
+            <//>
+
+            <${Box} sx=${{ mt: 2, textAlign: 'center' }}>
+              <${Button} color="primary" sx=${{ fontWeight: 700, fontSize: '0.75rem' }}>
+                VER ESTADÍSTICAS COMPLETAS
+              <//>
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    function LoadingState() {
+      return html`
+        <${Card} variant="outlined" sx=${{ bgcolor: 'background.paper', opacity: 0.6 }}>
+          <${CardContent}>
+            <${Skeleton} variant="text" width="60%" sx=${{ mb: 2 }} />
+            <${Stack} spacing=${2}>
+              ${[1, 2, 3, 4, 5].map(i => html`
+                <${Box} key=${i} sx=${{ display: 'flex', gap: 2 }}>
+                  <${Skeleton} variant="circular" width={24} height={24} />
+                  <${Box} sx=${{ flex: 1 }}>
+                    <${Skeleton} variant="text" width="80%" />
+                    <${Skeleton} variant="text" width="40%" />
+                  <//>
+                <//>
+              `)}
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    function MockupApp() {
+      const [state, setState] = React.useState('populated');
+
+      return html`
+        <${ThemeProvider} theme=${theme}>
+          <${CssBaseline} />
+          <${Container} maxWidth="sm" sx=${{ py: 4 }}>
+            <${Box} sx=${{ mb: 4, textAlign: 'center' }}>
+              <${Typography} variant="h5" sx=${{ fontWeight: 700, mb: 1 }}>Recent Results Redesign<//>
+              <${Typography} variant="body2" color="text.secondary">
+                Carousel navigation (max 5 visible) + Penalty shootout indicators
+              <//>
+            <//>
+
+            <${Box} sx=${{ display: 'flex', justifyContent: 'center', mb: 4 }}>
+              <${Stack} direction="row" spacing=${1}>
+                ${['loading', 'populated'].map(s => html`
+                  <${Chip}
+                    key=${s}
+                    label=${s.toUpperCase()}
+                    size="small"
+                    onClick=${() => setState(s)}
+                    color=${state === s ? 'primary' : 'default'}
+                    variant=${state === s ? 'filled' : 'outlined'}
+                    sx=${{ fontWeight: 700, fontSize: '10px' }}
+                  />
+                `)}
+              <//>
+            <//>
+
+            ${state === 'loading' && html`<${LoadingState} />`}
+            ${state === 'populated' && html`<${PopulatedState} />`}
+
+            <${Box} sx=${{ mt: 6, p: 3, bgcolor: 'rgba(167, 139, 250, 0.05)', borderRadius: 2, border: '1px dashed', borderColor: 'primary.main' }}>
+              <${Typography} variant="subtitle2" color="primary" gutterBottom sx=${{ fontWeight: 700 }}>DESIGN NOTES<//>
+              <${List} size="small" sx=${{ '& .MuiTypography-root': { fontSize: '0.85rem' } }}>
+                <${ListItem}>
+                  <${Typography}>• <b>Carousel:</b> Vertical navigation with up/down arrows. Single-step sliding.<//>
+                <//>
+                <${ListItem}>
+                  <${Typography}>• <b>Penalty Indicators:</b> Winner team gets "(pen)" suffix and bold weight. Matches the actual tournament results logic.<//>
+                <//>
+                <${ListItem}>
+                  <${Typography}>• <b>Guess Feedback:</b> For shootout games, subtext explicitly confirms the penalty winner prediction.<//>
+                <//>
+                <${ListItem}>
+                  <${Typography}>• <b>Height Control:</b> Fixed to 5 items to prevent "super tall" layout shifts on mobile/iPad.<//>
+                <//>
+              <//>
+            <//>
+          <//>
+        <//>
+      `;
+    }
+
+    const root = createRoot(document.getElementById('root'));
+    root.render(html`<${MockupApp} />`);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This PR fixes a foreign key constraint violation when deleting a tournament. 

The issue occurred because the tournament record held references to players and teams via columns like `best_young_player_id` and `champion_team_id`. Setting these fields to `null` before deleting the related entities resolves the conflict.