### PR TITLE
Plan: [Bug] QT header shows auto-fill banner before group stage matches are complete #426

### DIFF
--- a/app/components/prediction-status-header/__tests__/qt-header-variant.test.ts
+++ b/app/components/prediction-status-header/__tests__/qt-header-variant.test.ts
@@ -185,15 +185,15 @@ describe('computeQTHeaderVariant', () => {
     });
   });
 
-  describe('Variant 6: lock-window-urgent (deadlineNow < 2h)', () => {
-    it('should return deadlineNow tone when lock < 2h away', () => {
-      const lockTime = new Date(now.getTime() + 1.5 * 60 * 60 * 1000); // 1.5h
+  describe('Variant 6: lock-window-urgent', () => {
+    it('groups complete → auto-fill onClick action', () => {
+      const lockTime = new Date(now.getTime() + 1.5 * 60 * 60 * 1000); // 1.5h → deadlineNow
       const input = baseInput({
         isLocked: false,
         qualifiersCompleted: 3,
         qualifiersTotal: 8,
         qtLockAt: lockTime,
-        predictedGroupGames: 4,
+        predictedGroupGames: 8,
         totalGroupGames: 8,
         now,
       });
@@ -203,10 +203,77 @@ describe('computeQTHeaderVariant', () => {
       expect(result.tone).toBe('deadlineNow');
       expect(result.leadIcon).toBe('error');
       expect(result.statusText).toContain('statusHeader.qt.lockWindowUrgent.status');
-      expect(result.message).toBeDefined();
-      expect(result.action).toBeDefined();
+      expect(result.message).toContain('statusHeader.qt.lockWindowUrgent.message');
       expect(result.action?.onClick).toBeDefined();
+      expect(result.action?.href).toBeUndefined();
       expect(result.chip).toBeDefined();
+    });
+
+    it('groups NOT complete (partial) → predict-matches href action', () => {
+      const lockTime = new Date(now.getTime() + 1.5 * 60 * 60 * 1000); // 1.5h → deadlineNow
+      const input = baseInput({
+        isLocked: false,
+        qualifiersCompleted: 3,
+        qualifiersTotal: 8,
+        qtLockAt: lockTime,
+        predictedGroupGames: 5,
+        totalGroupGames: 8,
+        locale: 'en',
+        tournamentId: 'test-tournament',
+        now,
+      });
+
+      const result = computeQTHeaderVariant(input, mockT);
+
+      expect(result.tone).toBe('deadlineNow');
+      expect(result.leadIcon).toBe('error');
+      expect(result.statusText).toContain('statusHeader.qt.lockWindowUrgent.status');
+      expect(result.message).toContain('statusHeader.qt.lockWindowUrgentGroupsIncomplete.message');
+      expect(result.action?.href).toContain('/tournaments/test-tournament/games');
+      expect(result.action?.onClick).toBeUndefined();
+      expect(result.chip).toBeDefined();
+    });
+
+    it('groups NOT complete (zero predictions) → predict-matches href action', () => {
+      const lockTime = new Date(now.getTime() + 12 * 60 * 60 * 1000); // 12h → deadlineUrgent
+      const input = baseInput({
+        isLocked: false,
+        qualifiersCompleted: 0,
+        qualifiersTotal: 8,
+        qtLockAt: lockTime,
+        predictedGroupGames: 0,
+        totalGroupGames: 8,
+        locale: 'en',
+        tournamentId: 'test-tournament',
+        now,
+      });
+
+      const result = computeQTHeaderVariant(input, mockT);
+
+      expect(result.tone).toBe('deadlineUrgent');
+      expect(result.message).toContain('statusHeader.qt.lockWindowUrgentGroupsIncomplete.message');
+      expect(result.action?.href).toContain('/tournaments/test-tournament/games');
+      expect(result.action?.onClick).toBeUndefined();
+    });
+
+    it('totalGroupGames=0 → falls into groups-incomplete branch', () => {
+      const lockTime = new Date(now.getTime() + 1.5 * 60 * 60 * 1000);
+      const input = baseInput({
+        isLocked: false,
+        qtLockAt: lockTime,
+        predictedGroupGames: 0,
+        totalGroupGames: 0,
+        locale: 'en',
+        tournamentId: 'test-tournament',
+        now,
+      });
+
+      const result = computeQTHeaderVariant(input, mockT);
+
+      // groupsAllPredicted = false when totalGroupGames=0 (guard fails)
+      expect(result.message).toContain('statusHeader.qt.lockWindowUrgentGroupsIncomplete.message');
+      expect(result.action?.href).toContain('/tournaments/test-tournament/games');
+      expect(result.action?.onClick).toBeUndefined();
     });
   });
 

--- a/app/components/prediction-status-header/__tests__/qt-header-variant.test.ts
+++ b/app/components/prediction-status-header/__tests__/qt-header-variant.test.ts
@@ -161,11 +161,11 @@ describe('computeQTHeaderVariant', () => {
   });
 
   describe('Variant 5: completed-pre-lock', () => {
-    it('should return success tone with check icon when all predictions completed before lock', () => {
+    it('qualifiers complete + groups complete → success with Recalculate CTA', () => {
       const lockTime = new Date(now.getTime() + 12 * 60 * 60 * 1000); // 12h away
       const input = baseInput({
         isLocked: false,
-        predictedGroupGames: 8, // groups must also be complete to show Recalcular
+        predictedGroupGames: 8,
         totalGroupGames: 8,
         qualifiersCompleted: 8,
         qualifiersTotal: 8,
@@ -178,9 +178,29 @@ describe('computeQTHeaderVariant', () => {
       expect(result.tone).toBe('success');
       expect(result.leadIcon).toBe('check');
       expect(result.statusText).toContain('statusHeader.qt.completedPreLock.status');
-      expect(result.action).toBeDefined();
       expect(result.action?.onClick).toBeDefined();
       expect(result.action?.href).toBeUndefined();
+      expect(result.chip).toBeDefined();
+    });
+
+    it('qualifiers complete + groups NOT complete → success with no CTA', () => {
+      const lockTime = new Date(now.getTime() + 12 * 60 * 60 * 1000); // 12h away (urgent)
+      const input = baseInput({
+        isLocked: false,
+        predictedGroupGames: 5,
+        totalGroupGames: 8,
+        qualifiersCompleted: 8,
+        qualifiersTotal: 8,
+        qtLockAt: lockTime,
+        now,
+      });
+
+      const result = computeQTHeaderVariant(input, mockT);
+
+      expect(result.tone).toBe('success');
+      expect(result.leadIcon).toBe('check');
+      expect(result.statusText).toContain('statusHeader.qt.completedPreLock.status');
+      expect(result.action).toBeUndefined();
       expect(result.chip).toBeDefined();
     });
   });

--- a/app/components/prediction-status-header/qt-header-variant.ts
+++ b/app/components/prediction-status-header/qt-header-variant.ts
@@ -114,8 +114,8 @@ function computeLockedQTVariant(
 /**
  * Computes the PredictionStatusHeader variant for the Qualified Teams page.
  * Priority: never-filled-locked → locked-with-results → locked-pending →
- *           completed-pre-lock → lock-window-urgent → pre-tournament-auto-fill-ready
- *           → pre-tournament-urgent → pre-tournament
+ *           completed-pre-lock → lock-window-urgent (groups complete OR incomplete) →
+ *           pre-tournament-auto-fill-ready → pre-tournament
  */
 export function computeQTHeaderVariant(input: QTHeaderInput, t: TFunction): StatusHeaderVariant {
   const now = input.now ?? new Date();
@@ -153,23 +153,35 @@ export function computeQTHeaderVariant(input: QTHeaderInput, t: TFunction): Stat
     };
   }
 
+  // Hoist before Variant 5 so the urgency branch can gate on group completion
+  const groupsAllPredicted = predictedGroupGames >= totalGroupGames && totalGroupGames > 0;
+
   // ── VARIANT 5: lock-window-urgent ───────────────────────────────────────────
   const urgencyTone = qtLockAt ? computeQTLockUrgency(qtLockAt, now) : 'brand';
   const isUrgent = urgencyTone !== 'brand';
   if (isUrgent) {
     const countdown = qtLockAt ? countdownLabel(qtLockAt, now) : '—';
+    if (groupsAllPredicted) {
+      return {
+        tone: urgencyTone,
+        leadIcon: urgencyIcon(urgencyTone),
+        statusText: t('statusHeader.qt.lockWindowUrgent.status', { countdown }),
+        chip,
+        message: t('statusHeader.qt.lockWindowUrgent.message', { countdown }),
+        action: { label: t('statusHeader.qt.lockWindowUrgent.cta'), onClick: onAutoFillClick },
+      };
+    }
     return {
       tone: urgencyTone,
       leadIcon: urgencyIcon(urgencyTone),
       statusText: t('statusHeader.qt.lockWindowUrgent.status', { countdown }),
       chip,
-      message: t('statusHeader.qt.lockWindowUrgent.message', { countdown }),
-      action: { label: t('statusHeader.qt.lockWindowUrgent.cta'), onClick: onAutoFillClick },
+      message: t('statusHeader.qt.lockWindowUrgentGroupsIncomplete.message', { countdown }),
+      action: { label: t('statusHeader.qt.lockWindowUrgentGroupsIncomplete.cta'), href: `/${locale}/tournaments/${tournamentId}/games?edit=next` },
     };
   }
 
   // ── VARIANT 6: pre-tournament-auto-fill-ready ────────────────────────────────
-  const groupsAllPredicted = predictedGroupGames >= totalGroupGames && totalGroupGames > 0;
   if (groupsAllPredicted) {
     return {
       tone: 'brand',

--- a/app/components/prediction-status-header/qt-header-variant.ts
+++ b/app/components/prediction-status-header/qt-header-variant.ts
@@ -138,23 +138,23 @@ export function computeQTHeaderVariant(input: QTHeaderInput, t: TFunction): Stat
     );
   }
 
+  const groupsAllPredicted = predictedGroupGames >= totalGroupGames && totalGroupGames > 0;
+  const qualifiersComplete = qualifiersCompleted >= qualifiersTotal && qualifiersTotal > 0;
+
   // ── VARIANT 4: completed-pre-lock ───────────────────────────────────────────
-  // Require group games to be complete — if user hasn't finished groups, don't show Recalcular
-  const groupsComplete = totalGroupGames > 0 && predictedGroupGames >= totalGroupGames;
-  const qtComplete = groupsComplete && qualifiersCompleted >= qualifiersTotal && qualifiersTotal > 0;
-  if (qtComplete) {
+  // Fires whenever all qualifier slots are filled — user is in a good state regardless of
+  // whether group games are all predicted. Recalculate CTA only shown when groups are also
+  // done (auto-fill needs group standings to work).
+  if (qualifiersComplete) {
     const countdown = qtLockAt ? countdownLabel(qtLockAt, now) : '—';
     return {
       tone: 'success',
       leadIcon: 'check',
       statusText: t('statusHeader.qt.completedPreLock.status', { countdown }),
       chip,
-      action: { label: t('statusHeader.qt.completedPreLock.cta'), onClick: onAutoFillClick },
+      ...(groupsAllPredicted && { action: { label: t('statusHeader.qt.completedPreLock.cta'), onClick: onAutoFillClick } }),
     };
   }
-
-  // Hoist before Variant 5 so the urgency branch can gate on group completion
-  const groupsAllPredicted = predictedGroupGames >= totalGroupGames && totalGroupGames > 0;
 
   // ── VARIANT 5: lock-window-urgent ───────────────────────────────────────────
   const urgencyTone = qtLockAt ? computeQTLockUrgency(qtLockAt, now) : 'brand';

--- a/docs/code-structure/components/components-tournament-games.md
+++ b/docs/code-structure/components/components-tournament-games.md
@@ -266,7 +266,7 @@ Pure selector functions for the Games prediction page header variant.
 
 **File:** `app/components/prediction-status-header/qt-header-variant.ts`
 Pure selector function for the Qualified Teams prediction page header variant.
-- **computeQTHeaderVariant(input: QTHeaderInput, t: TFunction)**: `StatusHeaderVariant` — Priority: never-filled-locked → locked-with-results → locked-pending → completed-pre-lock → lock-window-urgent → pre-tournament-auto-fill-ready → pre-tournament
+- **computeQTHeaderVariant(input: QTHeaderInput, t: TFunction)**: `StatusHeaderVariant` — Priority: never-filled-locked → locked-with-results → locked-pending → completed-pre-lock → lock-window-urgent (groups complete: auto-fill CTA; groups incomplete: predict-matches href) → pre-tournament-auto-fill-ready → pre-tournament
 - **computeQTLockUrgency(qtLockAt: Date, now: Date)**: `StatusHeaderTone` — < 2h → deadlineNow, < 24h → deadlineUrgent, < 48h → deadlineSoon, else → brand
 - **QTHeaderInput** (interface) — isLocked, qtLockAt, predictedGroupGames, totalGroupGames, qualifiersCompleted, qualifiersTotal, definedSoFar, correctSoFar, qtPointsEarned?, onAutoFillClick, tournamentId, locale, now?
 

--- a/docs/code-structure/components/components-tournament-games.md
+++ b/docs/code-structure/components/components-tournament-games.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-04
+**Last updated:** 2026-05-07
 
 ---
 
@@ -266,7 +266,7 @@ Pure selector functions for the Games prediction page header variant.
 
 **File:** `app/components/prediction-status-header/qt-header-variant.ts`
 Pure selector function for the Qualified Teams prediction page header variant.
-- **computeQTHeaderVariant(input: QTHeaderInput, t: TFunction)**: `StatusHeaderVariant` — Priority: never-filled-locked → locked-with-results → locked-pending → completed-pre-lock → lock-window-urgent (groups complete: auto-fill CTA; groups incomplete: predict-matches href) → pre-tournament-auto-fill-ready → pre-tournament
+- **computeQTHeaderVariant(input: QTHeaderInput, t: TFunction)**: `StatusHeaderVariant` — Priority: never-filled-locked → locked-with-results → locked-pending → completed-pre-lock (qualifiers done regardless of group progress; Recalculate CTA only when groups also done) → lock-window-urgent (groups complete: auto-fill CTA; groups incomplete: predict-matches href) → pre-tournament-auto-fill-ready → pre-tournament
 - **computeQTLockUrgency(qtLockAt: Date, now: Date)**: `StatusHeaderTone` — < 2h → deadlineNow, < 24h → deadlineUrgent, < 48h → deadlineSoon, else → brand
 - **QTHeaderInput** (interface) — isLocked, qtLockAt, predictedGroupGames, totalGroupGames, qualifiersCompleted, qualifiersTotal, definedSoFar, correctSoFar, qtPointsEarned?, onAutoFillClick, tournamentId, locale, now?
 

--- a/locales/en/predictions.json
+++ b/locales/en/predictions.json
@@ -199,6 +199,10 @@
         "message": "Your qualifiers lock in {countdown}. Auto-fill from your groups or choose manually.",
         "cta": "Auto-fill"
       },
+      "lockWindowUrgentGroupsIncomplete": {
+        "message": "Qualifiers lock in {countdown}. You can pick them manually now — you don't need to finish your group predictions first.",
+        "cta": "Predict Matches"
+      },
       "completedPreLock": {
         "status": "Qualifiers ready · lock in {countdown}",
         "cta": "Recalculate"

--- a/locales/es/predictions.json
+++ b/locales/es/predictions.json
@@ -199,6 +199,10 @@
         "message": "Tus clasificados cierran en {countdown}. Auto-completá desde tus grupos o elegí manualmente.",
         "cta": "Auto-completar"
       },
+      "lockWindowUrgentGroupsIncomplete": {
+        "message": "Los clasificados cierran en {countdown}. Podés elegirlos manualmente ahora — no necesitás terminar de predecir los partidos de grupos primero.",
+        "cta": "Predecir Partidos"
+      },
       "completedPreLock": {
         "status": "Clasificados listos · cierran en {countdown}",
         "cta": "Recalcular"

--- a/plans/STORY-426-context.md
+++ b/plans/STORY-426-context.md
@@ -1,0 +1,17 @@
+# Story 426 Context
+
+## Metadata
+- **Story Number:** 426
+- **Story Title:** [Bug] QT header shows auto-fill banner before group stage matches are complete
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/hungry-mayer-52fe39
+- **Branch:** claude/hungry-mayer-52fe39
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-426-plan.md
+- **Task File:** (fill when implementation starts)
+
+## Quick Summary
+Adds a new "group stage in progress" variant to the QT prediction status header. When the tournament has started but actual group standings aren't yet finalized, the auto-fill banner is suppressed in favor of an informational message. Two optional boolean flags (`tournamentStarted`, `groupStageComplete`) are added to `QTHeaderInput` with safe defaults, so existing tests and callers are unaffected.

--- a/plans/STORY-426-context.md
+++ b/plans/STORY-426-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** [Bug] QT header shows auto-fill banner before group stage matches are complete
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/hungry-mayer-52fe39
 - **Branch:** claude/hungry-mayer-52fe39
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 429
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/429
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-426-context.md
+++ b/plans/STORY-426-context.md
@@ -14,4 +14,4 @@
 - **Task File:** (fill when implementation starts)
 
 ## Quick Summary
-Adds a new "group stage in progress" variant to the QT prediction status header. When the tournament has started but actual group standings aren't yet finalized, the auto-fill banner is suppressed in favor of an informational message. Two optional boolean flags (`tournamentStarted`, `groupStageComplete`) are added to `QTHeaderInput` with safe defaults, so existing tests and callers are unaffected.
+Adds a new "group stage in progress" variant (6a) to the QT prediction status header. When the tournament has started but actual group standings aren't yet finalized, the auto-fill banner is suppressed in favor of an informational message. Two optional boolean flags (`tournamentStarted`, `groupStageComplete`) are added to `QTHeaderInput` with safe defaults, so existing tests and callers are unaffected.

--- a/plans/STORY-426-plan.md
+++ b/plans/STORY-426-plan.md
@@ -2,19 +2,23 @@
 
 ## Context
 
-The Qualified Teams (QT) status header uses `computeQTHeaderVariant()` to decide which message to show. Variant 6 ("pre-tournament-auto-fill-ready") fires whenever `predictedGroupGames >= totalGroupGames` — meaning the user has predicted all group stage games. This condition is checked with no awareness of whether the tournament has started or whether group games are still being played in real life.
+The Qualified Teams (QT) status header uses `computeQTHeaderVariant()` to decide which message to show. **Variant 5 (lock-window-urgent)** fires whenever the lock deadline is approaching, and unconditionally shows an auto-fill CTA regardless of whether the user has finished predicting group games.
 
-**The Bug**: If a user predicts all group games before the tournament starts, then the tournament starts and group stage matches begin playing, Variant 6 continues to show the "auto-fill available" banner. The banner should instead be suppressed while actual group games are in progress, showing a "group stage in progress" message instead.
+**The Bug**: After a tournament starts and the qualifier lock window becomes active, a user who has NOT finished predicting group games still sees the auto-fill banner. The auto-fill option is only meaningful once group predictions are complete (it fills qualifiers based on group standings), so showing it before that is incorrect and confusing.
 
-**The Fix**: Add two optional flags to `QTHeaderInput` — `tournamentStarted` and `groupStageComplete` — and insert a new Variant 6a that intercepts the auto-fill banner path when the tournament has started but group stage hasn't been finalized yet.
+**The Fix**: Move `groupsAllPredicted` computation before Variant 5, then split Variant 5 into two sub-cases based on whether the user has completed group predictions — mirroring the non-urgent split between Variant 6 (auto-fill ready) and Variant 7/8 (pre-tournament):
+
+- **Variant 5, groups complete**: current urgency + auto-fill CTA, message updated with more urgency
+- **Variant 5, groups NOT complete**: same urgency tone, but CTA becomes "Predict Matches" (link to games page), message conveys urgency while clarifying they don't need to finish group predictions to pick qualifiers
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] When tournament started + QT open + group stage not finalized (`!allGroupsComplete`) + user predicted all groups → QT header shows "group stage in progress" message, NOT auto-fill banner
-- [ ] Pre-tournament + all group games predicted → still shows auto-fill banner (no regression)
-- [ ] After group stage finalized (`allGroupsComplete=true`) + all group games predicted → auto-fill banner shows correctly
+- [ ] Urgent + groups NOT complete → no auto-fill button; shows "Predict Matches" CTA; message is urgent but clarifies user can pick qualifiers manually
+- [ ] Urgent + groups complete → auto-fill CTA present; urgency conveyed in message (no regression)
+- [ ] Non-urgent + groups complete → auto-fill banner unchanged (Variant 6, no regression)
+- [ ] Non-urgent + groups NOT complete → pre-tournament fallback unchanged (Variant 7/8, no regression)
 - [ ] Games header behavior is unchanged
 - [ ] Works in EN and ES locales
 
@@ -24,46 +28,34 @@ The Qualified Teams (QT) status header uses `computeQTHeaderVariant()` to decide
 
 ### Root Cause
 
-In `app/components/prediction-status-header/qt-header-variant.ts:172`:
+In `app/components/prediction-status-header/qt-header-variant.ts`, `groupsAllPredicted` is currently computed **after** Variant 5:
 
 ```typescript
+// ── VARIANT 5: lock-window-urgent ───────────────────────────────────────────
+if (isUrgent) {
+  // always shows auto-fill CTA — no check on groupsAllPredicted
+  return { ..., action: { label: t('...autoFill.cta'), onClick: onAutoFillClick } };
+}
+
 // ── VARIANT 6: pre-tournament-auto-fill-ready ────────────────────────────────
 const groupsAllPredicted = predictedGroupGames >= totalGroupGames && totalGroupGames > 0;
-if (groupsAllPredicted) {
-  return { /* auto-fill banner */ };
-}
 ```
 
-No knowledge of tournament start or group stage completion.
+`groupsAllPredicted` needs to be hoisted before Variant 5 so it can gate the auto-fill action.
 
-### Data Already Available in Client Page
+### No Interface Changes
 
-`QualifiedTeamsClientPage` already receives as props (both from the server page):
-- `allGroupsComplete: boolean` — `true` when all groups have DB-finalized standings (`is_complete=true` in `tournament_group_teams`)
-- `tournamentStartDate?: Date` — earliest game date across all tournament games
+`QTHeaderInput` already has `predictedGroupGames` and `totalGroupGames`. No new props needed. No changes to the client page.
 
-Neither is currently passed to `computeQTHeaderVariant`.
-
-### Solution: Two New Optional Fields on `QTHeaderInput`
-
-Add `tournamentStarted?: boolean` (default `false`) and `groupStageComplete?: boolean` (default `false`) to `QTHeaderInput`. Defaults preserve all existing test and caller behavior unchanged.
-
-**New variant priority order after fix:**
+### Fix: Hoist + Split Variant 5
 
 ```
-locked → completed-pre-lock → lock-window-urgent
-  → [NEW] group-stage-in-progress  (tournamentStarted && !groupStageComplete && groupsAllPredicted)
-  → pre-tournament-auto-fill-ready (!tournamentStarted || groupStageComplete) && groupsAllPredicted
+locked → completed-pre-lock
+  → urgent + groups complete    → auto-fill CTA (urgency message)
+  → urgent + groups incomplete  → "Predict Matches" CTA (urgency + "no need to finish groups")
+  → auto-fill ready (non-urgent, groups complete)
   → pre-tournament (fallback)
 ```
-
-New variant characteristics:
-- Tone: `'calm'`
-- Icon: `'info'`
-- Status: `statusHeader.qt.groupStageInProgress.status`
-- Message: `statusHeader.qt.groupStageInProgress.message`
-- Shows chip (qualifier count)
-- No action button
 
 ---
 
@@ -71,12 +63,11 @@ New variant characteristics:
 
 | File | Change |
 |------|--------|
-| `app/components/prediction-status-header/qt-header-variant.ts` | Add `tournamentStarted?` and `groupStageComplete?` to `QTHeaderInput`; add new variant branch |
-| `app/components/qualified-teams/qualified-teams-client-page.tsx` | Pass `tournamentStarted` and `groupStageComplete` in `computeQTHeaderVariant` call; update useMemo deps |
-| `locales/en/predictions.json` | Add `statusHeader.qt.groupStageInProgress.status` and `.message` |
+| `app/components/prediction-status-header/qt-header-variant.ts` | Hoist `groupsAllPredicted` before Variant 5; split Variant 5 on `groupsAllPredicted` |
+| `locales/en/predictions.json` | Add `statusHeader.qt.lockWindowUrgentGroupsIncomplete` keys; optionally update `lockWindowUrgent.message` for more urgency |
 | `locales/es/predictions.json` | Spanish translations for the same keys |
-| `app/components/prediction-status-header/__tests__/qt-header-variant.test.ts` | New tests for group-stage-in-progress variant |
-| `docs/code-structure/components/components-leaderboard-stats.md` | Update `QTHeaderInput` signature |
+| `app/components/prediction-status-header/__tests__/qt-header-variant.test.ts` | New tests for the split Variant 5 |
+| `docs/code-structure/components/components-leaderboard-stats.md` | No signature change; update variant description comment if present |
 
 ---
 
@@ -84,79 +75,55 @@ New variant characteristics:
 
 ### Call Graph Changes
 
-No call graph changes. `computeQTHeaderVariant` already exists in the call graph; only its input signature and internal branching change.
+No call graph changes.
 
 ---
 
 ### `app/components/prediction-status-header/qt-header-variant.ts` *(modified)*
 
-**Changed interface:**
-
-```typescript
-export interface QTHeaderInput {
-  // ... existing fields unchanged ...
-  /** True once the tournament's first game date has passed. Defaults to false (pre-tournament behavior). */
-  tournamentStarted?: boolean;
-  /** True once all groups in the tournament have finalized standings (allGroupsComplete from DB). Defaults to false. */
-  groupStageComplete?: boolean;
-}
-```
-
 **Changed function: `computeQTHeaderVariant(input: QTHeaderInput, t: TFunction)`**
 
-After Variant 5 (lock-window-urgent), before existing Variant 6:
+Hoist `groupsAllPredicted` and move the Variant 5 split:
 
 ```typescript
-// ── VARIANT 6a: group-stage-in-progress ──────────────────────────────────────
-// Suppress auto-fill banner while actual group games are still being played
-const tournamentStarted = input.tournamentStarted ?? false;
-const groupStageComplete = input.groupStageComplete ?? false;
-if (groupsAllPredicted && tournamentStarted && !groupStageComplete) {
+// hoist before Variant 5
+const groupsAllPredicted = predictedGroupGames >= totalGroupGames && totalGroupGames > 0;
+
+// ── VARIANT 5: lock-window-urgent ───────────────────────────────────────────
+if (isUrgent) {
+  const countdown = qtLockAt ? countdownLabel(qtLockAt, now) : '—';
+  if (groupsAllPredicted) {
+    return {
+      tone: urgencyTone,
+      leadIcon: urgencyIcon(urgencyTone),
+      statusText: t('statusHeader.qt.lockWindowUrgent.status', { countdown }),
+      chip,
+      message: t('statusHeader.qt.lockWindowUrgent.message', { countdown }),
+      action: { label: t('statusHeader.qt.lockWindowUrgent.cta'), onClick: onAutoFillClick },
+    };
+  }
   return {
-    tone: 'calm',
-    leadIcon: 'info',
-    statusText: t('statusHeader.qt.groupStageInProgress.status'),
+    tone: urgencyTone,
+    leadIcon: urgencyIcon(urgencyTone),
+    statusText: t('statusHeader.qt.lockWindowUrgent.status', { countdown }),
     chip,
-    message: t('statusHeader.qt.groupStageInProgress.message'),
+    message: t('statusHeader.qt.lockWindowUrgentGroupsIncomplete.message', { countdown }),
+    action: { label: t('statusHeader.qt.lockWindowUrgentGroupsIncomplete.cta'), href: `/${locale}/tournaments/${tournamentId}/games?edit=next` },
   };
 }
+
+// ── VARIANT 6: pre-tournament-auto-fill-ready ────────────────────────────────
+// (groupsAllPredicted already computed above — remove the duplicate declaration)
+if (groupsAllPredicted) { ... }
 ```
 
-Existing Variant 6 check is unchanged — it naturally fires for pre-tournament (`!tournamentStarted`) and post-group-stage (`groupStageComplete`) cases.
-
 Tests:
-- fires when `tournamentStarted=true`, `groupStageComplete=false`, all groups predicted
-- does NOT fire when `tournamentStarted=false` (pre-tournament → shows auto-fill instead)
-- does NOT fire when `groupStageComplete=true` (post-group-stage → shows auto-fill instead)
-- does NOT fire when groups not fully predicted (falls through to pre-tournament fallback)
-- shows chip, has message, has NO action button
-- does NOT fire when `totalGroupGames=0` (guarded by `totalGroupGames > 0` in `groupsAllPredicted`)
-
----
-
-### `app/components/qualified-teams/qualified-teams-client-page.tsx` *(modified)*
-
-**Changed: `qtHeaderVariant` useMemo** — pass two new fields:
-
-```typescript
-const qtHeaderVariant = useMemo(
-  () => computeQTHeaderVariant(
-    {
-      // ... existing fields unchanged ...
-      tournamentStarted: !!tournamentStartDate && new Date() >= tournamentStartDate,
-      groupStageComplete: allGroupsComplete,
-    },
-    tPredictions as (key: string, values?: Record<string, unknown>) => string
-  ),
-  [isLocked, qtLockAt, tournamentPredictionCompletion, qualifiedTeamsCompleted,
-   actualResults, correctSoFar, scoringBreakdown, locale, allGroupsComplete, tournamentStartDate]
-);
-```
-
-`allGroupsComplete` and `tournamentStartDate` are already props — no server page changes needed.
-
-Tests:
-- (existing tests unchanged — new fields default to false)
+- urgent + groups complete → has auto-fill `onClick` action
+- urgent + groups NOT complete → has `href` action pointing to games page, no `onClick`
+- urgent + groups NOT complete → message uses `lockWindowUrgentGroupsIncomplete.message` key
+- urgent + groups NOT complete + `totalGroupGames=0` → falls through (guarded by `totalGroupGames > 0`)
+- non-urgent + groups complete → Variant 6 fires (auto-fill, no regression)
+- non-urgent + groups NOT complete → pre-tournament fallback (no regression)
 
 ---
 
@@ -164,17 +131,24 @@ Tests:
 
 ### `locales/en/predictions.json` — add inside `statusHeader.qt`:
 ```json
-"groupStageInProgress": {
-  "status": "Group stage in progress",
-  "message": "Group stage matches are still being played. Auto-fill will be available once all group results are in."
+"lockWindowUrgentGroupsIncomplete": {
+  "message": "Qualifiers lock in {countdown}. You can pick them manually now — you don't need to finish your group predictions first.",
+  "cta": "Predict Matches"
+}
+```
+
+Optionally update `lockWindowUrgent.message` to be more urgent:
+```json
+"lockWindowUrgent": {
+  "message": "Qualifiers lock in {countdown} — auto-fill now or choose manually below."
 }
 ```
 
 ### `locales/es/predictions.json` — add inside `statusHeader.qt`:
 ```json
-"groupStageInProgress": {
-  "status": "Fase de grupos en curso",
-  "message": "Los partidos de la fase de grupos todavía se están jugando. El auto-completar estará disponible cuando estén todos los resultados."
+"lockWindowUrgentGroupsIncomplete": {
+  "message": "Los clasificadores se bloquean en {countdown}. Puedes elegirlos manualmente ahora — no necesitas terminar de predecir los partidos de grupos primero.",
+  "cta": "Predecir Partidos"
 }
 ```
 
@@ -182,43 +156,36 @@ Tests:
 
 ## Implementation Steps
 
-1. **`qt-header-variant.ts`**: Add `tournamentStarted?` and `groupStageComplete?` to `QTHeaderInput`; add new variant branch (Variant 6a) before existing Variant 6
-2. **`locales/en/predictions.json`**: Add `statusHeader.qt.groupStageInProgress` keys
+1. **`qt-header-variant.ts`**: Hoist `groupsAllPredicted` before Variant 5; split Variant 5 into groups-complete and groups-incomplete branches; remove duplicate `groupsAllPredicted` declaration from Variant 6
+2. **`locales/en/predictions.json`**: Add `lockWindowUrgentGroupsIncomplete` keys
 3. **`locales/es/predictions.json`**: Add Spanish translations
-4. **`qualified-teams-client-page.tsx`**: Pass `tournamentStarted` and `groupStageComplete` in the `computeQTHeaderVariant` call; add both to useMemo deps
-5. **`qt-header-variant.test.ts`**: Add test block for the new variant; update `baseInput` defaults to include new optional fields
+4. **`qt-header-variant.test.ts`**: Add/update tests for the split Variant 5 behavior
 
 ---
 
 ## Testing Strategy
 
-### Unit Tests (`qt-header-variant.test.ts`)
+### Unit Tests (`app/components/prediction-status-header/__tests__/qt-header-variant.test.ts`)
 
-Update `baseInput` factory to include new fields with safe defaults:
-```typescript
-const baseInput = (overrides?: Partial<QTHeaderInput>): QTHeaderInput => ({
-  // ... existing fields ...
-  tournamentStarted: false,
-  groupStageComplete: false,
-  ...overrides,
-});
-```
+New tests in the existing "Variant 5: lock-window-urgent" describe block:
 
-New describe block: **"Variant 6a: group-stage-in-progress"**
+Tests use the existing `baseInput` factory (`(overrides?: Partial<QTHeaderInput>) => QTHeaderInput`) and a mock `t` function that returns the key as-is.
 
 | Test | Key inputs | Expected |
 |------|-----------|----------|
-| fires when tournament started, group stage ongoing, all groups predicted | `tournamentStarted=true, groupStageComplete=false, predictedGroupGames=8, totalGroupGames=8` | `tone='calm'`, `leadIcon='info'`, `statusText='statusHeader.qt.groupStageInProgress.status'`, chip defined, no action |
-| does NOT fire pre-tournament (shows auto-fill instead) | `tournamentStarted=false, groupStageComplete=false, predictedGroupGames=8, totalGroupGames=8` | `statusText='statusHeader.qt.autoFillReady.status'` |
-| does NOT fire when group stage complete (shows auto-fill) | `tournamentStarted=true, groupStageComplete=true, predictedGroupGames=8, totalGroupGames=8` | `statusText='statusHeader.qt.autoFillReady.status'` |
-| does NOT fire when groups not fully predicted | `tournamentStarted=true, groupStageComplete=false, predictedGroupGames=5, totalGroupGames=8` | `statusText='statusHeader.qt.preTournament.status'` |
-| does NOT fire when `totalGroupGames=0` | `tournamentStarted=true, groupStageComplete=false, predictedGroupGames=0, totalGroupGames=0` | falls through to pre-tournament |
+| urgent + groups complete → auto-fill | `isUrgent=true, predictedGroupGames=8, totalGroupGames=8` | action has `onClick`, message key = `lockWindowUrgent.message` |
+| urgent + groups NOT complete (partial) → predict matches | `isUrgent=true, predictedGroupGames=5, totalGroupGames=8` | action has `href` to games page, message key = `lockWindowUrgentGroupsIncomplete.message` |
+| urgent + groups NOT complete (zero) → predict matches | `isUrgent=true, predictedGroupGames=0, totalGroupGames=8` | action has `href` to games page, message key = `lockWindowUrgentGroupsIncomplete.message` |
+| urgent + totalGroupGames=0 → groups-incomplete branch | `isUrgent=true, predictedGroupGames=0, totalGroupGames=0` | `groupsAllPredicted=false` (guard `totalGroupGames>0` fails) → action has `href`, groups-incomplete message |
+| non-urgent + groups complete → Variant 6 fires | `isUrgent=false, predictedGroupGames=8, totalGroupGames=8` | statusText = `autoFillReady.status` |
+| non-urgent + groups NOT complete → pre-tournament | `isUrgent=false, predictedGroupGames=5, totalGroupGames=8` | statusText = `preTournament.status` |
 
 ### Manual Testing
 
-- [ ] Pre-tournament with all groups predicted: auto-fill banner visible
-- [ ] Tournament started + no group results yet: "Group stage in progress" banner visible, no auto-fill button
-- [ ] After group stage complete: auto-fill banner visible again
+- [ ] Lock window active, group predictions incomplete → "Predict Matches" CTA, urgent message, no auto-fill button
+- [ ] Lock window active, group predictions complete → auto-fill button present
+- [ ] Non-urgent, groups complete → auto-fill banner unchanged
+- [ ] Non-urgent, groups incomplete → pre-tournament banner unchanged
 
 ---
 
@@ -233,7 +200,13 @@ New describe block: **"Variant 6a: group-stage-in-progress"**
 
 ## Out of Scope
 
-- Auto-fill from actual results after group stage (separate story)
 - Changes to Games header logic
-- Changes to auto-fill action itself
+- Changes to auto-fill logic itself
 - Changes to lock/post-lock display states
+
+---
+
+## CODE-STRUCTURE Files to Update
+
+- `docs/code-structure/components/components-leaderboard-stats.md` — No signature change to `computeQTHeaderVariant`; update variant description if documented
+- Call graph: No changes needed

--- a/plans/STORY-426-plan.md
+++ b/plans/STORY-426-plan.md
@@ -1,0 +1,239 @@
+# Story 426 Plan: QT Header Shows Auto-Fill Banner Before Group Stage Matches Are Complete
+
+## Context
+
+The Qualified Teams (QT) status header uses `computeQTHeaderVariant()` to decide which message to show. Variant 6 ("pre-tournament-auto-fill-ready") fires whenever `predictedGroupGames >= totalGroupGames` — meaning the user has predicted all group stage games. This condition is checked with no awareness of whether the tournament has started or whether group games are still being played in real life.
+
+**The Bug**: If a user predicts all group games before the tournament starts, then the tournament starts and group stage matches begin playing, Variant 6 continues to show the "auto-fill available" banner. The banner should instead be suppressed while actual group games are in progress, showing a "group stage in progress" message instead.
+
+**The Fix**: Add two optional flags to `QTHeaderInput` — `tournamentStarted` and `groupStageComplete` — and insert a new Variant 6a that intercepts the auto-fill banner path when the tournament has started but group stage hasn't been finalized yet.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When tournament started + QT open + group stage not finalized (`!allGroupsComplete`) + user predicted all groups → QT header shows "group stage in progress" message, NOT auto-fill banner
+- [ ] Pre-tournament + all group games predicted → still shows auto-fill banner (no regression)
+- [ ] After group stage finalized (`allGroupsComplete=true`) + all group games predicted → auto-fill banner shows correctly
+- [ ] Games header behavior is unchanged
+- [ ] Works in EN and ES locales
+
+---
+
+## Technical Approach
+
+### Root Cause
+
+In `app/components/prediction-status-header/qt-header-variant.ts:172`:
+
+```typescript
+// ── VARIANT 6: pre-tournament-auto-fill-ready ────────────────────────────────
+const groupsAllPredicted = predictedGroupGames >= totalGroupGames && totalGroupGames > 0;
+if (groupsAllPredicted) {
+  return { /* auto-fill banner */ };
+}
+```
+
+No knowledge of tournament start or group stage completion.
+
+### Data Already Available in Client Page
+
+`QualifiedTeamsClientPage` already receives as props (both from the server page):
+- `allGroupsComplete: boolean` — `true` when all groups have DB-finalized standings (`is_complete=true` in `tournament_group_teams`)
+- `tournamentStartDate?: Date` — earliest game date across all tournament games
+
+Neither is currently passed to `computeQTHeaderVariant`.
+
+### Solution: Two New Optional Fields on `QTHeaderInput`
+
+Add `tournamentStarted?: boolean` (default `false`) and `groupStageComplete?: boolean` (default `false`) to `QTHeaderInput`. Defaults preserve all existing test and caller behavior unchanged.
+
+**New variant priority order after fix:**
+
+```
+locked → completed-pre-lock → lock-window-urgent
+  → [NEW] group-stage-in-progress  (tournamentStarted && !groupStageComplete && groupsAllPredicted)
+  → pre-tournament-auto-fill-ready (!tournamentStarted || groupStageComplete) && groupsAllPredicted
+  → pre-tournament (fallback)
+```
+
+New variant characteristics:
+- Tone: `'calm'`
+- Icon: `'info'`
+- Status: `statusHeader.qt.groupStageInProgress.status`
+- Message: `statusHeader.qt.groupStageInProgress.message`
+- Shows chip (qualifier count)
+- No action button
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/components/prediction-status-header/qt-header-variant.ts` | Add `tournamentStarted?` and `groupStageComplete?` to `QTHeaderInput`; add new variant branch |
+| `app/components/qualified-teams/qualified-teams-client-page.tsx` | Pass `tournamentStarted` and `groupStageComplete` in `computeQTHeaderVariant` call; update useMemo deps |
+| `locales/en/predictions.json` | Add `statusHeader.qt.groupStageInProgress.status` and `.message` |
+| `locales/es/predictions.json` | Spanish translations for the same keys |
+| `app/components/prediction-status-header/__tests__/qt-header-variant.test.ts` | New tests for group-stage-in-progress variant |
+| `docs/code-structure/components/components-leaderboard-stats.md` | Update `QTHeaderInput` signature |
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+No call graph changes. `computeQTHeaderVariant` already exists in the call graph; only its input signature and internal branching change.
+
+---
+
+### `app/components/prediction-status-header/qt-header-variant.ts` *(modified)*
+
+**Changed interface:**
+
+```typescript
+export interface QTHeaderInput {
+  // ... existing fields unchanged ...
+  /** True once the tournament's first game date has passed. Defaults to false (pre-tournament behavior). */
+  tournamentStarted?: boolean;
+  /** True once all groups in the tournament have finalized standings (allGroupsComplete from DB). Defaults to false. */
+  groupStageComplete?: boolean;
+}
+```
+
+**Changed function: `computeQTHeaderVariant(input: QTHeaderInput, t: TFunction)`**
+
+After Variant 5 (lock-window-urgent), before existing Variant 6:
+
+```typescript
+// ── VARIANT 6a: group-stage-in-progress ──────────────────────────────────────
+// Suppress auto-fill banner while actual group games are still being played
+const tournamentStarted = input.tournamentStarted ?? false;
+const groupStageComplete = input.groupStageComplete ?? false;
+if (groupsAllPredicted && tournamentStarted && !groupStageComplete) {
+  return {
+    tone: 'calm',
+    leadIcon: 'info',
+    statusText: t('statusHeader.qt.groupStageInProgress.status'),
+    chip,
+    message: t('statusHeader.qt.groupStageInProgress.message'),
+  };
+}
+```
+
+Existing Variant 6 check is unchanged — it naturally fires for pre-tournament (`!tournamentStarted`) and post-group-stage (`groupStageComplete`) cases.
+
+Tests:
+- fires when `tournamentStarted=true`, `groupStageComplete=false`, all groups predicted
+- does NOT fire when `tournamentStarted=false` (pre-tournament → shows auto-fill instead)
+- does NOT fire when `groupStageComplete=true` (post-group-stage → shows auto-fill instead)
+- does NOT fire when groups not fully predicted (falls through to pre-tournament fallback)
+- shows chip, has message, has NO action button
+- does NOT fire when `totalGroupGames=0` (guarded by `totalGroupGames > 0` in `groupsAllPredicted`)
+
+---
+
+### `app/components/qualified-teams/qualified-teams-client-page.tsx` *(modified)*
+
+**Changed: `qtHeaderVariant` useMemo** — pass two new fields:
+
+```typescript
+const qtHeaderVariant = useMemo(
+  () => computeQTHeaderVariant(
+    {
+      // ... existing fields unchanged ...
+      tournamentStarted: !!tournamentStartDate && new Date() >= tournamentStartDate,
+      groupStageComplete: allGroupsComplete,
+    },
+    tPredictions as (key: string, values?: Record<string, unknown>) => string
+  ),
+  [isLocked, qtLockAt, tournamentPredictionCompletion, qualifiedTeamsCompleted,
+   actualResults, correctSoFar, scoringBreakdown, locale, allGroupsComplete, tournamentStartDate]
+);
+```
+
+`allGroupsComplete` and `tournamentStartDate` are already props — no server page changes needed.
+
+Tests:
+- (existing tests unchanged — new fields default to false)
+
+---
+
+## Translation Strings
+
+### `locales/en/predictions.json` — add inside `statusHeader.qt`:
+```json
+"groupStageInProgress": {
+  "status": "Group stage in progress",
+  "message": "Group stage matches are still being played. Auto-fill will be available once all group results are in."
+}
+```
+
+### `locales/es/predictions.json` — add inside `statusHeader.qt`:
+```json
+"groupStageInProgress": {
+  "status": "Fase de grupos en curso",
+  "message": "Los partidos de la fase de grupos todavía se están jugando. El auto-completar estará disponible cuando estén todos los resultados."
+}
+```
+
+---
+
+## Implementation Steps
+
+1. **`qt-header-variant.ts`**: Add `tournamentStarted?` and `groupStageComplete?` to `QTHeaderInput`; add new variant branch (Variant 6a) before existing Variant 6
+2. **`locales/en/predictions.json`**: Add `statusHeader.qt.groupStageInProgress` keys
+3. **`locales/es/predictions.json`**: Add Spanish translations
+4. **`qualified-teams-client-page.tsx`**: Pass `tournamentStarted` and `groupStageComplete` in the `computeQTHeaderVariant` call; add both to useMemo deps
+5. **`qt-header-variant.test.ts`**: Add test block for the new variant; update `baseInput` defaults to include new optional fields
+
+---
+
+## Testing Strategy
+
+### Unit Tests (`qt-header-variant.test.ts`)
+
+Update `baseInput` factory to include new fields with safe defaults:
+```typescript
+const baseInput = (overrides?: Partial<QTHeaderInput>): QTHeaderInput => ({
+  // ... existing fields ...
+  tournamentStarted: false,
+  groupStageComplete: false,
+  ...overrides,
+});
+```
+
+New describe block: **"Variant 6a: group-stage-in-progress"**
+
+| Test | Key inputs | Expected |
+|------|-----------|----------|
+| fires when tournament started, group stage ongoing, all groups predicted | `tournamentStarted=true, groupStageComplete=false, predictedGroupGames=8, totalGroupGames=8` | `tone='calm'`, `leadIcon='info'`, `statusText='statusHeader.qt.groupStageInProgress.status'`, chip defined, no action |
+| does NOT fire pre-tournament (shows auto-fill instead) | `tournamentStarted=false, groupStageComplete=false, predictedGroupGames=8, totalGroupGames=8` | `statusText='statusHeader.qt.autoFillReady.status'` |
+| does NOT fire when group stage complete (shows auto-fill) | `tournamentStarted=true, groupStageComplete=true, predictedGroupGames=8, totalGroupGames=8` | `statusText='statusHeader.qt.autoFillReady.status'` |
+| does NOT fire when groups not fully predicted | `tournamentStarted=true, groupStageComplete=false, predictedGroupGames=5, totalGroupGames=8` | `statusText='statusHeader.qt.preTournament.status'` |
+| does NOT fire when `totalGroupGames=0` | `tournamentStarted=true, groupStageComplete=false, predictedGroupGames=0, totalGroupGames=0` | falls through to pre-tournament |
+
+### Manual Testing
+
+- [ ] Pre-tournament with all groups predicted: auto-fill banner visible
+- [ ] Tournament started + no group results yet: "Group stage in progress" banner visible, no auto-fill button
+- [ ] After group stage complete: auto-fill banner visible again
+
+---
+
+## Validation
+
+- `npm run test` — all existing tests pass + new tests pass
+- `npm run lint` — no lint errors
+- `npm run build` — successful build
+- Test on Vercel Preview
+
+---
+
+## Out of Scope
+
+- Auto-fill from actual results after group stage (separate story)
+- Changes to Games header logic
+- Changes to auto-fill action itself
+- Changes to lock/post-lock display states

--- a/plans/STORY-426-plan.md
+++ b/plans/STORY-426-plan.md
@@ -163,6 +163,13 @@ Optionally update `lockWindowUrgent.message` to be more urgent:
 
 ---
 
+## Implementation Amendments
+
+### Amendment 1: Variant 4 (completed-pre-lock) widened to fire on qualifiers alone
+**Date:** 2026-05-07
+**Reason:** Discovered during manual testing that users with all qualifiers filled but some group games still unpredicted were falling through to the urgent Variant 5 banner instead of the calm success state. The original Variant 4 guard required both `qtComplete` (groups AND qualifiers done). This was an undocumented bug exposed by the same root cause.
+**Change:** Variant 4 now fires when `qualifiersComplete` alone (qualifiersCompleted >= qualifiersTotal && qualifiersTotal > 0), regardless of group game completion. The Recalculate CTA is conditionally rendered only when `groupsAllPredicted` is also true. Removed `groupsComplete` and `qtComplete` variables; hoisted `groupsAllPredicted` and introduced `qualifiersComplete` before Variant 4. New tests added: "qualifiers complete + groups NOT complete → success with no CTA" and "qualifiers complete + groups complete → success with Recalculate CTA".
+
 ## Testing Strategy
 
 ### Unit Tests (`app/components/prediction-status-header/__tests__/qt-header-variant.test.ts`)


### PR DESCRIPTION
Fixes #426

## Summary
Implementation plan for the story.

## Plan Document
See `plans/STORY-426-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)