### PR TITLE
Plan: [Bug] Locked games appear as predictable in header and backend allows saving post-deadline predictions #417

### DIFF
--- a/__tests__/actions/guesses-actions.test.ts
+++ b/__tests__/actions/guesses-actions.test.ts
@@ -66,6 +66,7 @@ const mockFindGroupsInTournament = vi.mocked(tournamentGroupRepository.findGroup
 const mockCalculatePlayoffTeamsFromPositions = vi.mocked(playoffTeamsCalculator.calculatePlayoffTeamsFromPositions);
 const mockFindPlayoffStagesWithGamesInTournament = vi.mocked(tournamentPlayoffRepository.findPlayoffStagesWithGamesInTournament);
 const mockFindGamesInTournament = vi.mocked(gameRepository.findGamesInTournament);
+const mockFindGameById = vi.mocked(gameRepository.findGameById);
 const mockGetAllUserGroupPositionsPredictions = vi.mocked(qualifiedTeamsRepository.getAllUserGroupPositionsPredictions);
 
 describe('Guesses Actions', () => {
@@ -139,6 +140,21 @@ describe('Guesses Actions', () => {
     mockCalculatePlayoffTeamsFromPositions.mockReturnValue(Promise.resolve({}));
     mockUpdateGameGuessByGameId.mockResolvedValue(mockGameGuessResult);
     mockGetAllUserGroupPositionsPredictions.mockResolvedValue([]);
+    // Default: game with open deadline so deadline validation doesn't block existing tests
+    mockFindGameById.mockResolvedValue({
+      id: 'game1',
+      game_date: new Date(Date.now() + 2 * 60 * 60 * 1000),
+      tournament_id: 'tournament1',
+      game_number: 1,
+      home_team: 'team1',
+      away_team: 'team2',
+      location: 'Stadium 1',
+      home_team_rule: undefined,
+      away_team_rule: undefined,
+      game_type: 'group',
+      game_local_timezone: undefined,
+      matchday: null,
+    } as any);
   });
 
   describe('updateOrCreateGameGuesses', () => {

--- a/__tests__/db/game-repository.test.ts
+++ b/__tests__/db/game-repository.test.ts
@@ -12,6 +12,7 @@ import {
   findAllGamesWithPublishedResultsAndGameGuesses,
   findGamesAroundCurrentTime,
   findGamesInNext24Hours,
+  findGamesForDashboard,
 } from '../../app/db/game-repository';
 import { db } from '../../app/db/database';
 import { testFactories } from './test-factories';
@@ -593,6 +594,73 @@ describe('Game Repository', () => {
 
         await expect(deleteAllGamesFromTournament('tournament-1')).rejects.toThrow('Delete failed');
       });
+    });
+  });
+
+  describe('findGamesForDashboard', () => {
+    const ONE_HOUR = 60 * 60 * 1000;
+
+    it('uses game_date >= deadlineFloor (now + 1h) as lower bound', async () => {
+      const mockQuery = {
+        selectAll: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      const before = Date.now();
+      await findGamesForDashboard('tournament-1');
+      const after = Date.now();
+
+      const deadlineFloorCalls = mockQuery.where.mock.calls.filter(
+        ([col, op]: string[]) => col === 'game_date' && op === '>='
+      );
+      expect(deadlineFloorCalls).toHaveLength(1);
+      const passedDate: Date = deadlineFloorCalls[0][2];
+      expect(passedDate.getTime()).toBeGreaterThanOrEqual(before + ONE_HOUR);
+      expect(passedDate.getTime()).toBeLessThanOrEqual(after + ONE_HOUR);
+    });
+
+    it('excludes games with game_date = now + 59min (deadline already passed)', async () => {
+      const lockedGame = testFactories.game({ game_date: new Date(Date.now() + 59 * 60 * 1000) });
+      const mockQuery = {
+        selectAll: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      await findGamesForDashboard('tournament-1');
+
+      const deadlineFloorCalls = mockQuery.where.mock.calls.filter(
+        ([col, op]: string[]) => col === 'game_date' && op === '>='
+      );
+      const floor: Date = deadlineFloorCalls[0][2];
+      expect(lockedGame.game_date.getTime()).toBeLessThan(floor.getTime());
+    });
+
+    it('includes games with game_date = now + 61min (deadline 1min away)', async () => {
+      const openGame = testFactories.game({ game_date: new Date(Date.now() + 61 * 60 * 1000) });
+      const mockQuery = {
+        selectAll: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([openGame]),
+      };
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      await findGamesForDashboard('tournament-1');
+
+      const deadlineFloorCalls = mockQuery.where.mock.calls.filter(
+        ([col, op]: string[]) => col === 'game_date' && op === '>='
+      );
+      const floor: Date = deadlineFloorCalls[0][2];
+      expect(openGame.game_date.getTime()).toBeGreaterThan(floor.getTime());
     });
   });
 

--- a/app/actions/__tests__/guesses-actions.test.ts
+++ b/app/actions/__tests__/guesses-actions.test.ts
@@ -17,6 +17,7 @@ vi.mock('next-intl/server', () => ({
 
 vi.mock('../../db/game-repository', () => ({
   findGamesInTournament: vi.fn(),
+  findGameById: vi.fn(),
 }));
 
 vi.mock('../../db/tournament-group-repository', () => ({
@@ -46,10 +47,15 @@ vi.mock('../../db/database', () => ({
 import { getLoggedInUser } from '../user-actions';
 import { updateOrCreateGuess } from '../../db/game-guess-repository';
 import { getTranslations } from 'next-intl/server';
+import { findGameById } from '../../db/game-repository';
+import { testFactories } from '@/__tests__/db/test-factories';
 
 describe('updateOrCreateGameGuesses', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: open-deadline game so existing success-path tests aren't affected
+    const openGame = testFactories.game({ game_date: new Date(Date.now() + 2 * 60 * 60 * 1000) });
+    vi.mocked(findGameById).mockResolvedValue(openGame as never);
   });
 
   it('success response includes analyticsEvent with name "prediction_submitted" and params { number_of_guesses, game_ids }', async () => {
@@ -102,6 +108,52 @@ describe('updateOrCreateGameGuesses', () => {
     expect(result.success).toBe(false);
     expect(result.error).toBeDefined();
     expect(result.analyticsEvent).toBeUndefined();
+  });
+
+  it('returns predictionClosed error when game deadline has passed', async () => {
+    const mockUser = { id: 'user-1' };
+    const pastDeadlineGame = testFactories.game({ game_date: new Date(Date.now() - 30 * 60 * 1000) });
+    const mockGameGuesses: GameGuessNew[] = [{ game_id: 'game-1', home_score: 2, away_score: 1, user_id: 'user-1' }];
+
+    vi.mocked(getLoggedInUser).mockResolvedValue(mockUser as never);
+    vi.mocked(findGameById).mockResolvedValue(pastDeadlineGame as never);
+    vi.mocked(getTranslations).mockResolvedValue(((key: string) => key) as never);
+
+    const result = await updateOrCreateGameGuesses(mockGameGuesses);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('guess.predictionClosed');
+    expect(result.analyticsEvent).toBeUndefined();
+  });
+
+  it('returns predictionClosed error when game is not found', async () => {
+    const mockUser = { id: 'user-1' };
+    const mockGameGuesses: GameGuessNew[] = [{ game_id: 'nonexistent', home_score: 1, away_score: 0, user_id: 'user-1' }];
+
+    vi.mocked(getLoggedInUser).mockResolvedValue(mockUser as never);
+    vi.mocked(findGameById).mockResolvedValue(null as never);
+    vi.mocked(getTranslations).mockResolvedValue(((key: string) => key) as never);
+
+    const result = await updateOrCreateGameGuesses(mockGameGuesses);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('guess.predictionClosed');
+  });
+
+  it('succeeds when game deadline is still open', async () => {
+    const mockUser = { id: 'user-1' };
+    const openGame = testFactories.game({ game_date: new Date(Date.now() + 2 * 60 * 60 * 1000) });
+    const mockGameGuesses: GameGuessNew[] = [{ game_id: 'game-1', home_score: 2, away_score: 1, user_id: 'user-1' }];
+
+    vi.mocked(getLoggedInUser).mockResolvedValue(mockUser as never);
+    vi.mocked(findGameById).mockResolvedValue(openGame as never);
+    vi.mocked(updateOrCreateGuess).mockResolvedValue({} as never);
+    vi.mocked(getTranslations).mockResolvedValue(((key: string) => key) as never);
+
+    const result = await updateOrCreateGameGuesses(mockGameGuesses);
+
+    expect(result.success).toBe(true);
+    expect(result.analyticsEvent).toBeDefined();
   });
 
   it('analyticsEvent.params.number_of_guesses matches the number of guesses passed in', async () => {

--- a/app/actions/guesses-actions.ts
+++ b/app/actions/guesses-actions.ts
@@ -8,8 +8,9 @@ import {findGroupsInTournament} from "../db/tournament-group-repository";
 import {calculatePlayoffTeamsFromPositions} from "../utils/playoff-teams-calculator";
 import {ExtendedPlayoffRoundData} from "../definitions";
 import {findPlayoffStagesWithGamesInTournament} from "../db/tournament-playoff-repository";
-import {findGamesInTournament} from "../db/game-repository";
+import {findGameById, findGamesInTournament} from "../db/game-repository";
 import {toMap} from "../utils/ObjectUtils";
+import { calculateDeadline } from "../utils/countdown-utils";
 import {db} from "../db/database";
 import { getTranslations } from 'next-intl/server';
 import type { Locale } from '../../i18n.config';
@@ -25,6 +26,16 @@ export async function updateOrCreateGameGuesses(
     if(!user) {
       throw new Error(t('guess.unauthorized'))
     }
+
+    const uniqueGameIds = [...new Set(gameGuesses.map(g => g.game_id))]
+    const now = Date.now()
+    const games = await Promise.all(uniqueGameIds.map(id => findGameById(id)))
+    for (const game of games) {
+      if (!game || calculateDeadline(game.game_date) <= now) {
+        return { success: false, error: t('guess.predictionClosed') }
+      }
+    }
+
     const _createdGameGuesses = await Promise.all(
       gameGuesses.map(gameGuess => {
         return updateOrCreateGuess({

--- a/app/components/__tests__/unified-games-page-client-url-params.test.tsx
+++ b/app/components/__tests__/unified-games-page-client-url-params.test.tsx
@@ -409,6 +409,38 @@ describe('UnifiedGamesPageClient URL Parameter Handling', () => {
     expect(mockSetActiveFilter).toHaveBeenCalledWith('all');
   });
 
+  it('should skip locked game (deadline passed) when ?edit=next and open the next valid unpredicted game', async () => {
+    mockSearchParams.set('edit', 'next');
+    const now = Date.now();
+    // deadline = game_date - 1h; locked game has game_date = now + 30min → deadline = now - 30min (passed)
+    const lockedGame = testFactories.game({ id: 'locked-game', game_date: new Date(now + 30 * 60 * 1000) });
+    // open game has game_date = now + 2h → deadline = now + 1h (open)
+    const openGame = testFactories.game({ id: 'open-game', game_date: new Date(now + 2 * 60 * 60 * 1000) });
+    const tournament = testFactories.tournament();
+    const team = testFactories.team();
+
+    render(
+      <UnifiedGamesPageClient
+        games={[lockedGame, openGame] as any}
+        gameCounts={{ total: 2, predicted: 0, remaining: 2 }}
+        teamsMap={{ [team.id]: team }}
+        tournamentId={tournament.id}
+        groups={[]}
+        rounds={[]}
+        tournament={tournament}
+        closingGames={[]}
+        tournamentPredictionCompletion={null}
+        tournamentStartDate={undefined}
+        qualifiedTeamsHref="/en/tournaments/t1/qualified-teams"
+      />
+    );
+
+    await act(async () => { vi.runAllTimers(); });
+
+    expect(mockTriggerEdit).toHaveBeenCalledWith('open-game');
+    expect(mockTriggerEdit).not.toHaveBeenCalledWith('locked-game');
+  });
+
   it('should do nothing when no edit parameter', () => {
     // No edit parameter in URL
     mockSearchParams.clear();

--- a/app/components/prediction-status-header/__tests__/games-header-variant.test.ts
+++ b/app/components/prediction-status-header/__tests__/games-header-variant.test.ts
@@ -177,7 +177,7 @@ describe('computeGamesHeaderVariant', () => {
     const now = new Date('2026-05-30T18:00:00Z');
     const urgentGame = createMockGame({
       id: 'urgent-3',
-      game_date: new Date('2026-06-01T18:00:00Z'), // 48h away
+      game_date: new Date('2026-06-01T16:00:00Z'), // 46h away — strictly within 48h window
     });
 
     const input = createMockInput({
@@ -191,6 +191,30 @@ describe('computeGamesHeaderVariant', () => {
 
     expect(result.tone).toBe('deadlineSoon');
     expect(result.leadIcon).toBe('info');
+  });
+
+  it('should not trigger urgent-unpredicted for games beyond the 48h threshold', () => {
+    const now = new Date('2026-05-30T18:00:00Z');
+    // Game is exactly 48h away — at the boundary, NOT strictly less than 48h
+    const beyondThresholdGame = createMockGame({
+      id: 'beyond-48h',
+      game_date: new Date('2026-06-01T18:00:00Z'), // exactly 48h away
+    });
+
+    const input = createMockInput({
+      games: [beyondThresholdGame],
+      urgentGames: [beyondThresholdGame],
+      gameGuesses: {},
+      now,
+    });
+
+    const result = computeGamesHeaderVariant(input, mockT);
+
+    // Game at exactly 48h is excluded from unpredictedUrgentGames (strict < threshold)
+    expect(result.tone).not.toBe('deadlineNow');
+    expect(result.tone).not.toBe('deadlineUrgent');
+    expect(result.tone).not.toBe('deadlineSoon');
+    expect(result.leadIcon).not.toBe('info'); // urgent-unpredicted uses 'info'
   });
 
   it('should ignore urgent games with complete guesses', () => {

--- a/app/components/prediction-status-header/__tests__/games-header-variant.test.ts
+++ b/app/components/prediction-status-header/__tests__/games-header-variant.test.ts
@@ -239,6 +239,33 @@ describe('computeGamesHeaderVariant', () => {
     expect(result.tone).toBe('deadlineNow');
   });
 
+  it('should count only games in the most urgent tier, not all unpredicted urgent games', () => {
+    const now = new Date('2026-06-01T17:00:00Z');
+    // 1 game closing in < 2h (deadlineNow)
+    const nowGame = createMockGame({ id: 'now-game', game_number: 10, game_date: new Date('2026-06-01T18:30:00Z') });
+    // 3 games closing in < 24h (deadlineUrgent)
+    const urgentGame1 = createMockGame({ id: 'urgent-1', game_number: 11, game_date: new Date('2026-06-02T10:00:00Z') });
+    const urgentGame2 = createMockGame({ id: 'urgent-2', game_number: 12, game_date: new Date('2026-06-02T12:00:00Z') });
+    const urgentGame3 = createMockGame({ id: 'urgent-3', game_number: 13, game_date: new Date('2026-06-02T14:00:00Z') });
+
+    const input = createMockInput({
+      games: [nowGame, urgentGame1, urgentGame2, urgentGame3],
+      urgentGames: [nowGame, urgentGame1, urgentGame2, urgentGame3],
+      gameGuesses: {},
+      now,
+    });
+
+    const result = computeGamesHeaderVariant(input, mockT);
+
+    expect(result.tone).toBe('deadlineNow');
+    // statusText count must be 1 (only the deadlineNow game), not 4 (all unpredicted urgent)
+    expect(result.statusText).toContain('"count":1');
+    expect(result.statusText).toContain('< 2h');
+    // message only lists game #10 (deadlineNow tier), not the deadlineUrgent games
+    expect(result.message).toContain('"number":10');
+    expect(result.message).not.toContain('"number":11');
+  });
+
   // ── VARIANT 3: pre-groups-complete-nudge-qt ─────────────────────────────────
 
   it('should return pre-groups-complete-nudge-qt when groups done, QT open, QT incomplete', () => {

--- a/app/components/prediction-status-header/games-header-variant.ts
+++ b/app/components/prediction-status-header/games-header-variant.ts
@@ -243,9 +243,11 @@ function prepareData(input: GamesHeaderInput, now: Date): GamesHeaderData {
     && completion.completedGames >= completion.totalGames
     && games.every(g => new Date(g.game_date).getTime() < nowMs);
 
-  const unpredictedUrgentGames = urgentGames.filter(
-    g => !isGuessComplete(gameGuesses[g.id], !!g.playoffStage)
-  );
+  const unpredictedUrgentGames = urgentGames.filter(g => {
+    const msUntilStart = new Date(g.game_date).getTime() - nowMs;
+    return msUntilStart < FORTY_EIGHT_HOURS_MS
+      && !isGuessComplete(gameGuesses[g.id], !!g.playoffStage);
+  });
 
   const groupsComplete = liveCompletedGroupGames >= completion.totalGroupGames && completion.totalGroupGames > 0;
   const qtOpen = !completion.isPredictionLocked;

--- a/app/components/prediction-status-header/games-header-variant.ts
+++ b/app/components/prediction-status-header/games-header-variant.ts
@@ -315,10 +315,13 @@ function buildUrgentUnpredicted(input: GamesHeaderInput, data: GamesHeaderData, 
     tone = 'deadlineSoon';
   }
 
-  const count = unpredictedUrgentGames.length;
-  const window = urgencyWindow(tone as UrgencyLevel);
+  // Only count/show games in the most urgent tier so the window label is accurate
+  const urgencyLevel = tone as UrgencyLevel;
+  const mostUrgentGames = unpredictedUrgentGames.filter(g => getGameUrgencyLevel(g, now) === urgencyLevel);
+  const count = mostUrgentGames.length;
+  const window = urgencyWindow(urgencyLevel);
 
-  const matchups = unpredictedUrgentGames.slice(0, 3).map(g => {
+  const matchups = mostUrgentGames.slice(0, 3).map(g => {
     const home = teamsMap[g.home_team ?? '']?.name;
     const away = teamsMap[g.away_team ?? '']?.name;
     if (home && away) return `${home} vs ${away}`;

--- a/app/components/unified-games-page-client.tsx
+++ b/app/components/unified-games-page-client.tsx
@@ -21,6 +21,7 @@ import { GuessesContext } from './context-providers/guesses-context-provider';
 import { findScrollTarget, scrollToGame } from '../utils/auto-scroll';
 import { isGuessComplete } from '../utils/guess-utils';
 import { EDIT_NEXT_TOKEN } from '../utils/prediction-constants';
+import { calculateDeadline } from '../utils/countdown-utils';
 
 // Timing constants for edit parameter handling
 const DOM_RENDER_DELAY = 50; // ms - small delay for DOM to re-render after filter change
@@ -99,7 +100,8 @@ function UnifiedGamesPageContent({
         const guesses = guessesContext.gameGuesses;
         const now = new Date();
         const unpredictedUpcoming = games.find(
-          g => g.game_date >= now && !isGuessComplete(guesses[g.id], !!g.playoffStage)
+          g => calculateDeadline(g.game_date) > now.getTime()
+            && !isGuessComplete(guesses[g.id], !!g.playoffStage)
         );
         if (unpredictedUpcoming) {
           targetGameId = unpredictedUpcoming.id;

--- a/app/db/game-repository.ts
+++ b/app/db/game-repository.ts
@@ -5,6 +5,7 @@ import {jsonArrayFrom, jsonObjectFrom} from "kysely/helpers/postgres";
 import {sql} from "kysely";
 import {ExtendedGameData} from "../definitions";
 import {cache} from "react";
+import { ONE_HOUR } from "../utils/countdown-utils";
 
 const tableName = 'games'
 
@@ -407,8 +408,8 @@ export const findGamesInNext24Hours = cache(async (tournamentId: string) => {
 
 /**
  * Find games for dashboard display
- * Returns games from last 24 hours (recent results) + next 48 hours (upcoming fixtures & accordion)
- * This unified function replaces both findGamesAroundCurrentTime and findGamesClosingWithin48Hours
+ * Returns only games whose prediction deadline hasn't passed (game_date >= now + 1h),
+ * up to 7 days in the future.
  *
  * ⚠️ RETURNS RAW DATA - i18n fields must be localized in Server Action
  * ⚠️ DO NOT add locale parameter to this function
@@ -418,7 +419,7 @@ export const findGamesInNext24Hours = cache(async (tournamentId: string) => {
  */
 export const findGamesForDashboard = cache(async (tournamentId: string) => {
   const now = new Date();
-  const past24Hours = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const deadlineFloor = new Date(now.getTime() + ONE_HOUR);
   const future7Days = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
 
   return await db.selectFrom(tableName)
@@ -454,8 +455,8 @@ export const findGamesForDashboard = cache(async (tournamentId: string) => {
       ).as('gameResult')
     ])
     .where('tournament_id', '=', tournamentId)
-    // Include games from last 24h (for recent results display)
-    .where('game_date', '>=', past24Hours)
+    // Only games whose prediction deadline hasn't closed (game starts > 1h from now)
+    .where('game_date', '>=', deadlineFloor)
     // Include games up to 7 days in future (covers inter-round gaps in knockout stage)
     .where('game_date', '<=', future7Days)
     .orderBy('game_date', 'asc')

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -101,8 +101,8 @@ Manages tournament betting configuration and payment tracking for friend groups.
 ### app/actions/guesses-actions.ts
 Manages game and tournament predictions (guesses).
 
-- **updateOrCreateGameGuesses(gameGuesses, locale)**: `Promise<{ success: boolean; error?: string; analyticsEvent?: AnalyticsEventPayload }>` — Saves game predictions (upsert). Returns analytics event payload on success.
-  Calls: getLoggedInUser, updateOrCreateGuess, trackEvent
+- **updateOrCreateGameGuesses(gameGuesses, locale)**: `Promise<{ success: boolean; error?: string; analyticsEvent?: AnalyticsEventPayload }>` — Saves game predictions (upsert). Validates each game's deadline before saving; returns `predictionClosed` error if any game deadline has passed. Returns analytics event payload on success.
+  Calls: getLoggedInUser, findGameById, calculateDeadline, updateOrCreateGuess
 - **updateOrCreateTournamentGuess(guess, locale)**: `Promise<TournamentGuess>` — Saves tournament-level prediction.
   Calls: dbUpdateOrCreateTournamentGuess
 - **updatePlayoffGameGuesses(tournamentId, user)**: `Promise<void>` — Recalculates and updates playoff guesses from position predictions.

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-01
+**Last updated:** 2026-05-05
 
 ---
 

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -106,7 +106,7 @@ Repository for games table. Manages game records with group/playoff metadata. Re
 - **findAllGamesWithPublishedResultsAndGameGuesses(forceDrafts: boolean, forceAllGameGuesses: boolean)**: `Promise<GameWithResultAndGuess[]>` — Finds games with published results and unscored guesses (cached).
 - **findGamesAroundCurrentTime(tournamentId: string)**: `Promise<ExtendedGameData[]>` — Finds last 24h results + next 48h upcoming games (cached).
 - **findGamesInNext24Hours(tournamentId: string)**: `Promise<ExtendedGameData[]>` — Finds upcoming games in next 24 hours (secondary sort by game_number, cached).
-- **findGamesForDashboard(tournamentId: string)**: `Promise<ExtendedGameData[]>` — Unified dashboard query: last 24h + next 48h games (secondary sort by game_number, cached).
+- **findGamesForDashboard(tournamentId: string)**: `Promise<ExtendedGameData[]>` — Unified dashboard query: only games whose prediction deadline hasn't closed (`game_date >= now + 1h`), up to 7 days ahead (secondary sort by game_number, cached).
 - **getAllTournamentGames(tournamentId: string)**: `Promise<ExtendedGameData[]>` — Fetches ALL games for unified games page (cached). Sorted by `matchday ASC NULLS LAST, game_date ASC, game_number ASC`.
 - **getTournamentGameCounts(userId: string | null, tournamentId: string)**: `Promise<TournamentGameCounts>` — Counts for filter badges (total, groups, playoffs, unpredicted, closing soon) (cached).
 - **findRecentGamesWithUserGuesses(userId: string, tournamentId: string, limit: number)**: `Promise<RecentGameWithGuess[]>` — Returns games with published (non-draft) results where the user has a guess, ordered by game_date desc and game_number desc, up to `limit` rows. Returns empty array when limit is 0.

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-03
+**Last updated:** 2026-05-05
 
 ---
 

--- a/locales/en/games.json
+++ b/locales/en/games.json
@@ -9,7 +9,8 @@
   "guess": {
     "unauthorized": "Unauthorized action",
     "saveFailed": "Failed to save prediction",
-    "updateFailed": "Failed to update tournament guess"
+    "updateFailed": "Failed to update tournament guess",
+    "predictionClosed": "Prediction deadline has passed"
   },
   "scoreGenerator": {
     "groupNotFound": "Group not found",

--- a/locales/es/games.json
+++ b/locales/es/games.json
@@ -9,7 +9,8 @@
   "guess": {
     "unauthorized": "Acción no autorizada",
     "saveFailed": "Error al guardar la predicción",
-    "updateFailed": "Error al actualizar la predicción del torneo"
+    "updateFailed": "Error al actualizar la predicción del torneo",
+    "predictionClosed": "El tiempo para realizar esta predicción ha finalizado"
   },
   "scoreGenerator": {
     "groupNotFound": "Grupo no encontrado",

--- a/plans/STORY-417-context.md
+++ b/plans/STORY-417-context.md
@@ -1,0 +1,17 @@
+# Story 417 Context
+
+## Metadata
+- **Story Number:** 417
+- **Story Title:** [Bug] Locked games appear as predictable in header and backend allows saving post-deadline predictions
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/cranky-lumiere-96eca3
+- **Branch:** (fill after worktree creation)
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-417-plan.md
+- **Task File:** (fill when implementation starts)
+
+## Quick Summary
+Three targeted fixes for locked-game prediction bugs: (1) filter `unpredictedUrgentGames` in the header by `calculateDeadline` to exclude past-deadline games, (2) fix the `edit=next` client-side navigation to skip games whose deadline has passed, and (3) add a backend deadline guard in `updateOrCreateGameGuesses` that rejects saves for locked games. AC4 (direct URL shows game as non-editable) is already handled by `game-view.tsx`.

--- a/plans/STORY-417-context.md
+++ b/plans/STORY-417-context.md
@@ -9,9 +9,9 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/421
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** review-ready
 - **Plan File:** plans/STORY-417-plan.md
-- **Task File:** (fill when implementation starts)
+- **Task File:** plans/STORY-417-tasks.md
 
 ## Quick Summary
 Three targeted fixes for locked-game prediction bugs: (1) filter `unpredictedUrgentGames` in the header by `calculateDeadline` to exclude past-deadline games, (2) fix the `edit=next` client-side navigation to skip games whose deadline has passed, and (3) add a backend deadline guard in `updateOrCreateGameGuesses` that rejects saves for locked games. AC4 (direct URL shows game as non-editable) is already handled by `game-view.tsx`.

--- a/plans/STORY-417-context.md
+++ b/plans/STORY-417-context.md
@@ -4,9 +4,9 @@
 - **Story Number:** 417
 - **Story Title:** [Bug] Locked games appear as predictable in header and backend allows saving post-deadline predictions
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/cranky-lumiere-96eca3
-- **Branch:** (fill after worktree creation)
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **Branch:** claude/cranky-lumiere-96eca3
+- **PR Number:** 421
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/421
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-417-plan.md
+++ b/plans/STORY-417-plan.md
@@ -17,42 +17,50 @@ After the action-driven `PredictionStatusHeader` was introduced, the "unpredicte
 
 | Bug | Location | Root Cause |
 |-----|----------|------------|
-| Header counts locked games | `games-header-variant.ts:246` | `unpredictedUrgentGames` only filters `!isGuessComplete()` — no deadline check |
-| Predict Next opens locked game | `unified-games-page-client.tsx:101` | Compares `g.game_date >= now` instead of checking the actual deadline (`game_date - 1h`) |
+| Header counts locked games | `game-repository.ts` (`findGamesForDashboard`) | Query returns games from the past 24h; games that have already kicked off flow through as "unpredicted urgent" |
+| Predict Next opens locked game | `unified-games-page-client.tsx:101` | Compares `g.game_date >= now` instead of checking the actual deadline (`game_date - 1h`); works off `getAllTournamentGames`, not `closingGames` |
 | Backend saves past-deadline prediction | `guesses-actions.ts:18` | `updateOrCreateGameGuesses()` has zero deadline validation |
 | Direct URL shows locked game as editable | `game-view.tsx:41` | **Already fixed** — `editDisabled = Date.now() + ONE_HOUR > game.game_date.getTime()` |
 
 ### Why `closingGames` contains locked games
 
-`getGamesClosingWithin48Hours()` → `findGamesForDashboard()` returns games from the last 24h to the next 7 days. Games from the past 24h have already kicked off. The `prepareData()` function in `games-header-variant.ts` passes these straight into `urgentGames` without a deadline filter, so recently-started games with missing predictions appear as actionable.
+`getGamesClosingWithin48Hours()` → `findGamesForDashboard()` currently returns games from the past 24h to the next 7 days. The past-24h window is vestigial — the comment citing "recent results display" is incorrect; that widget uses `findRecentGamesForDashboard` instead. No consumer meaningfully uses games older than their deadline from this query, but they flow through to the header and accumulate as false "unpredicted urgent" entries.
 
 ---
 
 ## Technical Approach
 
-Three targeted fixes, one per bug. No new files.
+Three targeted fixes. No new files.
 
-### Fix 1 — Header: filter locked games out of `unpredictedUrgentGames`
+### Fix 1 — Query: only return games whose deadline hasn't passed
 
-**File:** `app/components/prediction-status-header/games-header-variant.ts`
+**File:** `app/db/game-repository.ts` — `findGamesForDashboard`
 
-Add import for `calculateDeadline` and extend the filter on line 246:
+Replace the `past24Hours` lower bound with `now + ONE_HOUR` (i.e. only games whose prediction deadline hasn't closed):
 
 ```diff
-+import { calculateDeadline } from '../../utils/countdown-utils';
- 
- const unpredictedUrgentGames = urgentGames.filter(
--  g => !isGuessComplete(gameGuesses[g.id], !!g.playoffStage)
-+  g => !isGuessComplete(gameGuesses[g.id], !!g.playoffStage)
-+     && calculateDeadline(new Date(g.game_date)) > nowMs
- );
+ export const findGamesForDashboard = cache(async (tournamentId: string) => {
+   const now = new Date();
+-  const past24Hours = new Date(now.getTime() - 24 * 60 * 60 * 1000);
++  const deadlineFloor = new Date(now.getTime() + ONE_HOUR); // only games still open for prediction
+   const future7Days = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+   return await db.selectFrom(tableName)
+     ...
+-    .where('game_date', '>=', past24Hours)
++    .where('game_date', '>=', deadlineFloor)
+     .where('game_date', '<=', future7Days)
 ```
 
-`nowMs` is already in scope (`const nowMs = now.getTime()` set earlier in `prepareData()`).
+`ONE_HOUR` is already imported from `../utils/countdown-utils` in `game-view.tsx`; import it the same way in `game-repository.ts`.
+
+This fixes bug #1 at the root: `closingGames` will never contain locked games, so the header and any other consumer automatically get the correct set.
 
 ### Fix 2 — Predict Next: skip games whose deadline has passed
 
 **File:** `app/components/unified-games-page-client.tsx`
+
+This fix is still needed independently because `edit=next` works off `games` (from `getAllTournamentGames` — all tournament games), not `closingGames`. A game starting in 30 minutes has `game_date > now` and passes the current filter, but its deadline has already passed.
 
 Import `calculateDeadline` and replace the `game_date >= now` check:
 
@@ -75,7 +83,7 @@ Import `calculateDeadline` and replace the `game_date >= now` check:
 Import `findGameById` and `calculateDeadline`, then validate each game's deadline before persisting:
 
 ```diff
-+import { findGameById, findGamesInTournament } from '../db/game-repository';
++import { findGameById } from '../db/game-repository';
 +import { calculateDeadline } from '../utils/countdown-utils';
  
  export async function updateOrCreateGameGuesses(...) {
@@ -97,7 +105,7 @@ Import `findGameById` and `calculateDeadline`, then validate each game's deadlin
      const _createdGameGuesses = await Promise.all(...)
 ```
 
-**Note:** `findGameById` is already imported in `guesses-actions.ts`'s mock in the test file (the mock stub `findGamesInTournament` is there). We add `findGameById` to the existing `game-repository` import.
+Pattern follows `game-boost-actions.ts` which uses `findGameById` + date check before applying mutations.
 
 ### Fix 4 — Translation keys
 
@@ -127,25 +135,25 @@ Add `predictionClosed` to the `guess` object:
 
 ### Call Graph Changes
 
-No new cross-layer flows. This story adds deadline guards to existing save and display flows.
+No new cross-layer flows. This story narrows an existing DB query and adds deadline guards to existing flows.
 
 **Modified flows:**
-- **games page header flow** — `computeGamesHeaderVariant` now filters `urgentGames` by deadline in addition to completion status
+- **`findGamesForDashboard` → all consumers** — query now returns only open-deadline games, fixing the header upstream without touching display logic
 - **games page edit=next flow** — `useEffect` in `UnifiedGamesPageClient` now uses `calculateDeadline` instead of raw `game_date` comparison
 - **prediction save flow** — `updateOrCreateGameGuesses` now calls `findGameById` per unique game before delegating to `updateOrCreateGuess`
 
 ---
 
-### `app/components/prediction-status-header/games-header-variant.ts` *(modified)*
+### `app/db/game-repository.ts` *(modified)*
 
 **Changed functions:**
 
-- **`prepareData(input: GamesHeaderInput, now: Date): GamesHeaderData`** *(internal, was: no deadline filter on urgent games)*  
-  `unpredictedUrgentGames` now excludes games whose `calculateDeadline(game_date) <= nowMs`.  
+- **`findGamesForDashboard(tournamentId: string): Promise<ExtendedGameData[]>`** *(was: `game_date >= past24Hours`)*  
+  Lower bound changes from 24h in the past to 1h in the future (`game_date >= now + ONE_HOUR`). All consumers that need "closing games" now automatically receive only games still open for prediction.  
   Tests:
-  - game with deadline already passed is excluded from unpredictedUrgentGames even when guess is incomplete
-  - game with deadline in the future AND incomplete guess is included in unpredictedUrgentGames
-  - game with deadline in the future AND complete guess is excluded from unpredictedUrgentGames
+  - returns only games whose `game_date` is at least 1 hour in the future
+  - excludes a game whose `game_date` is exactly `now + 59min` (deadline already passed)
+  - includes a game whose `game_date` is exactly `now + 61min` (deadline 1min away)
 
 ---
 
@@ -156,8 +164,8 @@ No new cross-layer flows. This story adds deadline guards to existing save and d
 - **`useEffect` edit=next handler** *(was: `g.game_date >= now`)*  
   Now uses `calculateDeadline(g.game_date) > now.getTime()` so a game starting in 30 minutes (deadline already passed) is skipped.  
   Tests:
-  - edit=next skips a game whose deadline has passed (game_date = now + 30min) and opens the next valid game
-  - edit=next opens a game whose deadline has not passed (game_date = now + 2h)
+  - edit=next skips a game whose deadline has passed (`game_date = now + 30min`) and opens the next valid game
+  - edit=next opens a game whose deadline has not passed (`game_date = now + 2h`)
   - edit=next falls back to scroll target when all games are either predicted or locked
 
 ---
@@ -181,24 +189,23 @@ No new cross-layer flows. This story adds deadline guards to existing save and d
 
 | File | Change |
 |------|--------|
-| `app/components/prediction-status-header/games-header-variant.ts` | Add `calculateDeadline` import; add deadline check to `unpredictedUrgentGames` filter |
+| `app/db/game-repository.ts` | Change `findGamesForDashboard` lower bound from `past24Hours` to `now + ONE_HOUR` |
 | `app/components/unified-games-page-client.tsx` | Add `calculateDeadline` import; fix `edit=next` game filter |
-| `app/actions/guesses-actions.ts` | Add `findGameById` import; add deadline validation before saving |
+| `app/actions/guesses-actions.ts` | Add `findGameById` + `calculateDeadline` imports; add deadline validation before saving |
 | `locales/en/games.json` | Add `guess.predictionClosed` key |
 | `locales/es/games.json` | Add `guess.predictionClosed` key (Spanish) |
 
 **Files NOT modified:**
+- `app/components/prediction-status-header/games-header-variant.ts` — no longer needs a display-layer fix; query fix handles it upstream
 - `app/components/game-view.tsx` — already handles AC4 correctly
-- `app/db/game-repository.ts` — no new queries needed
-- `app/actions/tournament-actions.ts` / `app/db/game-repository.ts` (`findGamesForDashboard`) — filtering is intentionally broad (past 24h for recent results widget); the fix belongs at the display layer
 
 ---
 
 ## Implementation Steps
 
-1. Modify `games-header-variant.ts` — add import + deadline filter
+1. Modify `findGamesForDashboard` in `game-repository.ts` — change lower bound to `now + ONE_HOUR`
 2. Modify `unified-games-page-client.tsx` — add import + fix `edit=next` filter
-3. Modify `guesses-actions.ts` — add import + deadline validation block
+3. Modify `guesses-actions.ts` — add imports + deadline validation block
 4. Update both locale JSON files — add `guess.predictionClosed`
 5. Update/extend unit tests for all three changed files
 
@@ -208,9 +215,9 @@ No new cross-layer flows. This story adds deadline guards to existing save and d
 
 ### Unit Tests
 
-**`games-header-variant.test.ts`** — add to existing describe block:
-- `urgentGames` containing `testFactories.extendedGameData({ game_date: new Date(now - 30 * 60 * 1000) })` (deadline 90min ago) should not appear in `unpredictedUrgentGames` even when guess is incomplete
-- `testFactories.extendedGameData({ game_date: new Date(now + 2 * 60 * 60 * 1000) })` (deadline in 1h) with incomplete guess → should appear in `unpredictedUrgentGames`
+**`game-repository.test.ts`** (or create if it doesn't exist for this function):
+- `findGamesForDashboard` excludes `testFactories.game({ game_date: new Date(now + 30 * 60 * 1000) })` (deadline already passed)
+- `findGamesForDashboard` includes `testFactories.game({ game_date: new Date(now + 2 * 60 * 60 * 1000) })` (deadline open)
 
 **`unified-games-page-client-url-params.test.tsx`** — add case:
 - When `edit=next` and the first unpredicted game is `testFactories.extendedGameData({ game_date: new Date(now + 30 * 60 * 1000) })` (deadline already passed), it should be skipped in favor of a second game with `game_date = new Date(now + 2 * 60 * 60 * 1000)`
@@ -223,7 +230,7 @@ No new cross-layer flows. This story adds deadline guards to existing save and d
 ### Manual / Integration Verification
 
 1. Deploy to Vercel Preview
-2. Create a test scenario where a game has recently started (game_date = now - 10min):
+2. Create a test scenario where a game has recently started (`game_date = now - 10min`):
    - Visit `/tournaments/[id]/games` → header should NOT show the started game as unpredicted
    - Navigate to `?edit=next` → should skip the started game and open the next valid one
    - Attempt to POST a prediction for the started game via the prediction flow → should receive error "Prediction deadline has passed"
@@ -233,12 +240,12 @@ No new cross-layer flows. This story adds deadline guards to existing save and d
 
 ## Code-Structure Files to Update
 
-- `docs/code-structure/actions.md` — update `updateOrCreateGameGuesses` signature: add `Calls: findGameById, calculateDeadline`
-- `docs/code-structure/components/components-predictions.md` (or games) — note deadline filter added to `prepareData` in `games-header-variant.ts`
+- `docs/code-structure/db.md` — update `findGamesForDashboard`: note the lower bound change from `past24Hours` to `now + ONE_HOUR`
+- `docs/code-structure/actions.md` — update `updateOrCreateGameGuesses`: add `Calls: findGameById, calculateDeadline`
 - Call graph: **No new cross-layer flows** — no call graph changes needed
 
 ---
 
 ## Open Questions
 
-None. Root causes are confirmed, approach is consistent with existing patterns (`game-boost-actions.ts` uses the same `findGameById` + deadline check pattern).
+None. Root causes are confirmed, approach is consistent with existing patterns.

--- a/plans/STORY-417-plan.md
+++ b/plans/STORY-417-plan.md
@@ -246,6 +246,23 @@ No new cross-layer flows. This story narrows an existing DB query and adds deadl
 
 ---
 
+## Implementation Amendments
+
+### Amendment 1: i18n namespace registration
+**Date:** 2026-05-05
+**Reason:** The `games` namespace was used in `guesses-actions.ts` via `getTranslations({ namespace: 'games' })`, but `types/i18n.ts` had never imported it. This caused a runtime error: "missing internationalized text games.guess.predictionClosed".
+**Change:** Added `import games from '@/locales/en/games.json'` and `games: typeof games` to `types/i18n.ts`.
+
+### Amendment 2: Header urgency-count bug fix
+**Date:** 2026-05-05
+**Reason:** User testing revealed that when games spanned multiple urgency tiers, `buildUrgentUnpredicted` used `unpredictedUrgentGames.length` (all urgent games) for `count` but `urgencyWindow(tone)` for `window`. The tone was set to the most-urgent tier, but the count included games from less-urgent tiers.
+**Change:** Modified `buildUrgentUnpredicted` in `games-header-variant.ts` to filter `unpredictedUrgentGames` to `mostUrgentGames` (only those matching `urgencyLevel`) and derive `count`, `window`, and `matchups` from that filtered set.
+
+### Amendment 3: Header 48h upper-bound bug fix
+**Date:** 2026-05-05
+**Reason:** User testing revealed that `deadlineSoon` (48h tier) showed all remaining open games, including those beyond 48h. `FORTY_EIGHT_HOURS_MS` was defined in `games-header-variant.ts` but unused.
+**Change:** Modified `prepareData` in `games-header-variant.ts` to add `msUntilStart < FORTY_EIGHT_HOURS_MS` guard when filtering `unpredictedUrgentGames`. Updated the existing `deadlineSoon` test (which used a game exactly 48h away — now excluded by the strict `<`) to use 46h, and added a new test verifying games at exactly 48h are excluded.
+
 ## Open Questions
 
 None. Root causes are confirmed, approach is consistent with existing patterns.

--- a/plans/STORY-417-plan.md
+++ b/plans/STORY-417-plan.md
@@ -1,0 +1,244 @@
+# Story 417 Plan: Locked games appear as predictable in header and backend allows saving post-deadline predictions
+
+## Context
+
+After the action-driven `PredictionStatusHeader` was introduced, the "unpredicted games" banner stopped filtering out games whose prediction deadline has already passed. This caused three cascading bugs: the header counts locked games as needing predictions, the "Predict Next" button navigates to locked games, and the backend has no deadline guard, so a prediction for a closed game can actually be saved. A fourth concern (direct-URL access showing games as editable) is already handled by `game-view.tsx` and requires no change.
+
+## Acceptance Criteria
+
+- [ ] The header banner does not count games whose deadline has passed as needing a prediction
+- [ ] The "Predict Next" button does not navigate to a game whose deadline has passed
+- [ ] The backend rejects saving a prediction for a game whose deadline has passed
+- [ ] A user reaching a locked game via direct URL sees it as non-editable (already working — no change)
+
+---
+
+## Root Cause Analysis
+
+| Bug | Location | Root Cause |
+|-----|----------|------------|
+| Header counts locked games | `games-header-variant.ts:246` | `unpredictedUrgentGames` only filters `!isGuessComplete()` — no deadline check |
+| Predict Next opens locked game | `unified-games-page-client.tsx:101` | Compares `g.game_date >= now` instead of checking the actual deadline (`game_date - 1h`) |
+| Backend saves past-deadline prediction | `guesses-actions.ts:18` | `updateOrCreateGameGuesses()` has zero deadline validation |
+| Direct URL shows locked game as editable | `game-view.tsx:41` | **Already fixed** — `editDisabled = Date.now() + ONE_HOUR > game.game_date.getTime()` |
+
+### Why `closingGames` contains locked games
+
+`getGamesClosingWithin48Hours()` → `findGamesForDashboard()` returns games from the last 24h to the next 7 days. Games from the past 24h have already kicked off. The `prepareData()` function in `games-header-variant.ts` passes these straight into `urgentGames` without a deadline filter, so recently-started games with missing predictions appear as actionable.
+
+---
+
+## Technical Approach
+
+Three targeted fixes, one per bug. No new files.
+
+### Fix 1 — Header: filter locked games out of `unpredictedUrgentGames`
+
+**File:** `app/components/prediction-status-header/games-header-variant.ts`
+
+Add import for `calculateDeadline` and extend the filter on line 246:
+
+```diff
++import { calculateDeadline } from '../../utils/countdown-utils';
+ 
+ const unpredictedUrgentGames = urgentGames.filter(
+-  g => !isGuessComplete(gameGuesses[g.id], !!g.playoffStage)
++  g => !isGuessComplete(gameGuesses[g.id], !!g.playoffStage)
++     && calculateDeadline(new Date(g.game_date)) > nowMs
+ );
+```
+
+`nowMs` is already in scope (`const nowMs = now.getTime()` set earlier in `prepareData()`).
+
+### Fix 2 — Predict Next: skip games whose deadline has passed
+
+**File:** `app/components/unified-games-page-client.tsx`
+
+Import `calculateDeadline` and replace the `game_date >= now` check:
+
+```diff
++import { calculateDeadline } from '../utils/countdown-utils';
+ 
+ const unpredictedUpcoming = games.find(
+-  g => g.game_date >= now && !isGuessComplete(guesses[g.id], !!g.playoffStage)
++  g => calculateDeadline(g.game_date) > now.getTime()
++     && !isGuessComplete(guesses[g.id], !!g.playoffStage)
+ );
+```
+
+`g.game_date` is a `Date` object in `ExtendedGameData`, so it can be passed directly to `calculateDeadline`.
+
+### Fix 3 — Backend: reject post-deadline predictions
+
+**File:** `app/actions/guesses-actions.ts`
+
+Import `findGameById` and `calculateDeadline`, then validate each game's deadline before persisting:
+
+```diff
++import { findGameById, findGamesInTournament } from '../db/game-repository';
++import { calculateDeadline } from '../utils/countdown-utils';
+ 
+ export async function updateOrCreateGameGuesses(...) {
+   const t = await getTranslations({ locale, namespace: 'games' });
+   try {
+     const user = await getLoggedInUser()
+     if (!user) throw new Error(t('guess.unauthorized'))
+ 
++    // Validate each game's deadline before saving
++    const uniqueGameIds = [...new Set(gameGuesses.map(g => g.game_id))]
++    const now = Date.now()
++    const games = await Promise.all(uniqueGameIds.map(id => findGameById(id)))
++    for (const game of games) {
++      if (!game || calculateDeadline(game.game_date) <= now) {
++        return { success: false, error: t('guess.predictionClosed') }
++      }
++    }
+ 
+     const _createdGameGuesses = await Promise.all(...)
+```
+
+**Note:** `findGameById` is already imported in `guesses-actions.ts`'s mock in the test file (the mock stub `findGamesInTournament` is there). We add `findGameById` to the existing `game-repository` import.
+
+### Fix 4 — Translation keys
+
+**Files:** `locales/en/games.json`, `locales/es/games.json`
+
+Add `predictionClosed` to the `guess` object:
+
+```json
+// en
+"guess": {
+  "unauthorized": "Unauthorized action",
+  "saveFailed": "Failed to save prediction",
+  "updateFailed": "Failed to update tournament guess",
+  "predictionClosed": "Prediction deadline has passed"
+}
+
+// es
+"guess": {
+  ...
+  "predictionClosed": "El tiempo para realizar esta predicción ha finalizado"
+}
+```
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+No new cross-layer flows. This story adds deadline guards to existing save and display flows.
+
+**Modified flows:**
+- **games page header flow** — `computeGamesHeaderVariant` now filters `urgentGames` by deadline in addition to completion status
+- **games page edit=next flow** — `useEffect` in `UnifiedGamesPageClient` now uses `calculateDeadline` instead of raw `game_date` comparison
+- **prediction save flow** — `updateOrCreateGameGuesses` now calls `findGameById` per unique game before delegating to `updateOrCreateGuess`
+
+---
+
+### `app/components/prediction-status-header/games-header-variant.ts` *(modified)*
+
+**Changed functions:**
+
+- **`prepareData(input: GamesHeaderInput, now: Date): GamesHeaderData`** *(internal, was: no deadline filter on urgent games)*  
+  `unpredictedUrgentGames` now excludes games whose `calculateDeadline(game_date) <= nowMs`.  
+  Tests:
+  - game with deadline already passed is excluded from unpredictedUrgentGames even when guess is incomplete
+  - game with deadline in the future AND incomplete guess is included in unpredictedUrgentGames
+  - game with deadline in the future AND complete guess is excluded from unpredictedUrgentGames
+
+---
+
+### `app/components/unified-games-page-client.tsx` *(modified)*
+
+**Changed functions:**
+
+- **`useEffect` edit=next handler** *(was: `g.game_date >= now`)*  
+  Now uses `calculateDeadline(g.game_date) > now.getTime()` so a game starting in 30 minutes (deadline already passed) is skipped.  
+  Tests:
+  - edit=next skips a game whose deadline has passed (game_date = now + 30min) and opens the next valid game
+  - edit=next opens a game whose deadline has not passed (game_date = now + 2h)
+  - edit=next falls back to scroll target when all games are either predicted or locked
+
+---
+
+### `app/actions/guesses-actions.ts` *(modified)*
+
+**Changed functions:**
+
+- **`updateOrCreateGameGuesses(gameGuesses: GameGuessNew[], locale?: Locale): Promise<{...}>`** *(was: no deadline check)*  
+  Adds a pre-save validation step: fetches each unique game by ID in parallel and returns `{ success: false, error: t('guess.predictionClosed') }` if any game's deadline has already passed or game is not found.  
+  Calls: `getLoggedInUser`, `findGameById` (parallel), `calculateDeadline`, `updateOrCreateGuess`  
+  Tests:
+  - returns `{ success: false, error: 'guess.predictionClosed' }` when game deadline has passed
+  - returns `{ success: false, error: 'guess.predictionClosed' }` when game is not found (game_id invalid)
+  - still returns `{ success: true, analyticsEvent }` when all games have open deadlines
+  - returns `{ success: false, error: 'guess.unauthorized' }` when user is not authenticated (existing behavior preserved)
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/components/prediction-status-header/games-header-variant.ts` | Add `calculateDeadline` import; add deadline check to `unpredictedUrgentGames` filter |
+| `app/components/unified-games-page-client.tsx` | Add `calculateDeadline` import; fix `edit=next` game filter |
+| `app/actions/guesses-actions.ts` | Add `findGameById` import; add deadline validation before saving |
+| `locales/en/games.json` | Add `guess.predictionClosed` key |
+| `locales/es/games.json` | Add `guess.predictionClosed` key (Spanish) |
+
+**Files NOT modified:**
+- `app/components/game-view.tsx` — already handles AC4 correctly
+- `app/db/game-repository.ts` — no new queries needed
+- `app/actions/tournament-actions.ts` / `app/db/game-repository.ts` (`findGamesForDashboard`) — filtering is intentionally broad (past 24h for recent results widget); the fix belongs at the display layer
+
+---
+
+## Implementation Steps
+
+1. Modify `games-header-variant.ts` — add import + deadline filter
+2. Modify `unified-games-page-client.tsx` — add import + fix `edit=next` filter
+3. Modify `guesses-actions.ts` — add import + deadline validation block
+4. Update both locale JSON files — add `guess.predictionClosed`
+5. Update/extend unit tests for all three changed files
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+**`games-header-variant.test.ts`** — add to existing describe block:
+- `urgentGames` containing `testFactories.extendedGameData({ game_date: new Date(now - 30 * 60 * 1000) })` (deadline 90min ago) should not appear in `unpredictedUrgentGames` even when guess is incomplete
+- `testFactories.extendedGameData({ game_date: new Date(now + 2 * 60 * 60 * 1000) })` (deadline in 1h) with incomplete guess → should appear in `unpredictedUrgentGames`
+
+**`unified-games-page-client-url-params.test.tsx`** — add case:
+- When `edit=next` and the first unpredicted game is `testFactories.extendedGameData({ game_date: new Date(now + 30 * 60 * 1000) })` (deadline already passed), it should be skipped in favor of a second game with `game_date = new Date(now + 2 * 60 * 60 * 1000)`
+
+**`guesses-actions.test.ts`** — add to existing describe block:
+- Mock `findGameById` to return `testFactories.game({ game_date: new Date(now - 30 * 60 * 1000) })` (game already started) → expect `{ success: false, error: 'guess.predictionClosed' }`
+- Mock `findGameById` to return `null` (invalid game_id) → expect `{ success: false, error: 'guess.predictionClosed' }`
+- Mock `findGameById` to return `testFactories.game({ game_date: new Date(now + 2 * 60 * 60 * 1000) })` (deadline open) → expect `{ success: true }`
+
+### Manual / Integration Verification
+
+1. Deploy to Vercel Preview
+2. Create a test scenario where a game has recently started (game_date = now - 10min):
+   - Visit `/tournaments/[id]/games` → header should NOT show the started game as unpredicted
+   - Navigate to `?edit=next` → should skip the started game and open the next valid one
+   - Attempt to POST a prediction for the started game via the prediction flow → should receive error "Prediction deadline has passed"
+3. Verify a game with `game_date = now + 2h` is still editable in all three paths
+
+---
+
+## Code-Structure Files to Update
+
+- `docs/code-structure/actions.md` — update `updateOrCreateGameGuesses` signature: add `Calls: findGameById, calculateDeadline`
+- `docs/code-structure/components/components-predictions.md` (or games) — note deadline filter added to `prepareData` in `games-header-variant.ts`
+- Call graph: **No new cross-layer flows** — no call graph changes needed
+
+---
+
+## Open Questions
+
+None. Root causes are confirmed, approach is consistent with existing patterns (`game-boost-actions.ts` uses the same `findGameById` + deadline check pattern).

--- a/types/i18n.ts
+++ b/types/i18n.ts
@@ -14,6 +14,7 @@ import tables from '@/locales/en/tables.json';
 import qualifiedTeams from '@/locales/en/qualified-teams.json';
 import pwa from '@/locales/en/pwa.json';
 import hub from '@/locales/en/hub.json';
+import games from '@/locales/en/games.json';
 
 // Merge all namespaces into single type
 type Messages = {
@@ -33,6 +34,7 @@ type Messages = {
   'qualified-teams': typeof qualifiedTeams;
   pwa: typeof pwa;
   hub: typeof hub;
+  games: typeof games;
 };
 
 declare global {


### PR DESCRIPTION
Fixes #417

## Summary
Implementation plan for the story.

## Plan Document
See `plans/STORY-417-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)