### PR TITLE
Plan: [Story] Replace JS-side count with SQL COUNT query for "Predictions Made" on statistics page #414

### DIFF
--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -381,7 +381,7 @@ Key flows:
       ├── findTournamentGuessByUserIdTournament
       ├── getBoostAllocationBreakdown
       ├── getGameCountsForTournament
-      ├── findGameGuessesByUserId
+      ├── countGameGuessesByUserId
       ├── calculateAccuracyStats (util)
       ├── calculateBoostStats (util)
       └── getScoreHistoryForUsers (score-history-repository)

--- a/__tests__/db/game-guess-repository.test.ts
+++ b/__tests__/db/game-guess-repository.test.ts
@@ -5,6 +5,7 @@ import {
   updateGameGuess,
   deleteGameGuess,
   findGameGuessesByUserId,
+  countGameGuessesByUserId,
   updateGameGuessByGameId,
   updateOrCreateGuess,
   getGameGuessStatisticsForUsers,
@@ -155,6 +156,46 @@ describe('Game Guess Repository', () => {
         const result = await findGameGuessesByUserId('user-1', 'tournament-1');
 
         expect(result).toEqual([]);
+      });
+    });
+
+    describe('countGameGuessesByUserId', () => {
+      const buildMockCountQuery = (result: { count: string } | undefined) => ({
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        executeTakeFirst: vi.fn().mockResolvedValue(result),
+      });
+
+      it('should return the numeric count when guesses exist', async () => {
+        const mockQuery = buildMockCountQuery({ count: '3' });
+        mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+        const result = await countGameGuessesByUserId('user-1', 'tournament-1');
+
+        expect(mockDb.selectFrom).toHaveBeenCalledWith('game_guesses');
+        expect(mockQuery.innerJoin).toHaveBeenCalledWith('games', 'games.id', 'game_guesses.game_id');
+        expect(mockQuery.where).toHaveBeenCalledWith('game_guesses.user_id', '=', 'user-1');
+        expect(mockQuery.where).toHaveBeenCalledWith('games.tournament_id', '=', 'tournament-1');
+        expect(result).toBe(3);
+      });
+
+      it('should return 0 when executeTakeFirst returns undefined (no matching guesses)', async () => {
+        const mockQuery = buildMockCountQuery(undefined);
+        mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+        const result = await countGameGuessesByUserId('user-1', 'tournament-1');
+
+        expect(result).toBe(0);
+      });
+
+      it('should return 0 when executeTakeFirst returns undefined for a non-existent userId', async () => {
+        const mockQuery = buildMockCountQuery(undefined);
+        mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+        const result = await countGameGuessesByUserId('nonexistent-user', 'tournament-1');
+
+        expect(result).toBe(0);
       });
     });
 

--- a/__tests__/tournaments/[id]/stats.page.test.tsx
+++ b/__tests__/tournaments/[id]/stats.page.test.tsx
@@ -7,7 +7,7 @@ import { getLoggedInUser } from '../../../app/actions/user-actions';
 import {
   getGameGuessStatisticsForUsers,
   getBoostAllocationBreakdown,
-  findGameGuessesByUserId,
+  countGameGuessesByUserId,
 } from '../../../app/db/game-guess-repository';
 import { findTournamentGuessByUserIdTournament } from '../../../app/db/tournament-guess-repository';
 import { findTournamentById } from '../../../app/db/tournament-repository';
@@ -32,7 +32,7 @@ vi.mock('../../../app/actions/user-actions', () => ({
 vi.mock('../../../app/db/game-guess-repository', () => ({
   getGameGuessStatisticsForUsers: vi.fn(),
   getBoostAllocationBreakdown: vi.fn(),
-  findGameGuessesByUserId: vi.fn(),
+  countGameGuessesByUserId: vi.fn(),
 }));
 
 vi.mock('../../../app/db/tournament-guess-repository', () => ({
@@ -124,11 +124,8 @@ describe('TournamentStatsPage', () => {
       .mockResolvedValueOnce(mockSilverBoostData)
       .mockResolvedValueOnce(mockGoldenBoostData);
 
-    // Mock game guesses (32 predictions)
-    const mockGameGuesses = Array.from({ length: 32 }, (_, i) =>
-      testFactories.gameGuess({ id: `guess-${i + 1}`, user_id: mockUser.id })
-    );
-    vi.mocked(findGameGuessesByUserId).mockResolvedValue(mockGameGuesses);
+    // Mock game guess count (32 predictions)
+    vi.mocked(countGameGuessesByUserId).mockResolvedValue(32);
 
     // Mock game counts (38 total, 32 played)
     vi.mocked(getGameCountsForTournament).mockResolvedValue({ total: 38, played: 32 });
@@ -179,7 +176,7 @@ describe('TournamentStatsPage', () => {
       expect(findTournamentGuessByUserIdTournament).toHaveBeenCalledWith(mockUser.id, mockTournamentId);
       expect(getBoostAllocationBreakdown).toHaveBeenCalledWith(mockUser.id, mockTournamentId, 'silver');
       expect(getBoostAllocationBreakdown).toHaveBeenCalledWith(mockUser.id, mockTournamentId, 'golden');
-      expect(findGameGuessesByUserId).toHaveBeenCalledWith(mockUser.id, mockTournamentId);
+      expect(countGameGuessesByUserId).toHaveBeenCalledWith(mockUser.id, mockTournamentId);
       expect(getGameCountsForTournament).toHaveBeenCalledWith(mockTournamentId);
       expect(getScoreHistoryForUsers).toHaveBeenCalledWith([mockUser.id], mockTournamentId);
     });

--- a/app/[locale]/tournaments/[id]/stats/page.tsx
+++ b/app/[locale]/tournaments/[id]/stats/page.tsx
@@ -4,7 +4,7 @@ import { Metadata } from 'next'
 import { Box } from "../../../../components/mui-wrappers";
 import { getLoggedInUser } from "../../../../actions/user-actions";
 import { redirect } from "next/navigation";
-import { getGameGuessStatisticsForUsers, getBoostAllocationBreakdown, findGameGuessesByUserId } from "../../../../db/game-guess-repository";
+import { getGameGuessStatisticsForUsers, getBoostAllocationBreakdown, countGameGuessesByUserId } from "../../../../db/game-guess-repository";
 import { findTournamentGuessByUserIdTournament } from "../../../../db/tournament-guess-repository";
 import { getGameCountsForTournament } from "../../../../db/game-repository";
 import { getScoreHistoryForUsers } from "../../../../db/score-history-repository";
@@ -104,9 +104,8 @@ export default async function TournamentStatsPage(props: Props) {
   }
 
   // Calculate Prediction Accuracy stats
-  // Get actual game prediction count from game guesses
-  const gameGuessesArray = user ? await findGameGuessesByUserId(user.id, tournamentId) : []
-  const totalPredictionsMade = gameGuessesArray.length
+  // Get actual game prediction count via SQL COUNT(*) query
+  const totalPredictionsMade = await countGameGuessesByUserId(user.id, tournamentId)
 
   // Get total games and played games via efficient COUNT query (1 row instead of all game rows)
   const { total: totalGamesAvailable, played: totalGamesPlayed } = await getGameCountsForTournament(tournamentId)

--- a/app/db/game-guess-repository.ts
+++ b/app/db/game-guess-repository.ts
@@ -24,6 +24,20 @@ export const findGameGuessesByUserId = cache(async function (userId: string, tou
     .execute()
 })
 
+export const countGameGuessesByUserId = cache(async function (
+  userId: string,
+  tournamentId: string
+): Promise<number> {
+  const result = await db
+    .selectFrom(tableName)
+    .innerJoin('games', 'games.id', 'game_guesses.game_id')
+    .where('game_guesses.user_id', '=', userId)
+    .where('games.tournament_id', '=', tournamentId)
+    .select((eb) => eb.fn.countAll<string>().as('count'))
+    .executeTakeFirst()
+  return result ? Number(result.count) : 0
+})
+
 export async function updateGameGuessByGameId(game_id: string, user_id: string, withUpdate: {home_team?: string | null, away_team?:string | null }) {
 
   return await db

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -74,6 +74,7 @@ Repository for game_guesses table. Handles user predictions with boost tracking 
 - **updateGameGuess(id: string, update: Updateable<GameGuessTable>)**: `Promise<GameGuess>` — Updates an existing game guess.
 - **deleteGameGuess(id: string)**: `Promise<GameGuess>` — Deletes a game guess.
 - **findGameGuessesByUserId(userId: string, tournamentId: string)**: `Promise<GameGuess[]>` — Returns all game guesses for user in tournament (cached).
+- **countGameGuessesByUserId(userId: string, tournamentId: string)**: `Promise<number>` — Returns count of game guesses for user in tournament via SQL COUNT(*) (cached).
 - **updateGameGuessByGameId(gameId: string, userId: string, update: object)**: `Promise<GameGuess | undefined>` — Updates home/away scores for a specific game guess.
 - **updateOrCreateGuess(guess: GameGuessNew)**: `Promise<GameGuess>` — Upserts a game guess (deletes existing, creates new).
 - **legacyGetGameGuessStatisticsForUsers(userIds: string[], tournamentId: string)**: `Promise<GameStatisticForUser[]>` — Legacy SQL aggregation for game statistics; includes goal_difference_guesses count (via prediction_tier column); used for backfill and validation.

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-05
+**Last updated:** 2026-05-09
 
 ---
 

--- a/docs/code-structure/pages.md
+++ b/docs/code-structure/pages.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-08
+**Last updated:** 2026-05-09
 
 ---
 
@@ -200,8 +200,8 @@ User tournament statistics page showing performance, accuracy, boost analysis, a
 
 - **generateMetadata({ params }: { params: Promise<{ id: string }> })**: `Promise<Metadata>` — [Server] Returns sub-page title `"{sidebar.title} – {long_name} | {appName}"` with localized description; falls back to appName on error.
   Calls: buildTournamentMetadata, getTranslations, getLocale
-- **TournamentStatsPage(props: Props)**: `JSX.Element` — [Server] Fetches game guesses, tournament guesses, boost allocations, and score history (tournament via cache); calculates performance and accuracy metrics; renders stats with BreadcrumbList JSON-LD.
-  Calls: getLoggedInUser, findTournamentByIdCached, getLocale, getTranslations, getGameGuessStatisticsForUsers, findTournamentGuessByUserIdTournament, getBoostAllocationBreakdown, getGameCountsForTournament, findGameGuessesByUserId, calculateAccuracyStats, calculateBoostStats, getScoreHistoryForUsers, buildBreadcrumbListJsonLd
+- **TournamentStatsPage(props: Props)**: `JSX.Element` — [Server] Counts game guesses via SQL COUNT, fetches tournament guesses, boost allocations, and score history (tournament via cache); calculates performance and accuracy metrics; renders stats with BreadcrumbList JSON-LD.
+  Calls: getLoggedInUser, findTournamentByIdCached, getLocale, getTranslations, getGameGuessStatisticsForUsers, findTournamentGuessByUserIdTournament, getBoostAllocationBreakdown, getGameCountsForTournament, countGameGuessesByUserId, calculateAccuracyStats, calculateBoostStats, getScoreHistoryForUsers, buildBreadcrumbListJsonLd
   Renders: JsonLd, StatsTabs, PerformanceOverviewCard, PredictionAccuracyCard, BoostAnalysisCard, HistoryTabCard
 
 ### app/[locale]/tournaments/[id]/awards/page.tsx

--- a/plans/STORY-414-context.md
+++ b/plans/STORY-414-context.md
@@ -1,0 +1,17 @@
+# Story 414 Context
+
+## Metadata
+- **Story Number:** 414
+- **Story Title:** [Story] Replace JS-side count with SQL COUNT query for "Predictions Made" on statistics page
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/determined-turing-f8c893
+- **Branch:** claude/determined-turing-f8c893
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-414-plan.md
+- **Task File:** (fill when implementation starts)
+
+## Quick Summary
+Replaces JS-side `.length`-on-array pattern in the stats page with a new `countGameGuessesByUserId` repository function that issues a single SQL COUNT(*) query. Changes two files: game-guess-repository.ts (new function) and stats/page.tsx (import + usage swap).

--- a/plans/STORY-414-context.md
+++ b/plans/STORY-414-context.md
@@ -5,11 +5,11 @@
 - **Story Title:** [Story] Replace JS-side count with SQL COUNT query for "Predictions Made" on statistics page
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/determined-turing-f8c893
 - **Branch:** claude/determined-turing-f8c893
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 430
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/430
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** review-ready
 - **Plan File:** plans/STORY-414-plan.md
 - **Task File:** (fill when implementation starts)
 

--- a/plans/STORY-414-plan.md
+++ b/plans/STORY-414-plan.md
@@ -1,0 +1,140 @@
+# Plan: Story #414 — Replace JS-side count with SQL COUNT query for "Predictions Made"
+
+## Story Metadata
+- **Story Number:** 414
+- **Story Title:** [Story] Replace JS-side count with SQL COUNT query for "Predictions Made" on statistics page
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/determined-turing-f8c893
+- **Branch:** claude/determined-turing-f8c893
+- **Epic:** #409
+
+## Context
+`app/[locale]/tournaments/[id]/stats/page.tsx` fetches every `game_guesses` row for the user
+via `findGameGuessesByUserId()` just to call `.length` on the result (lines 108–109). This
+transfers all row data over the wire when a single SQL `COUNT(*)` would suffice. The pattern for
+efficient COUNT queries already exists in this codebase (e.g., `getGameCountsForTournament` in
+`game-repository.ts`, `users-repository.ts` count helper).
+
+## Objective
+Replace the `.length`-on-array pattern on the stats page with a dedicated `countGameGuessesByUserId`
+repository function that issues one `COUNT(*)` SQL query and returns a plain `number`.
+
+## Files to Modify
+| File | Change |
+|------|--------|
+| `app/db/game-guess-repository.ts` | Add `countGameGuessesByUserId` function |
+| `app/[locale]/tournaments/[id]/stats/page.tsx` | Replace import + usage with new count function |
+| `docs/code-structure/db.md` | Document new function |
+| `CODE-STRUCTURE.md` | Update Flow 12 call graph entry |
+
+## Technical Approach
+
+### 1. New repository function (`game-guess-repository.ts`)
+
+Add after `findGameGuessesByUserId` (line 25):
+
+```typescript
+export const countGameGuessesByUserId = cache(async function (
+  userId: string,
+  tournamentId: string
+): Promise<number> {
+  const result = await db
+    .selectFrom(tableName)
+    .innerJoin('games', 'games.id', 'game_guesses.game_id')
+    .where('game_guesses.user_id', '=', userId)
+    .where('games.tournament_id', '=', tournamentId)
+    .select((eb) => eb.fn.countAll<string>().as('count'))
+    .executeTakeFirst()
+  return result ? Number(result.count) : 0
+})
+```
+
+- Uses identical joins/where clauses as `findGameGuessesByUserId` so counts match exactly
+- Returns `number` (0 when no guesses), not nullable — callers need no null checks
+- Wrapped in `cache()` consistent with other read functions in this file
+- Uses `countAll<string>` (Kysely serializes numeric aggregates as strings) then `Number()` — same pattern as `users-repository.ts` lines 63–73
+
+### 2. Stats page (`stats/page.tsx`)
+
+**Remove** `findGameGuessesByUserId` from import (line 7):
+```typescript
+// Before
+import { getGameGuessStatisticsForUsers, getBoostAllocationBreakdown, findGameGuessesByUserId } from "../../../../db/game-guess-repository";
+// After
+import { getGameGuessStatisticsForUsers, getBoostAllocationBreakdown, countGameGuessesByUserId } from "../../../../db/game-guess-repository";
+```
+
+**Replace** lines 108–109:
+```typescript
+// Before
+const gameGuessesArray = user ? await findGameGuessesByUserId(user.id, tournamentId) : []
+const totalPredictionsMade = gameGuessesArray.length
+
+// After
+const totalPredictionsMade = await countGameGuessesByUserId(user.id, tournamentId)
+```
+
+Note: `user` is guaranteed non-null here because of the `redirect` guard at line 55–57, so the ternary is not needed.
+
+### 3. CODE-STRUCTURE.md updates
+
+**`docs/code-structure/db.md`** — add after `findGameGuessesByUserId` entry (line 76):
+```
+- **countGameGuessesByUserId(userId: string, tournamentId: string)**: `Promise<number>` — Returns the count of game guesses for user in tournament via SQL COUNT(*) (cached).
+```
+
+**`CODE-STRUCTURE.md` Flow 12** — replace `findGameGuessesByUserId` with `countGameGuessesByUserId`:
+```
+      ├── countGameGuessesByUserId   # was findGameGuessesByUserId
+```
+
+## Mid-Level Design
+
+### Call Graph Changes
+**Modified flows:**
+- **Flow 12 (User stats page)** — replace `findGameGuessesByUserId` with `countGameGuessesByUserId`
+
+### `app/db/game-guess-repository.ts` *(modified)*
+
+**New functions:**
+- **countGameGuessesByUserId(userId: string, tournamentId: string)**: `Promise<number>`
+  Returns the count of game guesses for the user in tournament via SQL COUNT(*).
+  Calls: db (Kysely), cache
+  Tests:
+  - returns 0 when executeTakeFirst returns undefined (no matching guesses)
+  - returns Number(result.count) when executeTakeFirst returns a count row (e.g. { count: '3' } → 3)
+  - returns 0 when executeTakeFirst returns undefined for a non-existent userId
+
+### `app/[locale]/tournaments/[id]/stats/page.tsx` *(modified)*
+
+**Changed usage:**
+- Remove `findGameGuessesByUserId` import and array-then-length pattern
+- Replace with single `await countGameGuessesByUserId(user.id, tournamentId)` call
+- `totalPredictionsMade` type remains `number` — no downstream changes needed
+
+## Testing Strategy
+Add to `__tests__/db/game-guess-repository.test.ts` using the existing test infrastructure:
+- Mock: `createMockSelectQuery({ count: '3' })` → `mockDb.selectFrom.mockReturnValue(mockQuery)` (same mock pattern as other tests in the file)
+- Mock `react` cache: already mocked in the file as `cache: vi.fn((fn) => fn)`
+- Test cases:
+  - Returns correct count: mock returns `{ count: '3' }`, expect result `3` (verifies Number() conversion)
+  - Returns 0 when no guesses: mock `executeTakeFirst` returns `undefined`, expect result `0`
+  - Returns 0 for nonexistent user: same as above (db returns undefined row)
+
+Note: `testFactories.gameGuess()` is not needed here — we're testing the COUNT query result, not full row data.
+Note: Database errors are intentionally allowed to propagate — no error handling at the repository layer (consistent with all other functions in the file).
+
+## Acceptance Criteria (from issue)
+- [ ] "Predictions Made" count on the statistics page shows the correct number
+- [ ] Statistics page loads and displays all sections correctly
+- [ ] `countGameGuessesByUserId` repository function replaces the `.length` pattern
+
+## Verification
+1. Run `npm run build` — no TS errors
+2. Run `npm run test` — existing stats page tests pass
+3. Navigate to `/[locale]/tournaments/[id]/stats` while logged in — "Predictions Made" count is correct
+4. Run `npm run lint` — no lint errors
+
+## Out of Scope
+- Visual changes to the statistics page
+- Boost count queries (already optimized in story #412)
+- Changes to other callers of `findGameGuessesByUserId` (games page, etc.)


### PR DESCRIPTION
Fixes #414

## Summary
Implementation plan for replacing the JS-side `.length`-on-array pattern with a dedicated SQL COUNT(*) query for the "Predictions Made" stat on the statistics page.

## Plan Document
See `plans/STORY-414-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)