### PR TITLE
Plan: [Story] Limit urgent games banner to 24-hour window #403

### DIFF
--- a/app/actions/__tests__/hub-actions-priority.test.ts
+++ b/app/actions/__tests__/hub-actions-priority.test.ts
@@ -101,11 +101,15 @@ describe('computePriorityAttention', () => {
   })
 
   describe('Tier 1 — urgent-games', () => {
-    it('returns urgent-games when mode is urgent', () => {
-      const urgentGame = { id: 'game-1' } as ActionCenterData['games'][0]
+    const gameWithin24h = (id: string) =>
+      ({ id, game_date: new Date(Date.now() + 2 * 60 * 60 * 1000) }) as ActionCenterData['games'][0]
+    const gameOutside24h = (id: string) =>
+      ({ id, game_date: new Date(Date.now() + 30 * 60 * 60 * 1000) }) as ActionCenterData['games'][0]
+
+    it('returns urgent-games when mode is urgent and a game is within 24h', () => {
       const data = makeData({
         mode: 'urgent',
-        games: [urgentGame],
+        games: [gameWithin24h('game-1')],
         tournamentHasStarted: true,
         predictedGames: 10,
         totalGames: 64,
@@ -114,22 +118,65 @@ describe('computePriorityAttention', () => {
       expect(result?.type).toBe('urgent-games')
     })
 
-    it('includes urgentCount = games.length when mode is urgent', () => {
+    it('includes urgentCount = within-24h game count', () => {
       const data = makeData({
         mode: 'urgent',
-        games: [{ id: 'g1' }, { id: 'g2' }, { id: 'g3' }] as ActionCenterData['games'],
+        games: [gameWithin24h('g1'), gameWithin24h('g2'), gameWithin24h('g3')],
         tournamentHasStarted: true,
       })
       expect(computePriorityAttention(data)?.urgentCount).toBe(3)
     })
 
-    it('includes firstUrgentGameId = games[0].id when mode is urgent', () => {
+    it('includes firstUrgentGameId = id of first within-24h game', () => {
       const data = makeData({
         mode: 'urgent',
-        games: [{ id: 'first-urgent' }, { id: 'second-urgent' }] as ActionCenterData['games'],
+        games: [gameWithin24h('first-urgent'), gameWithin24h('second-urgent')],
         tournamentHasStarted: true,
       })
       expect(computePriorityAttention(data)?.firstUrgentGameId).toBe('first-urgent')
+    })
+
+    it('does NOT return urgent-games when mode is urgent but all games are outside 24h', () => {
+      const data = makeData({
+        mode: 'urgent',
+        games: [gameOutside24h('far-game')],
+        tournamentHasStarted: true,
+      })
+      expect(computePriorityAttention(data)?.type).not.toBe('urgent-games')
+    })
+
+    it('urgentCount reflects only within-24h games, not all games in data.games', () => {
+      const data = makeData({
+        mode: 'urgent',
+        games: [gameWithin24h('near'), gameOutside24h('far-1'), gameOutside24h('far-2')],
+        tournamentHasStarted: true,
+      })
+      expect(computePriorityAttention(data)?.urgentCount).toBe(1)
+    })
+
+    it('falls through to deadline state when mode is urgent but no games within 24h', () => {
+      const data = makeData({
+        mode: 'urgent',
+        games: [gameOutside24h('far-game')],
+        tournamentHasStarted: true,
+        qtAndAwardsOpen: true,
+        msUntilPredictionLock: HOURS_48_MS - 1,
+        qualifiersCompleted: 10,
+        qualifiersTotal: 32,
+        awardsCompleted: 3,
+        awardsTotal: 7,
+      })
+      expect(computePriorityAttention(data)?.type).toBe('deadline')
+    })
+
+    it('returns null when mode is urgent, no games within 24h, and no other condition matches', () => {
+      const data = makeData({
+        mode: 'urgent',
+        games: [gameOutside24h('far-game')],
+        tournamentHasStarted: true,
+        qtAndAwardsOpen: false,
+      })
+      expect(computePriorityAttention(data)).toBeNull()
     })
   })
 

--- a/app/utils/priority-attention.ts
+++ b/app/utils/priority-attention.ts
@@ -1,4 +1,5 @@
 import type { ActionCenterData } from '../actions/hub-actions'
+import { calculateDeadline } from './countdown-utils'
 import { areGroupStageGamesPredicted } from './stage-utils'
 
 export type PriorityAttentionType =
@@ -30,6 +31,7 @@ export interface PriorityAttentionState {
 }
 
 const HOURS_48_MS = 48 * 60 * 60 * 1000
+const HOURS_24_MS = 24 * 60 * 60 * 1000
 
 function buildDeadlineState(data: ActionCenterData): PriorityAttentionState | null {
   if (!data.tournamentHasStarted || !data.qtAndAwardsOpen || data.msUntilPredictionLock >= HOURS_48_MS) return null
@@ -62,13 +64,20 @@ export function computePriorityAttention(data: ActionCenterData): PriorityAttent
   if (data.tournamentFinished) return null
 
   if (data.mode === 'urgent') {
-    return {
-      type: 'urgent-games',
-      urgentCount: data.games.length,
-      firstUrgentGameId: data.games[0]?.id,
-      completedCount: data.predictedGames,
-      totalCount: data.totalGames,
+    const now = Date.now()
+    const within24h = data.games.filter(
+      (g) => calculateDeadline(g.game_date) - now <= HOURS_24_MS
+    )
+    if (within24h.length > 0) {
+      return {
+        type: 'urgent-games',
+        urgentCount: within24h.length,
+        firstUrgentGameId: within24h[0]?.id,
+        completedCount: data.predictedGames,
+        totalCount: data.totalGames,
+      }
     }
+    // No games within 24h — fall through to lower-priority states
   }
 
   const deadline = buildDeadlineState(data)

--- a/docs/code-structure/utils.md
+++ b/docs/code-structure/utils.md
@@ -13,8 +13,8 @@ Pure priority computation for the Tournament Hub attention widget. No I/O — ta
 
 - **PriorityAttentionType**: TypeScript type — `'urgent-games' | 'deadline' | 'new-actions-qt' | 'new-actions-awards'`
 - **PriorityAttentionState**: TypeScript interface — `{ type: PriorityAttentionType, urgentCount?: number, firstUrgentGameId?: string, completedCount: number, totalCount: number, qtIncomplete?: boolean, qtCompleted?: number, qtTotal?: number, awardsIncomplete?: boolean, awardsCompleted?: number, awardsTotal?: number }`
-- **computePriorityAttention(data: ActionCenterData)**: `PriorityAttentionState | null` — Priority order: `urgent-games` (mode==='urgent') → `deadline` (tournamentHasStarted && qtAndAwardsOpen && msUntilPredictionLock < 48h && at least one of QT/awards incomplete) → `new-actions-qt` (!tournamentHasStarted && areGroupStageGamesPredicted(data) && qualifiersCompleted===0) → `new-actions-awards` (!tournamentHasStarted && qualifiersCompleted===qualifiersTotal && awardsCompleted===0). Returns null when tournamentFinished or no condition matches.
-  Calls: areGroupStageGamesPredicted
+- **computePriorityAttention(data: ActionCenterData)**: `PriorityAttentionState | null` — Priority order: `urgent-games` (mode==='urgent' AND at least one game has `calculateDeadline(game_date) - now <= 24h`) → `deadline` (tournamentHasStarted && qtAndAwardsOpen && msUntilPredictionLock < 48h && at least one of QT/awards incomplete) → `new-actions-qt` (!tournamentHasStarted && areGroupStageGamesPredicted(data) && qualifiersCompleted===0) → `new-actions-awards` (!tournamentHasStarted && qualifiersCompleted===qualifiersTotal && awardsCompleted===0). Returns null when tournamentFinished or no condition matches. `urgentCount` reflects only the within-24h game count.
+  Calls: calculateDeadline, areGroupStageGamesPredicted
 
 ### app/utils/stage-utils.ts
 Stage-completion detection helpers for the Priority Attention Widget.

--- a/docs/code-structure/utils.md
+++ b/docs/code-structure/utils.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-04-27
+**Last updated:** 2026-04-29
 
 ---
 

--- a/plans/STORY-403-context.md
+++ b/plans/STORY-403-context.md
@@ -9,7 +9,7 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/404
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** implementing
 - **Plan File:** plans/STORY-403-plan.md
 
 ## Quick Summary

--- a/plans/STORY-403-context.md
+++ b/plans/STORY-403-context.md
@@ -1,0 +1,16 @@
+# Story 403 Context
+
+## Metadata
+- **Story Number:** 403
+- **Story Title:** [Story] Limit urgent games banner to 24-hour window
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-403
+- **Branch:** feature/story-403
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-403-plan.md
+
+## Quick Summary
+Change `computePriorityAttention()` in `app/utils/priority-attention.ts` to only return the `urgent-games` banner state (red banner) when at least one unpredicted game's prediction deadline is within 24 hours. Currently, any unpredicted game with an open deadline triggers the red banner even if the game is days away. The fix is a surgical filter that falls through to lower-priority states when no games are imminent. The carousel is unaffected.

--- a/plans/STORY-403-context.md
+++ b/plans/STORY-403-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** [Story] Limit urgent games banner to 24-hour window
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-403
 - **Branch:** feature/story-403
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 404
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/404
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-403-plan.md
+++ b/plans/STORY-403-plan.md
@@ -1,0 +1,134 @@
+# Plan: Story #403 — Limit Urgent Games Banner to 24-Hour Window
+
+## Story
+
+**Issue:** [#403](https://github.com/gvinokur/qatar-prode/issues/403)
+**Title:** [Story] Limit urgent games banner to 24-hour window
+
+## Context
+
+The Action Center's red urgent banner ("X games closing soon") currently fires whenever any unpredicted game with an open deadline exists — even if that game is days away. This creates false urgency and buries other useful states (QT/awards deadlines, stage-transition nudges). The fix: only show the red banner when at least one unpredicted game's deadline is within 24 hours of now.
+
+## Acceptance Criteria
+
+- [ ] The "Games closing soon" urgent banner (red) only triggers if at least one unpredicted game is within 24 hours of its prediction deadline (1h before kickoff).
+- [ ] When unpredicted games exist but are all outside the 24h window, the Action Center naturally falls back to the next priority state.
+- [ ] The behavior is consistent across all tournaments.
+- [ ] The "Upcoming Games" carousel still correctly identifies and highlights these games when they are the primary focus, but doesn't force the "Urgent" banner state at the hub level prematurely.
+
+## Technical Approach
+
+**Root cause:** `computePriorityAttention()` in `app/utils/priority-attention.ts` returns `urgent-games` whenever `data.mode === 'urgent'`, which is set by `getActionCenterGames()` for ANY unpredicted game with an open deadline.
+
+**Fix:** In `computePriorityAttention()`, filter `data.games` to find games whose deadline is ≤ 24h from now. Only return the `urgent-games` state if at least one such game exists; otherwise fall through to lower-priority states.
+
+**Why here (not in `getActionCenterGames`):** The carousel (`games-active-widget`) reads `ActionCenterData.mode` directly — keeping `mode='urgent'` ensures the carousel still shows unpredicted games. Only the banner logic needs to change.
+
+## Files to Create / Modify
+
+| File | Action |
+|------|--------|
+| `app/utils/priority-attention.ts` | Modify — add 24h deadline check |
+| `app/actions/__tests__/hub-actions-priority.test.ts` | Modify — update existing + add new tests |
+| `docs/code-structure/utils.md` | Modify — update `computePriorityAttention` description |
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+No new cross-layer flows. `computePriorityAttention` is still called from the same places. The addition of `calculateDeadline` is internal to `priority-attention.ts`.
+
+### `app/utils/priority-attention.ts` *(modified)*
+
+**New imports/constants:**
+```typescript
+import { calculateDeadline } from './countdown-utils'
+const HOURS_24_MS = 24 * 60 * 60 * 1000
+```
+
+**Changed functions:**
+
+- **computePriorityAttention(data: ActionCenterData)**: `PriorityAttentionState | null` *(behavior change)*
+  Now requires at least one game in `data.games` to have `calculateDeadline(game_date) - now <= 24h` before returning `urgent-games`. Falls through to `buildDeadlineState` when mode='urgent' but no game is within 24h. `urgentCount` now reflects only within-24h games.
+  Calls: calculateDeadline, buildDeadlineState, areGroupStageGamesPredicted
+  Tests:
+  - returns urgent-games when mode=urgent and a game has deadline within 24h
+  - does NOT return urgent-games when mode=urgent but all games > 24h away
+  - urgentCount equals count of within-24h games, not total games in data.games
+  - firstUrgentGameId points to earliest within-24h game
+  - falls through to deadline state when mode=urgent but no games within 24h and deadline condition met
+  - returns null when mode=urgent, no games within 24h, and no other condition matches
+
+## Implementation Steps
+
+### Task 1 — Update `computePriorityAttention` logic
+
+In `app/utils/priority-attention.ts`:
+
+1. Add import: `import { calculateDeadline } from './countdown-utils'`
+2. Add constant: `const HOURS_24_MS = 24 * 60 * 60 * 1000`
+3. Replace the `urgent` branch:
+
+```typescript
+if (data.mode === 'urgent') {
+  const now = Date.now()
+  const within24h = data.games.filter(
+    (g) => calculateDeadline(g.game_date) - now <= HOURS_24_MS
+  )
+  if (within24h.length > 0) {
+    return {
+      type: 'urgent-games',
+      urgentCount: within24h.length,
+      firstUrgentGameId: within24h[0]?.id,
+      completedCount: data.predictedGames,
+      totalCount: data.totalGames,
+    }
+  }
+  // No games within 24h — fall through to lower-priority states
+}
+```
+
+Note: `data.games` when `mode==='urgent'` are already filtered to open deadlines and sorted nearest-first by `getActionCenterGames()`.
+
+**CODE-STRUCTURE files to update:** `docs/code-structure/utils.md` — update `computePriorityAttention` description. Call graph: NO update needed (no new cross-layer flow).
+
+### Task 2 — Update tests
+
+In `app/actions/__tests__/hub-actions-priority.test.ts`:
+
+Add helpers at the top of the describe block:
+```typescript
+const gameWithin24h = (id: string) => ({
+  id,
+  game_date: new Date(Date.now() + 2 * 60 * 60 * 1000), // 2 hours away
+})
+const gameOutside24h = (id: string) => ({
+  id,
+  game_date: new Date(Date.now() + 30 * 60 * 60 * 1000), // 30 hours away
+})
+```
+
+Update existing tests (lines 104–134) to use `gameWithin24h()` instead of `{ id: 'game-1' }`.
+
+Add new tests in `describe('Tier 1 — urgent-games')`:
+- `does NOT return urgent-games when mode=urgent but all games > 24h away`
+- `falls through to deadline state when mode=urgent but no games within 24h`
+- `urgentCount = count of within-24h games (not all games in data.games)`
+- `firstUrgentGameId = earliest within-24h game`
+
+**CODE-STRUCTURE files to update:** None (test file only).
+
+## Testing Strategy
+
+- Unit tests cover all acceptance criteria scenarios (banner shows/hides, fallthrough behavior)
+- Existing test suite for `computePriorityAttention` fully updated — no regressions
+- Run: `npm run test -- hub-actions-priority`
+- Run full suite: `npm run test`
+
+## Validation
+
+- `npm run lint && npm run build` — clean
+- Deploy to Vercel Preview
+- Verify: red banner does NOT appear when all unpredicted games are 2+ days away
+- Verify: red banner DOES appear when a game closes in < 24h
+- Verify: carousel still shows unpredicted games in both cases


### PR DESCRIPTION
Fixes #403

## Summary
Implementation plan for the story.

## Plan Document
See `plans/STORY-403-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)