### PR TITLE
Plan: [Bug] Group standings tiebreaker ranks teams incorrectly when conduct scores are set #431

### DIFF
--- a/app/actions/backoffice-actions.ts
+++ b/app/actions/backoffice-actions.ts
@@ -20,7 +20,9 @@ import {
   createTournamentGroupGame,
   createTournamentGroupTeam,
   deleteAllGroupsFromTournament,
-  findGroupsWithGamesAndTeamsInTournament, updateTournamentGroupTeams
+  findGroupsWithGamesAndTeamsInTournament,
+  findTeamsInGroup,
+  updateTournamentGroupTeams
 } from "../db/tournament-group-repository";
 import {
   createPlayoffRound,
@@ -551,13 +553,19 @@ export async function calculateGameScores(forceDrafts: boolean, forceAllGuesses:
 }
 
 export async function calculateAndStoreGroupPosition(group_id: string, teamIds: string[], groupGames: ExtendedGameData[], sortByGamesBetweenTeams: boolean) {
+  const currentTeamStats = await findTeamsInGroup(group_id)
+  const conductScores: Record<string, number> = Object.fromEntries(
+    currentTeamStats.map(t => [t.team_id, t.conduct_score ?? 0])
+  )
+
   const groupPositions: TournamentGroupTeamNew[] = calculateGroupPosition(
     teamIds,
     groupGames.map(game => ({
       ...game,
       resultOrGuess: game.gameResult
     })),
-    sortByGamesBetweenTeams)
+    sortByGamesBetweenTeams,
+    conductScores)
       .map((teamPosition, index) => ({
         ...teamPosition,
         tournament_group_id: group_id,

--- a/app/components/backoffice/group-backoffice-tab.tsx
+++ b/app/components/backoffice/group-backoffice-tab.tsx
@@ -74,10 +74,11 @@ export default function GroupBackoffice({group, tournamentId} :Props) {
         ...game,
         resultOrGuess: game.gameResult
       })),
-      group.sort_by_games_between_teams)
+      group.sort_by_games_between_teams,
+      conductScores)
     setPositions(groupPositions)
 
-  }, [teamsMap, gamesMap, setPositions, group.sort_by_games_between_teams]);
+  }, [teamsMap, gamesMap, setPositions, group.sort_by_games_between_teams, conductScores]);
 
   const saveGamesAndRecalculate = async (newGamesMap: {[k: string]: ExtendedGameData}) => {
     await saveGameResults(Object.values(newGamesMap))

--- a/app/components/groups-page/team-standings-cards.tsx
+++ b/app/components/groups-page/team-standings-cards.tsx
@@ -22,10 +22,12 @@ export default function TeamStandingsCards({
   const standings = useMemo(() => {
     if (teamStats.length === 0) return []
 
-    // Pre-sort by points DESC, then goal_difference DESC (for tiebreaking)
+    // Pre-sort by full FIFA tiebreaker chain
     const sorted = [...teamStats].sort((a, b) => {
       if (b.points !== a.points) return b.points - a.points
-      return b.goal_difference - a.goal_difference
+      if (b.goal_difference !== a.goal_difference) return b.goal_difference - a.goal_difference
+      if (b.goals_for !== a.goals_for) return b.goals_for - a.goals_for
+      return (a.conduct_score || 0) - (b.conduct_score || 0)
     })
 
     // Add ranks using competition ranking (handles ties: 1-2-2-4)
@@ -36,7 +38,9 @@ export default function TeamStandingsCards({
     if (previousTeamStats && previousTeamStats.length > 0) {
       const prevSorted = [...previousTeamStats].sort((a, b) => {
         if (b.points !== a.points) return b.points - a.points
-        return b.goal_difference - a.goal_difference
+        if (b.goal_difference !== a.goal_difference) return b.goal_difference - a.goal_difference
+        if (b.goals_for !== a.goals_for) return b.goals_for - a.goals_for
+        return (a.conduct_score || 0) - (b.conduct_score || 0)
       })
       const prevRanked = calculateRanks(prevSorted, 'points')
       previousRanks = new Map(

--- a/app/utils/__tests__/group-position-calculator.test.ts
+++ b/app/utils/__tests__/group-position-calculator.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { calculateGroupPosition } from '../group-position-calculator';
+import type { GameWithResultOrGuess } from '../group-position-calculator';
+
+const makeGame = (home: string, away: string, homeScore: number, awayScore: number): GameWithResultOrGuess => ({
+  id: `${home}-${away}`,
+  home_team: home,
+  away_team: away,
+  game_number: 1,
+  tournament_group_id: 'g1',
+  resultOrGuess: { home_score: homeScore, away_score: awayScore } as any,
+})
+
+// All-draw group: A, B, C, D each draw every game → 3 pts each, GD=0, GF=2
+const ALL_DRAW_GAMES: GameWithResultOrGuess[] = [
+  makeGame('A', 'B', 1, 1),
+  makeGame('A', 'C', 1, 1),
+  makeGame('A', 'D', 1, 1),
+  makeGame('B', 'C', 1, 1),
+  makeGame('B', 'D', 1, 1),
+  makeGame('C', 'D', 1, 1),
+]
+const TEAMS = ['A', 'B', 'C', 'D']
+
+describe('calculateGroupPosition — conduct_score tiebreaker', () => {
+  it('ranks team with lower conduct_score first when all other stats are equal', () => {
+    const positions = calculateGroupPosition(TEAMS, ALL_DRAW_GAMES, false, {
+      A: 0, B: 2, C: 5, D: 10,
+    })
+    expect(positions.map(p => p.team_id)).toEqual(['A', 'B', 'C', 'D'])
+  })
+
+  it('ranks team with conduct_score=0 above team with conduct_score=5', () => {
+    const positions = calculateGroupPosition(['X', 'Y'], [
+      makeGame('X', 'Y', 1, 1),
+    ], false, { X: 0, Y: 5 })
+    expect(positions[0].team_id).toBe('X')
+    expect(positions[1].team_id).toBe('Y')
+  })
+
+  it('conductScores parameter is optional — omitting it preserves existing behavior', () => {
+    // Without conductScores, all-draw group falls back to insertion order / stable sort
+    const withParam = calculateGroupPosition(TEAMS, ALL_DRAW_GAMES, false, {})
+    const withoutParam = calculateGroupPosition(TEAMS, ALL_DRAW_GAMES, false)
+    expect(withParam.map(p => p.team_id)).toEqual(withoutParam.map(p => p.team_id))
+  })
+
+  it('goal_difference beats conduct_score: better GD wins even with conduct_score=0 on the other side', () => {
+    // A beats C 2-0, A draws B 0-0, B beats C 1-0
+    // A: 4pts, GD+2; B: 4pts, GD+1; C: 0pts
+    const games = [
+      makeGame('A', 'C', 2, 0),
+      makeGame('A', 'B', 0, 0),
+      makeGame('B', 'C', 1, 0),
+    ]
+    // Give A the worst conduct (highest number) — it should still rank first due to GD
+    const positions = calculateGroupPosition(['A', 'B', 'C'], games, false, { A: 99, B: 0, C: 0 })
+    expect(positions[0].team_id).toBe('A')
+    expect(positions[1].team_id).toBe('B')
+  })
+
+  it('goals_for beats conduct_score: more goals_for wins even with conduct_score=0 on the other side', () => {
+    // All 3 teams draw all games, but with different scorelines → same pts, same GD, different GF
+    // A draws B 2-2 (+2 GF each), A draws C 1-1 (+1 GF each), B draws C 0-0
+    // A: 2pts, GD=0, GF=3; B: 2pts, GD=0, GF=2; C: 2pts, GD=0, GF=1
+    const games = [
+      makeGame('A', 'B', 2, 2),
+      makeGame('A', 'C', 1, 1),
+      makeGame('B', 'C', 0, 0),
+    ]
+    // Give A the worst conduct — it should still rank first due to GF
+    const positions = calculateGroupPosition(['A', 'B', 'C'], games, false, { A: 99, B: 0, C: 0 })
+    expect(positions[0].team_id).toBe('A')
+    expect(positions[1].team_id).toBe('B')
+    expect(positions[2].team_id).toBe('C')
+  })
+
+  it('three-way tie: teams ranked by conduct_score when all other stats from H2H are equal', () => {
+    // 4-team group: D beats everyone. A, B, C all draw each other and lose to D.
+    // A, B, C all have equal pts/GD/GF among themselves → conduct_score is the tiebreaker.
+    const games = [
+      makeGame('A', 'B', 1, 1),
+      makeGame('A', 'C', 1, 1),
+      makeGame('B', 'C', 1, 1),
+      makeGame('D', 'A', 2, 0),
+      makeGame('D', 'B', 2, 0),
+      makeGame('D', 'C', 2, 0),
+    ]
+    const positions = calculateGroupPosition(['A', 'B', 'C', 'D'], games, false, {
+      A: 1, B: 3, C: 5, D: 0,
+    })
+    // D has most pts so ranks first; among A/B/C, lower conduct = higher rank
+    expect(positions[0].team_id).toBe('D')
+    expect(positions[1].team_id).toBe('A')
+    expect(positions[2].team_id).toBe('B')
+    expect(positions[3].team_id).toBe('C')
+  })
+
+  it('team ID missing from conductScores map defaults to 0 (treated as best conduct)', () => {
+    // X has conduct=5 explicit; Y is missing from the map → defaults to 0 → Y ranks first
+    const positions = calculateGroupPosition(['X', 'Y'], [
+      makeGame('X', 'Y', 1, 1),
+    ], false, { X: 5 })
+    expect(positions[0].team_id).toBe('Y')
+    expect(positions[1].team_id).toBe('X')
+  })
+})

--- a/app/utils/__tests__/group-position-calculator.test.ts
+++ b/app/utils/__tests__/group-position-calculator.test.ts
@@ -105,3 +105,24 @@ describe('calculateGroupPosition — conduct_score tiebreaker', () => {
     expect(positions[1].team_id).toBe('X')
   })
 })
+
+describe('calculateGroupPosition — sortByGamesBetweenTeams tie resolution', () => {
+  it('swaps two tied teams when head-to-head is a draw but one has better overall stats', () => {
+    // 4-team group. A and B both have 4pts. Head-to-head A vs B is 0-0 (no winner).
+    // B has more goals_for (2 > 1) so genericTeamStatsComparator should rank B higher.
+    // This exercises the `!winnerTeam && sortByGamesBetweenTeams && comparator > 0` swap.
+    const games = [
+      makeGame('A', 'B', 0, 0), // head-to-head draw
+      makeGame('A', 'C', 1, 0), // A wins
+      makeGame('D', 'A', 2, 0), // D beats A
+      makeGame('B', 'C', 2, 0), // B wins
+      makeGame('D', 'B', 3, 0), // D beats B
+      makeGame('C', 'D', 0, 1), // D beats C
+    ]
+    // A: 4pts, GD=-1, GF=1 | B: 4pts, GD=-1, GF=2 → B should rank above A
+    const positions = calculateGroupPosition(['A', 'B', 'C', 'D'], games, true)
+    const aIndex = positions.findIndex(p => p.team_id === 'A')
+    const bIndex = positions.findIndex(p => p.team_id === 'B')
+    expect(bIndex).toBeLessThan(aIndex)
+  })
+})

--- a/app/utils/group-position-calculator.ts
+++ b/app/utils/group-position-calculator.ts
@@ -45,66 +45,83 @@ export const calculateGroupPosition = (teamIds: string[], games: GameWithResultO
   //TODO: cannot do anything more right now about 4 way ties if !sortByGameBetweenTeams
   // But if there is a four way tie when calculating by games between teams, then the proper thing to do
   // is to recalculate the group as we would normally do, fully based on stats.
-  if(sortByGamesBetweenTeams) {
-    const allSamePoints = teamStats.every(teamStat => teamStat.points === teamStats[0].points)
-
-    if(allSamePoints) {
-      return calculateGroupPosition(teamIds, games, false, conductScores)
-    }
+  if(sortByGamesBetweenTeams && teamStats.every(teamStat => teamStat.points === teamStats[0].points)) {
+    return calculateGroupPosition(teamIds, games, false, conductScores)
   }
 
-  let threeWayTie = false
-  //Three way ties
-  if (teamStats.length === 4) {
-    const equals = sortByGamesBetweenTeams ? pointsBasedTeamStatsEquals : genericTeamStatsEquals
-    const topThreeWayTie = equals(teamStats[0], teamStats[1]) && equals(teamStats[1], teamStats[2])
-    const bottomThreeWayTie = equals(teamStats[1], teamStats[2]) && equals(teamStats[2], teamStats[3])
-    threeWayTie = topThreeWayTie || bottomThreeWayTie
-    if(threeWayTie) {
-      //Three way ties
-      // Among the top 3 teams
-      const baseIndex = topThreeWayTie  ? 0 : 1
-      const tiedTeams = teamStats.slice(baseIndex, baseIndex + 3).map(teamStat => teamStat.team_id)
-      const tiedTeamGames = games.filter(game =>
-        tiedTeams.includes(game.home_team as string) && tiedTeams.includes(game.away_team as string));
-      const threeWayTieStats = calculateGroupPosition(tiedTeams, tiedTeamGames, sortByGamesBetweenTeams, conductScores).sort(genericTeamStatsComparator);
+  const threeWayTie = resolveThreeWayTie(teamStats, teamsStatsByTeam, games, sortByGamesBetweenTeams, conductScores)
 
-      threeWayTieStats.forEach((teamStat, index) => {
-        teamStats[baseIndex + index] = teamsStatsByTeam[teamStat.team_id]
-      })
-    }
-  }
   if (!threeWayTie) {
-    for(let i = 0; i < teamStats.length - 1; i++) {
-      const equals = sortByGamesBetweenTeams ? pointsBasedTeamStatsEquals : genericTeamStatsEquals
-      if(equals(teamStats[i], teamStats[i+1])) {
-        const tiedTeams = [teamStats[i].team_id, teamStats[i+1].team_id];
-        const teamsGame = games.find(game =>
-          tiedTeams.includes(game.home_team as string) && tiedTeams.includes(game.away_team as string));
-        const winnerTeam = getWinner(teamsGame?.resultOrGuess?.home_score,
-          teamsGame?.resultOrGuess?.away_score,
-          undefined,
-          undefined,
-          teamsGame?.home_team,
-          teamsGame?.away_team)
-        //First sort by matches played between the 2 teams
-        if (winnerTeam && winnerTeam != teamStats[i].team_id) {
-          const temp = teamStats[i]
-          teamStats[i] = teamStats[i+1];
-          teamStats[i+1] = temp
-        } else if (!winnerTeam && sortByGamesBetweenTeams) {
-          // If there was no winner, and I haven't yet sorted by stats, sort by stats.
-          if (genericTeamStatsComparator(teamStats[i], teamStats[i + 1]) > 0) {
-            const temp = teamStats[i]
-            teamStats[i] = teamStats[i + 1];
-            teamStats[i + 1] = temp
-          }
-        }
-      }
-    }
+    resolveTwoWayTies(teamStats, games, sortByGamesBetweenTeams)
   }
 
   return teamStats;
+}
+
+const resolveThreeWayTie = (
+  teamStats: TeamStats[],
+  teamsStatsByTeam: Record<string, TeamStats>,
+  games: GameWithResultOrGuess[],
+  sortByGamesBetweenTeams: boolean,
+  conductScores: Record<string, number>
+): boolean => {
+  if (teamStats.length !== 4) return false
+
+  const equals = sortByGamesBetweenTeams ? pointsBasedTeamStatsEquals : genericTeamStatsEquals
+  const topThreeWayTie = equals(teamStats[0], teamStats[1]) && equals(teamStats[1], teamStats[2])
+  const bottomThreeWayTie = equals(teamStats[1], teamStats[2]) && equals(teamStats[2], teamStats[3])
+
+  if (!topThreeWayTie && !bottomThreeWayTie) return false
+
+  //Three way ties
+  // Among the top 3 or bottom 3 teams
+  const baseIndex = topThreeWayTie ? 0 : 1
+  const tiedTeams = teamStats.slice(baseIndex, baseIndex + 3).map(teamStat => teamStat.team_id)
+  const tiedTeamGames = games.filter(game =>
+    tiedTeams.includes(game.home_team as string) && tiedTeams.includes(game.away_team as string))
+  const threeWayTieStats = calculateGroupPosition(tiedTeams, tiedTeamGames, sortByGamesBetweenTeams, conductScores)
+    .sort(genericTeamStatsComparator)
+
+  threeWayTieStats.forEach((teamStat, index) => {
+    teamStats[baseIndex + index] = teamsStatsByTeam[teamStat.team_id]
+  })
+
+  return true
+}
+
+const resolveTwoWayTies = (
+  teamStats: TeamStats[],
+  games: GameWithResultOrGuess[],
+  sortByGamesBetweenTeams: boolean
+): void => {
+  const equals = sortByGamesBetweenTeams ? pointsBasedTeamStatsEquals : genericTeamStatsEquals
+
+  for(let i = 0; i < teamStats.length - 1; i++) {
+    if (!equals(teamStats[i], teamStats[i+1])) continue
+
+    const tiedTeams = [teamStats[i].team_id, teamStats[i+1].team_id]
+    const teamsGame = games.find(game =>
+      tiedTeams.includes(game.home_team as string) && tiedTeams.includes(game.away_team as string))
+    const winnerTeam = getWinner(teamsGame?.resultOrGuess?.home_score,
+      teamsGame?.resultOrGuess?.away_score,
+      undefined,
+      undefined,
+      teamsGame?.home_team,
+      teamsGame?.away_team)
+    //First sort by matches played between the 2 teams
+    if (winnerTeam && winnerTeam != teamStats[i].team_id) {
+      const temp = teamStats[i]
+      teamStats[i] = teamStats[i+1];
+      teamStats[i+1] = temp
+    } else if (!winnerTeam && sortByGamesBetweenTeams) {
+      // If there was no winner, and I haven't yet sorted by stats, sort by stats.
+      if (genericTeamStatsComparator(teamStats[i], teamStats[i + 1]) > 0) {
+        const temp = teamStats[i]
+        teamStats[i] = teamStats[i + 1];
+        teamStats[i + 1] = temp
+      }
+    }
+  }
 }
 
 /**

--- a/app/utils/group-position-calculator.ts
+++ b/app/utils/group-position-calculator.ts
@@ -24,8 +24,9 @@ export interface GameWithResultOrGuess extends Game{
  *
 * @param teamIds - The Ids of the 4 teams of a given group
 * @param games - Games played by the 4 teams of the group, with the scores filled
+* @param conductScores - Optional map of team_id to conduct_score; missing keys default to 0
 */
-export const calculateGroupPosition = (teamIds: string[], games: GameWithResultOrGuess[], sortByGamesBetweenTeams = false): TeamStats[] => {
+export const calculateGroupPosition = (teamIds: string[], games: GameWithResultOrGuess[], sortByGamesBetweenTeams = false, conductScores: Record<string, number> = {}): TeamStats[] => {
   const gamesWithScores = games.filter(game =>
     (Number.isInteger(game.resultOrGuess?.home_score) && Number.isInteger(game.resultOrGuess?.away_score)))
 
@@ -34,7 +35,7 @@ export const calculateGroupPosition = (teamIds: string[], games: GameWithResultO
   const teamsStatsByTeam = Object.fromEntries(teamIds.map(teamId => [
     teamId,
     gamesWithScores.filter(game => game.home_team === teamId|| game.away_team === teamId)
-      .reduce(teamStatsGameReducer(teamId), { ...initialTeamStats, team_id: teamId, is_complete: isComplete })
+      .reduce(teamStatsGameReducer(teamId), { ...initialTeamStats, team_id: teamId, is_complete: isComplete, conduct_score: conductScores[teamId] ?? 0 })
   ]))
 
   //Depending on the tournament rules, we may need to calculate differently how teams with the same points are sorted
@@ -48,7 +49,7 @@ export const calculateGroupPosition = (teamIds: string[], games: GameWithResultO
     const allSamePoints = teamStats.every(teamStat => teamStat.points === teamStats[0].points)
 
     if(allSamePoints) {
-      return calculateGroupPosition(teamIds, games, false)
+      return calculateGroupPosition(teamIds, games, false, conductScores)
     }
   }
 
@@ -66,7 +67,7 @@ export const calculateGroupPosition = (teamIds: string[], games: GameWithResultO
       const tiedTeams = teamStats.slice(baseIndex, baseIndex + 3).map(teamStat => teamStat.team_id)
       const tiedTeamGames = games.filter(game =>
         tiedTeams.includes(game.home_team as string) && tiedTeams.includes(game.away_team as string));
-      const threeWayTieStats = calculateGroupPosition(tiedTeams, tiedTeamGames, sortByGamesBetweenTeams).sort(genericTeamStatsComparator);
+      const threeWayTieStats = calculateGroupPosition(tiedTeams, tiedTeamGames, sortByGamesBetweenTeams, conductScores).sort(genericTeamStatsComparator);
 
       threeWayTieStats.forEach((teamStat, index) => {
         teamStats[baseIndex + index] = teamsStatsByTeam[teamStat.team_id]

--- a/app/utils/group-position-calculator.ts
+++ b/app/utils/group-position-calculator.ts
@@ -99,9 +99,9 @@ const resolveTwoWayTies = (
   for(let i = 0; i < teamStats.length - 1; i++) {
     if (!equals(teamStats[i], teamStats[i+1])) continue
 
-    const tiedTeams = [teamStats[i].team_id, teamStats[i+1].team_id]
+    const tiedTeams = new Set([teamStats[i].team_id, teamStats[i+1].team_id])
     const teamsGame = games.find(game =>
-      tiedTeams.includes(game.home_team as string) && tiedTeams.includes(game.away_team as string))
+      tiedTeams.has(game.home_team as string) && tiedTeams.has(game.away_team as string))
     const winnerTeam = getWinner(teamsGame?.resultOrGuess?.home_score,
       teamsGame?.resultOrGuess?.away_score,
       undefined,

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -29,8 +29,8 @@ Administrative tournament management — full lifecycle operations: tournament c
   Calls: updatePlayoffGameGuesses
 - **calculateGameScores(forceDrafts, forceAllGuesses, locale)**: `Promise<void>` — Recalculates all game guess scores, then triggers group rank snapshot materialization for all affected users.
   Calls: findAllGamesWithPublishedResultsAndGameGuesses, findAllGuessesForGamesWithResultsInDraft, findTournamentById, calculateScoreForGame, updateGameGuessWithBoost, updateGameGuess, recalculateGameScoresForUsers, recalculateGroupRankingsForUsers
-- **calculateAndStoreGroupPosition(groupId, teamIds, groupGames, sortByGamesBetweenTeams)**: `Promise<void>` — Updates group standings.
-  Calls: calculateGroupPosition, updateTournamentGroupTeams
+- **calculateAndStoreGroupPosition(groupId, teamIds, groupGames, sortByGamesBetweenTeams)**: `Promise<void>` — Updates group standings. Fetches current conduct_scores from DB before calculating so admin-set values are preserved and used in the tiebreaker sort.
+  Calls: findTeamsInGroup, calculateGroupPosition, updateTournamentGroupTeams
 - **findDataForAwards(tournamentId)**: `Promise<{ tournament: Tournament; players: ExtendedPlayerData[] }>` — Gets tournament and players for award assignment.
   Calls: findTournamentById, findAllPlayersInTournamentWithTeamData, applyLocalization
 - **updateTournamentAwards(tournamentId, withUpdate, locale)**: `Promise<void>` — Updates individual awards, recalculates scores, writes daily score snapshot for each user, then triggers group rank snapshot materialization for all tournament participants.

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-09
+**Last updated:** 2026-05-11
 
 ---
 

--- a/docs/code-structure/components/components-backoffice.md
+++ b/docs/code-structure/components/components-backoffice.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-09
+**Last updated:** 2026-05-11
 
 ---
 
@@ -117,8 +117,8 @@ Grid of groups with edit action. [Client] group management interface.
 ### app/components/backoffice/group-backoffice-tab.tsx
 Group-specific backoffice with games, standings, and conduct score editing. [Client] group data management.
 - **GroupBackoffice({ group, tournamentId }: Props)**: `JSX.Element` — [Client] Manages games, team standings, and conduct scores for a specific group.
-  Calls: getCompleteGroupData, saveGameResults, calculateAndSavePlayoffGamesForTournament, saveGamesData, calculateAndStoreGroupPosition, calculateGameScores, calculateAndStoreQualifiedTeamsScores, updateGroupTeamConductScores
-  Uses: useLocale, useEffect, useState, useMemo
+  Calls: getCompleteGroupData, calculateGroupPosition, saveGameResults, calculateAndSavePlayoffGamesForTournament, saveGamesData, calculateAndStoreGroupPosition, calculateGameScores, calculateAndStoreQualifiedTeamsScores, updateGroupTeamConductScores
+  Uses: useLocale, useEffect, useState
   Renders: BackofficeFlippableGameCard, BulkActionsMenu, TeamStandingsCards, TeamStatsEditDialog, Button, Grid, Paper, Snackbar, Alert
 
 ### app/components/backoffice/playoff-tab.tsx

--- a/docs/code-structure/components/components-tournament-games.md
+++ b/docs/code-structure/components/components-tournament-games.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-09
+**Last updated:** 2026-05-11
 
 ---
 
@@ -235,7 +235,7 @@ Expandable card showing team rank, name, points with collapsible details (W-D-L,
 
 **File:** `app/components/groups-page/team-standings-cards.tsx`
 Container for team standing cards with rank calculation, qualification highlighting, and rank change indicators.
-- **TeamStandingsCards** (FC) - `[Client]` - Calls: none - Uses: `useTranslations, useMemo, useState` - Renders: `LayoutGroup, Box, TeamStandingCard`
+- **TeamStandingsCards** (FC) - `[Client]` - Calls: `calculateRanks` - Uses: `useTranslations, useMemo, useState` - Renders: `LayoutGroup, Box, TeamStandingCard`
 
 **File:** `app/components/groups-page/types.ts`
 Type definitions for team standings components (TeamStanding, TeamStandingsCardsProps, TeamStandingCardProps).

--- a/docs/code-structure/utils.md
+++ b/docs/code-structure/utils.md
@@ -158,7 +158,7 @@ Game prediction scoring calculation with three tiers: exact score (3pt), goal di
 ### app/utils/group-position-calculator.ts
 Group stage team ranking calculator implementing FIFA tiebreaker rules and two-team head-to-head logic.
 
-- **calculateGroupPosition(teamIds, games, sortByGamesBetweenTeams)**: `TeamStats[]` — Calculates final group standings applying FIFA tiebreaker rules (points, goal difference, goals for, conduct score) with support for two-way and three-way ties.
+- **calculateGroupPosition(teamIds, games, sortByGamesBetweenTeams, conductScores)**: `TeamStats[]` — Calculates final group standings applying FIFA tiebreaker rules (points, goal difference, goals for, conduct score) with support for two-way and three-way ties. `conductScores` is an optional map of team_id → conduct_score; missing keys default to 0.
   Calls: getWinner, genericTeamStatsComparator
 - **genericTeamStatsComparator(a, b)**: `number` — Comparator function for sorting teams by complete FIFA stats hierarchy (higher score ranks better).
 - **pointsBasesTeamStatsComparator(a, b)**: `number` — Simple comparator sorting teams by points only (used in first pass for games-between-teams mode).

--- a/docs/code-structure/utils.md
+++ b/docs/code-structure/utils.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-09
+**Last updated:** 2026-05-11
 
 ---
 

--- a/plans/STORY-431-context.md
+++ b/plans/STORY-431-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** [Bug] Group standings tiebreaker ranks teams incorrectly when conduct scores are set
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-431
 - **Branch:** feature/story-431
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 440
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/440
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-431-context.md
+++ b/plans/STORY-431-context.md
@@ -9,9 +9,9 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/440
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** review-ready
 - **Plan File:** plans/STORY-431-plan.md
-- **Task File:** (fill when implementation starts)
+- **Task File:** plans/STORY-431-tasks.md
 
 ## Quick Summary
 Fixes three compounding bugs that cause group standings to display incorrect rankings when admins set conduct scores: (1) `calculateGroupPosition` ignores conduct scores entirely (always starts at 0), (2) `calculateAndStoreGroupPosition` wipes admin-set conduct scores by overwriting them with 0 every time positions are recalculated, and (3) `TeamStandingsCards` client-side sort only uses points and goal_difference, ignoring goals_for and conduct_score.

--- a/plans/STORY-431-context.md
+++ b/plans/STORY-431-context.md
@@ -1,0 +1,17 @@
+# Story 431 Context
+
+## Metadata
+- **Story Number:** 431
+- **Story Title:** [Bug] Group standings tiebreaker ranks teams incorrectly when conduct scores are set
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-431
+- **Branch:** feature/story-431
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-431-plan.md
+- **Task File:** (fill when implementation starts)
+
+## Quick Summary
+Fixes three compounding bugs that cause group standings to display incorrect rankings when admins set conduct scores: (1) `calculateGroupPosition` ignores conduct scores entirely (always starts at 0), (2) `calculateAndStoreGroupPosition` wipes admin-set conduct scores by overwriting them with 0 every time positions are recalculated, and (3) `TeamStandingsCards` client-side sort only uses points and goal_difference, ignoring goals_for and conduct_score.

--- a/plans/STORY-431-plan.md
+++ b/plans/STORY-431-plan.md
@@ -1,0 +1,127 @@
+# Plan: [Bug] Group standings tiebreaker ranks teams incorrectly when conduct scores are set (#431)
+
+## Context
+
+Admins can update conduct scores for teams via the backoffice team-stats dialog. Conduct score is the final tiebreaker in group standings (after points → goal difference → goals scored). Lower is better.
+
+Three separate bugs compound to produce incorrect ranking:
+
+1. **`calculateGroupPosition` ignores conduct_scores** — always starts each team at `conduct_score: 0`; the game-reducer never updates it since conduct is set separately from game results.
+2. **`calculateAndStoreGroupPosition` wipes conduct_scores in DB** — it calls `calculateGroupPosition` (which returns 0 for conduct_scores), then `updateTournamentGroupTeams` writes those zeroes over the admin-set values. This happens every time game results are saved or the admin triggers recalculation.
+3. **`TeamStandingsCards` client-side sort only uses points + goal_difference** — even if the DB had correct data, the display re-sorts without goals_for or conduct_score, so tied teams appear in wrong order.
+
+The backoffice local standings preview (useEffect calling `calculateGroupPosition` directly in `group-backoffice-tab.tsx`) has the same issue.
+
+---
+
+## Acceptance Criteria (from issue)
+
+- After admin updates conduct scores, standings re-rank tied teams with lower conduct score ranked higher
+- Conduct score acts as last tiebreaker (points → goal difference → goals for → conduct score)
+- Corrected ranking appears in both backoffice standings view and public tournament standings
+
+---
+
+## Technical Approach
+
+Four targeted changes + new unit tests. No schema changes needed. No new DB columns.
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/utils/group-position-calculator.ts` | Add `conductScores` param; inject into initial stats; thread through recursive calls |
+| `app/actions/backoffice-actions.ts` | Fetch existing conduct_scores from DB before calculating; pass to `calculateGroupPosition` |
+| `app/components/groups-page/team-standings-cards.tsx` | Extend sort to include goals_for and conduct_score |
+| `app/components/backoffice/group-backoffice-tab.tsx` | Pass `conductScores` state to local `calculateGroupPosition` useEffect |
+| `docs/code-structure/utils.md` | Update `calculateGroupPosition` signature |
+| `docs/code-structure/actions.md` | Update `calculateAndStoreGroupPosition` description |
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `app/utils/__tests__/group-position-calculator.test.ts` | Unit tests for conduct_score tiebreaking |
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+No new cross-layer flows added. Existing flows modified:
+- **calculateAndStoreGroupPosition** — now calls `findTeamsInGroup` before `calculateGroupPosition` to load current conduct scores.
+
+### `app/utils/group-position-calculator.ts` *(modified)*
+
+**Changed function:**
+
+- **calculateGroupPosition(teamIds, games, sortByGamesBetweenTeams, conductScores)**: `TeamStats[]`
+  *(was: no conductScores param)*
+  Adds optional 4th param `conductScores: Record<string, number> = {}`. Injects `conductScores[teamId] ?? 0` into the initial stats for each team so `getMagicNumber` correctly uses conduct score for tiebreaking. Threads the parameter through all recursive calls. No defensive validation added — callers guarantee valid data (`calculateAndStoreGroupPosition` ensures all teamIds have entries, or defaults to 0 for missing keys via `?? 0`).
+  Calls: getWinner, genericTeamStatsComparator, pointsBasesTeamStatsComparator
+  Tests:
+  - two teams equal on points, GD, and goals_for but different conduct_score → team with lower conduct_score ranks first
+  - team with conduct_score=0 (default) vs team with conduct_score=5 → zero-score team ranks first
+  - conductScores parameter is optional; omitting it preserves existing sort behavior (backward compat)
+  - team with better goal_difference ranks above another even when the lower-GD team has conduct_score=0 (GD beats conduct)
+  - team with more goals_for ranks above another even when the lower-GF team has conduct_score=0 (goals_for beats conduct)
+  - three-way tie resolved: teams with different conduct_scores rank in correct order when all other stats are equal
+  - team ID missing from conductScores map defaults to 0 (?? 0 fallback, treated as best conduct)
+
+### `app/actions/backoffice-actions.ts` *(modified)*
+
+**Changed function:**
+
+- **calculateAndStoreGroupPosition(groupId, teamIds, groupGames, sortByGamesBetweenTeams)**: `Promise<void>`
+  *(signature unchanged, internal logic changes)*
+  Before calling `calculateGroupPosition`, calls `findTeamsInGroup(group_id)` to read current conduct_scores and builds a `Record<string, number>` map. Passes this map as the 4th arg to `calculateGroupPosition`. The result then carries correct conduct_scores that are written back to DB, preserving admin-set values.
+  Calls: findTeamsInGroup, calculateGroupPosition, updateTournamentGroupTeams
+
+### `app/components/groups-page/team-standings-cards.tsx` *(modified)*
+
+**Changed logic (no signature change):**
+
+- **sort comparator in `useMemo`** (lines 26-29 and 37-39):
+  Extends the sort chain: points → goal_difference → goals_for → conduct_score (lower is better).
+  Before: `return b.goal_difference - a.goal_difference` as final fallback.
+  After: adds `if (b.goals_for !== a.goals_for) return b.goals_for - a.goals_for` then `return (a.conduct_score || 0) - (b.conduct_score || 0)`.
+  Same fix applied to the `prevSorted` comparator (previousTeamStats).
+
+### `app/components/backoffice/group-backoffice-tab.tsx` *(modified)*
+
+**Changed logic:**
+
+- **useEffect that calls `calculateGroupPosition` locally** (lines ~80-89):
+  Passes `conductScores` state as 4th arg so the backoffice live preview also ranks by conduct score.
+  Adds `conductScores` to the useEffect dependency array.
+
+---
+
+## Testing Strategy
+
+### New test file: `app/utils/__tests__/group-position-calculator.test.ts`
+
+Tests to write (all 7 map to the Mid-Level Design test cases above):
+- `conduct_score tiebreaker: lower conduct_score ranks higher when all other stats are equal`
+- `conduct_score tiebreaker: team with conduct_score=0 ranks above team with conduct_score=5`
+- `conduct_score is optional (backward compat): omitting conductScores parameter gives same results as before`
+- `goal_difference beats conduct_score: team with better GD ranks higher even with conduct_score=0`
+- `goals_for beats conduct_score: team with more goals_for ranks higher even with conduct_score=0`
+- `three-way tie with conduct_score: tied teams ranked correctly by conduct_score as final tiebreaker`
+- `missing team ID in conductScores defaults to 0`
+
+Pattern: construct test data inline using local helpers (e.g. `makeGame(homeTeam, awayTeam, homeScore, awayScore)`), matching the style in `group-standings-calculator.test.ts`. No external factories.
+
+Coverage: `calculateGroupPosition` is currently uncovered → this file provides direct coverage.
+
+---
+
+## Validation
+
+1. Run `npm test` — new tests in `group-position-calculator.test.ts` must pass; no regressions in existing standings tests
+2. Run `npm run build` and `npm run lint`
+3. In Vercel Preview: open backoffice for a group with tied teams (same points, GD, GF), set different conduct scores via the team-stats dialog, save → verify standings reorder with lower conduct score first
+4. Verify the public tournament standings page shows the same corrected order


### PR DESCRIPTION
Fixes #431

## Summary
Implementation plan for the story.

## Plan Document
See `plans/STORY-431-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)