### PR TITLE
Plan: [Story] Add copy-to-clipboard UX to OTP authentication email #459

### DIFF
--- a/app/actions/__tests__/otp-actions.test.ts
+++ b/app/actions/__tests__/otp-actions.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateOTPEmailContent } from '../otp-actions';
+
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn().mockImplementation(({ namespace }: { namespace: string }) => {
+    const translations: Record<string, Record<string, string>> = {
+      emails: {
+        'otp.subject': 'Your Access Code - Prode Mundial',
+        'otp.title': 'Your Access Code',
+        'otp.greeting': 'You have requested a code to sign in to Prode Mundial.',
+        'otp.validity': '⏱️ Valid for 3 minutes',
+        'otp.attempts': 'You have a maximum of 3 attempts to enter this code.',
+        'otp.securityTitle': '⚠️ Security:',
+        'otp.securityTips.tip1': 'Do not share this code with anyone',
+        'otp.securityTips.tip2': 'Prode Mundial will never ask you for this code by phone or email',
+        'otp.securityTips.tip3': 'If you did not request this code, you can ignore this message',
+        'otp.requestedFor': 'This code was requested for:',
+        'otp.support': 'If you have trouble signing in, contact support.',
+      },
+      emails_es: {
+        'otp.subject': 'Tu código de acceso - Prode Mundial',
+        'otp.title': 'Tu código de acceso',
+        'otp.greeting': 'Has solicitado un código para iniciar sesión en Prode Mundial.',
+        'otp.validity': '⏱️ Válido por 3 minutos',
+        'otp.attempts': 'Tienes un máximo de 3 intentos para ingresar este código.',
+        'otp.securityTitle': '⚠️ Seguridad:',
+        'otp.securityTips.tip1': 'No compartas este código con nadie',
+        'otp.securityTips.tip2': 'Prode Mundial nunca te pedirá este código por teléfono o correo',
+        'otp.securityTips.tip3': 'Si no solicitaste este código, puedes ignorar este mensaje',
+        'otp.requestedFor': 'Este código fue solicitado para:',
+        'otp.support': 'Si tienes problemas para iniciar sesión, contacta al soporte.',
+      },
+    };
+    return Promise.resolve((key: string) => translations[namespace]?.[key] ?? key);
+  }),
+}));
+
+describe('generateOTPEmailContent — OTP detection formatting', () => {
+  const OTP_CODE = '847391';
+  const TEST_EMAIL = 'user@example.com';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('subject starts with the OTP code followed by a dash separator', async () => {
+    const { subject } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'en');
+
+    expect(subject).toMatch(new RegExp(`^${OTP_CODE} - `));
+  });
+
+  it('subject ends with the existing translated suffix', async () => {
+    const { subject } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'en');
+
+    expect(subject).toBe(`${OTP_CODE} - Your Access Code - Prode Mundial`);
+  });
+
+  it('plain-text body contains the OTP code on its own prominent line before the greeting', async () => {
+    const { text } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'en');
+
+    const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
+    const codeLine = lines[0];
+    expect(codeLine).toContain(OTP_CODE);
+    // Greeting appears after the code line
+    const greetingIndex = lines.findIndex((l) => l.includes('requested a code'));
+    const codeIndex = lines.findIndex((l) => l.includes(OTP_CODE));
+    expect(codeIndex).toBeLessThan(greetingIndex);
+  });
+
+  it('html body still contains the OTP code block (no visual regression)', async () => {
+    const { html } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'en');
+
+    expect(html).toContain(OTP_CODE);
+  });
+
+  it('subject prefix works for Spanish locale', async () => {
+    // Re-mock for Spanish namespace
+    const { getTranslations } = await import('next-intl/server');
+    vi.mocked(getTranslations).mockImplementationOnce(({ namespace }: { namespace: string; locale?: string }) => {
+      if (namespace === 'emails') {
+        return Promise.resolve((key: string) => {
+          const es: Record<string, string> = {
+            'otp.subject': 'Tu código de acceso - Prode Mundial',
+            'otp.title': 'Tu código de acceso',
+            'otp.greeting': 'Has solicitado un código.',
+            'otp.validity': 'Válido 3 minutos',
+            'otp.attempts': 'Máximo 3 intentos.',
+            'otp.securityTitle': 'Seguridad:',
+            'otp.securityTips.tip1': 'tip1',
+            'otp.securityTips.tip2': 'tip2',
+            'otp.securityTips.tip3': 'tip3',
+            'otp.requestedFor': 'Solicitado para:',
+            'otp.support': 'Contacta soporte.',
+          };
+          return es[key] ?? key;
+        }) as ReturnType<typeof getTranslations>;
+      }
+      return Promise.resolve((key: string) => key) as ReturnType<typeof getTranslations>;
+    });
+
+    const { subject } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'es');
+
+    expect(subject).toMatch(new RegExp(`^${OTP_CODE} - `));
+    expect(subject).toContain('Tu código de acceso - Prode Mundial');
+  });
+});

--- a/app/actions/__tests__/otp-actions.test.ts
+++ b/app/actions/__tests__/otp-actions.test.ts
@@ -1,37 +1,41 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { generateOTPEmailContent } from '../otp-actions';
 
+const EN_OTP_TRANSLATIONS: Record<string, string> = {
+  'otp.subject': 'Your Access Code - Prode Mundial',
+  'otp.title': 'Your Access Code',
+  'otp.greeting': 'You have requested a code to sign in to Prode Mundial.',
+  'otp.validity': '⏱️ Valid for 3 minutes',
+  'otp.attempts': 'You have a maximum of 3 attempts to enter this code.',
+  'otp.securityTitle': '⚠️ Security:',
+  'otp.securityTips.tip1': 'Do not share this code with anyone',
+  'otp.securityTips.tip2': 'Prode Mundial will never ask you for this code by phone or email',
+  'otp.securityTips.tip3': 'If you did not request this code, you can ignore this message',
+  'otp.requestedFor': 'This code was requested for:',
+  'otp.support': 'If you have trouble signing in, contact support.',
+};
+
+const ES_OTP_TRANSLATIONS: Record<string, string> = {
+  'otp.subject': 'Tu código de acceso - Prode Mundial',
+  'otp.title': 'Tu código de acceso',
+  'otp.greeting': 'Has solicitado un código para iniciar sesión en Prode Mundial.',
+  'otp.validity': '⏱️ Válido por 3 minutos',
+  'otp.attempts': 'Tienes un máximo de 3 intentos para ingresar este código.',
+  'otp.securityTitle': '⚠️ Seguridad:',
+  'otp.securityTips.tip1': 'No compartas este código con nadie',
+  'otp.securityTips.tip2': 'Prode Mundial nunca te pedirá este código por teléfono o correo',
+  'otp.securityTips.tip3': 'Si no solicitaste este código, puedes ignorar este mensaje',
+  'otp.requestedFor': 'Este código fue solicitado para:',
+  'otp.support': 'Si tienes problemas para iniciar sesión, contacta al soporte.',
+};
+
 vi.mock('next-intl/server', () => ({
-  getTranslations: vi.fn().mockImplementation(({ namespace }: { namespace: string }) => {
-    const translations: Record<string, Record<string, string>> = {
-      emails: {
-        'otp.subject': 'Your Access Code - Prode Mundial',
-        'otp.title': 'Your Access Code',
-        'otp.greeting': 'You have requested a code to sign in to Prode Mundial.',
-        'otp.validity': '⏱️ Valid for 3 minutes',
-        'otp.attempts': 'You have a maximum of 3 attempts to enter this code.',
-        'otp.securityTitle': '⚠️ Security:',
-        'otp.securityTips.tip1': 'Do not share this code with anyone',
-        'otp.securityTips.tip2': 'Prode Mundial will never ask you for this code by phone or email',
-        'otp.securityTips.tip3': 'If you did not request this code, you can ignore this message',
-        'otp.requestedFor': 'This code was requested for:',
-        'otp.support': 'If you have trouble signing in, contact support.',
-      },
-      emails_es: {
-        'otp.subject': 'Tu código de acceso - Prode Mundial',
-        'otp.title': 'Tu código de acceso',
-        'otp.greeting': 'Has solicitado un código para iniciar sesión en Prode Mundial.',
-        'otp.validity': '⏱️ Válido por 3 minutos',
-        'otp.attempts': 'Tienes un máximo de 3 intentos para ingresar este código.',
-        'otp.securityTitle': '⚠️ Seguridad:',
-        'otp.securityTips.tip1': 'No compartas este código con nadie',
-        'otp.securityTips.tip2': 'Prode Mundial nunca te pedirá este código por teléfono o correo',
-        'otp.securityTips.tip3': 'Si no solicitaste este código, puedes ignorar este mensaje',
-        'otp.requestedFor': 'Este código fue solicitado para:',
-        'otp.support': 'Si tienes problemas para iniciar sesión, contacta al soporte.',
-      },
-    };
-    return Promise.resolve((key: string) => translations[namespace]?.[key] ?? key);
+  getTranslations: vi.fn().mockImplementation(({ locale, namespace }: { locale: string; namespace: string }) => {
+    if (namespace === 'emails') {
+      const map = locale === 'es' ? ES_OTP_TRANSLATIONS : EN_OTP_TRANSLATIONS;
+      return Promise.resolve((key: string) => map[key] ?? key);
+    }
+    return Promise.resolve((key: string) => key);
   }),
 }));
 
@@ -43,28 +47,19 @@ describe('generateOTPEmailContent — OTP detection formatting', () => {
     vi.clearAllMocks();
   });
 
-  it('subject starts with the OTP code followed by a dash separator', async () => {
-    const { subject } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'en');
-
-    expect(subject).toMatch(new RegExp(`^${OTP_CODE} - `));
-  });
-
-  it('subject ends with the existing translated suffix', async () => {
+  it('subject is prefixed with the OTP code and retains the translated suffix', async () => {
     const { subject } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'en');
 
     expect(subject).toBe(`${OTP_CODE} - Your Access Code - Prode Mundial`);
   });
 
-  it('plain-text body contains the OTP code on its own prominent line before the greeting', async () => {
+  it('plain-text body has the OTP code on its own line before the greeting', async () => {
     const { text } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'en');
 
     const lines = text.split('\n').map((l) => l.trim()).filter(Boolean);
-    const codeLine = lines[0];
-    expect(codeLine).toContain(OTP_CODE);
-    // Greeting appears after the code line
+    expect(lines[0]).toContain(OTP_CODE);
     const greetingIndex = lines.findIndex((l) => l.includes('requested a code'));
-    const codeIndex = lines.findIndex((l) => l.includes(OTP_CODE));
-    expect(codeIndex).toBeLessThan(greetingIndex);
+    expect(greetingIndex).toBeGreaterThan(0);
   });
 
   it('html body still contains the OTP code block (no visual regression)', async () => {
@@ -73,34 +68,9 @@ describe('generateOTPEmailContent — OTP detection formatting', () => {
     expect(html).toContain(OTP_CODE);
   });
 
-  it('subject prefix works for Spanish locale', async () => {
-    // Re-mock for Spanish namespace
-    const { getTranslations } = await import('next-intl/server');
-    vi.mocked(getTranslations).mockImplementationOnce(({ namespace }: { namespace: string; locale?: string }) => {
-      if (namespace === 'emails') {
-        return Promise.resolve((key: string) => {
-          const es: Record<string, string> = {
-            'otp.subject': 'Tu código de acceso - Prode Mundial',
-            'otp.title': 'Tu código de acceso',
-            'otp.greeting': 'Has solicitado un código.',
-            'otp.validity': 'Válido 3 minutos',
-            'otp.attempts': 'Máximo 3 intentos.',
-            'otp.securityTitle': 'Seguridad:',
-            'otp.securityTips.tip1': 'tip1',
-            'otp.securityTips.tip2': 'tip2',
-            'otp.securityTips.tip3': 'tip3',
-            'otp.requestedFor': 'Solicitado para:',
-            'otp.support': 'Contacta soporte.',
-          };
-          return es[key] ?? key;
-        }) as ReturnType<typeof getTranslations>;
-      }
-      return Promise.resolve((key: string) => key) as ReturnType<typeof getTranslations>;
-    });
-
+  it('subject is correctly prefixed for Spanish locale', async () => {
     const { subject } = await generateOTPEmailContent(TEST_EMAIL, OTP_CODE, 'es');
 
-    expect(subject).toMatch(new RegExp(`^${OTP_CODE} - `));
-    expect(subject).toContain('Tu código de acceso - Prode Mundial');
+    expect(subject).toBe(`${OTP_CODE} - Tu código de acceso - Prode Mundial`);
   });
 });

--- a/app/actions/otp-actions.ts
+++ b/app/actions/otp-actions.ts
@@ -9,10 +9,10 @@ import { User } from "../db/tables-definition";
 /**
  * Generate OTP email template with internationalized content
  */
-async function generateOTPEmailContent(email: string, otpCode: string, locale: Locale = 'es'): Promise<{ subject: string; html: string; text: string }> {
+export async function generateOTPEmailContent(email: string, otpCode: string, locale: Locale = 'es'): Promise<{ subject: string; html: string; text: string }> {
   const t = await getTranslations({ locale, namespace: 'emails' });
 
-  const subject = t('otp.subject');
+  const subject = `${otpCode} - ${t('otp.subject')}`;
 
   const html = `
     <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
@@ -56,11 +56,9 @@ async function generateOTPEmailContent(email: string, otpCode: string, locale: L
   `;
 
   const text = `
-${t('otp.subject')}
+${t('otp.title')}: ${otpCode}
 
 ${t('otp.greeting')}
-
-${t('otp.title')}: ${otpCode}
 
 ${t('otp.validity')}
 ${t('otp.attempts')}

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-20
+**Last updated:** 2026-05-21
 
 ---
 
@@ -147,6 +147,8 @@ Manages user onboarding flow, checklist state, and tooltip dismissal.
 ### app/actions/otp-actions.ts
 OTP (one-time password) based authentication and account creation.
 
+- **generateOTPEmailContent(email, otpCode, locale)**: `Promise<{ subject: string; html: string; text: string }>` — Generates localised OTP email content. Subject is prefixed with the OTP code (`"${otpCode} - ${subject}"`) for iOS/Android/Gmail native autofill detection. Plain-text opens with `"${title}: ${otpCode}"` for OS-level code heuristics. (Story #459)
+  Calls: getTranslations
 - **sendOTPCode(email, locale)**: `Promise<{ success: boolean; error?: string }>` — Sends OTP to email address.
   Calls: generateOTP, findUserByEmail, generateOTPEmailContent, sendEmail
 - **verifyOTPCode(email, code, locale)**: `Promise<{ success: boolean; user?: User; error?: string }>` — Verifies OTP code.

--- a/plans/STORY-459-context.md
+++ b/plans/STORY-459-context.md
@@ -9,7 +9,7 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/460
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** review-ready
 - **Plan File:** plans/STORY-459-plan.md
 - **Task File:** (fill when implementation starts)
 

--- a/plans/STORY-459-context.md
+++ b/plans/STORY-459-context.md
@@ -1,0 +1,20 @@
+# Story 459 Context
+
+## Metadata
+- **Story Number:** 459
+- **Story Title:** [Story] Add copy-to-clipboard UX to OTP authentication email
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/sweet-panini-099f38
+- **Branch:** claude/sweet-panini-099f38
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-459-plan.md
+- **Task File:** (fill when implementation starts)
+
+## Quick Summary
+Adds copy-to-clipboard UX to the OTP auth email: a "Copy code" link in the email opens a minimal
+browser page that auto-copies the 6-digit code to clipboard. Also updates the email subject to
+include the OTP code for iOS/Android/Gmail smart autofill detection. New route: /[locale]/otp-copy.
+New client component: OtpCopyPage. Modifies generateOTPEmailContent() to accept a copyUrl param.

--- a/plans/STORY-459-context.md
+++ b/plans/STORY-459-context.md
@@ -14,7 +14,7 @@
 - **Task File:** (fill when implementation starts)
 
 ## Quick Summary
-Adds copy-to-clipboard UX to the OTP auth email: a "Copy code" link in the email opens a minimal
-browser page that auto-copies the 6-digit code to clipboard. Also updates the email subject to
-include the OTP code for iOS/Android/Gmail smart autofill detection. New route: /[locale]/otp-copy.
-New client component: OtpCopyPage. Modifies generateOTPEmailContent() to accept a copyUrl param.
+Updates OTP email subject and plain-text body to trigger native iOS/Android/Gmail OTP autofill
+detection. Subject prefixed with the code ("847391 - Your Access Code - Prode Mundial"). Plain-text
+opens with the code on its own line before the greeting. No new pages or components. One file
+changed: app/actions/otp-actions.ts. generateOTPEmailContent() exported for testability.

--- a/plans/STORY-459-context.md
+++ b/plans/STORY-459-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** [Story] Add copy-to-clipboard UX to OTP authentication email
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode/.claude/worktrees/sweet-panini-099f38
 - **Branch:** claude/sweet-panini-099f38
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 460
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/460
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-459-plan.md
+++ b/plans/STORY-459-plan.md
@@ -122,6 +122,18 @@ No call graph changes.
 
 ---
 
+## Implementation Amendments
+
+### Amendment 1: generateOTPEmailContent exported for testability
+**Date:** 2026-05-22
+**Reason:** The function needed direct unit testing to verify subject and plain-text format independently of `sendOTPCode`. Exporting it is the cleanest approach without changing the overall architecture.
+**Change:** Changed `async function generateOTPEmailContent(...)` → `export async function generateOTPEmailContent(...)`.
+
+### Amendment 2: Plain-text code line uses otp.title translation key
+**Date:** 2026-05-22
+**Reason:** Using `t('otp.title')` (→ "Your Access Code") rather than hardcoded "Your code:" keeps the label localised for both EN and ES. The plan already noted "or locale equivalent" — this is that equivalent.
+**Change:** Plain text opens with `${t('otp.title')}: ${otpCode}` (e.g. "Your Access Code: 847391") instead of literal "Your code: 847391".
+
 ## Open Questions
 
 None.

--- a/plans/STORY-459-plan.md
+++ b/plans/STORY-459-plan.md
@@ -1,176 +1,82 @@
-# Story 459 Plan: Add copy-to-clipboard UX to OTP authentication email
+# Story 459 Plan: Add native OTP detection support to authentication email
 
 ## Context
 
-The OTP email displays a 6-digit code that users must manually select and type into the verification
-form. On mobile this is error-prone. This story adds two complementary UX improvements:
+The OTP email displays a 6-digit code that users must manually select and type. iOS Mail, Gmail
+(Android), and other modern clients can surface an "AutoFill" or suggested-code banner when the
+email is structured correctly — but the current template doesn't follow those conventions.
 
-1. **"Copy code" link in the email** — opens a minimal page that auto-copies the code to clipboard
-   and shows a confirmation. The user can then switch back to the app and paste.
-2. **OTP-detection-friendly subject line** — prepending the code to the email subject triggers
-   iOS Mail, Gmail (Android), and other clients to surface an "AutoFill" or "Copy code" suggestion.
+This story updates the OTP email subject and plain-text body to trigger native OS-level OTP
+detection, reducing sign-in friction especially on mobile — with zero new pages or UI components.
 
-Existing OTP verify form and flow are **unchanged**.
+**Descoped:** The "Copy code" link/page was removed in favour of relying on native platform
+detection, which covers the same use case with less complexity.
 
 ---
 
 ## Acceptance Criteria
 
-- [ ] OTP email shows a "Copy code" button/link below the 6-digit code block
-- [ ] Clicking it opens `/<locale>/otp-copy?code=XXXXXX` which auto-copies the code to clipboard
-       and shows a brief success confirmation
-- [ ] Email subject starts with the OTP code (e.g., `"123456 - Your Access Code - Prode Mundial"`)
-       for iOS/Android/Gmail smart-autofill detection
-- [ ] Plain-text fallback contains the copy-page URL and a prominently formatted code line
-- [ ] The otp-copy page supports English and Spanish
+- [ ] OTP email subject starts with the 6-digit code (e.g., `"123456 - Your Access Code - Prode Mundial"`) — triggers iOS Mail and Gmail autofill suggestions
+- [ ] Plain-text email body has the code on its own prominent line with OTP-detection keywords in proximity, matching the heuristics used by iOS, Android, and Gmail
+- [ ] HTML email body is unchanged in appearance (no copy button)
+- [ ] Both English and Spanish emails follow the updated format
 - [ ] Existing OTP verify form and sign-in flow are unchanged
-
----
-
-## Visual Prototypes
-
-### Email: "Copy code" button (below the code block)
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│  Your Access Code                                            │
-│                                                              │
-│  You have requested a code to sign in to Prode Mundial.     │
-│                                                              │
-│  ┌────────────────────────────────────────────────────────┐  │
-│  │                     1 2 3 4 5 6                        │  │
-│  └────────────────────────────────────────────────────────┘  │
-│                                                              │
-│              [ Copy code → ]        ← NEW LINK BUTTON        │
-│                                                              │
-│  ⏱️ Valid for 3 minutes                                      │
-│  You have a maximum of 3 attempts to enter this code.        │
-│  ...                                                         │
-└──────────────────────────────────────────────────────────────┘
-```
-
-The "Copy code" is a plain `<a href>` styled as a button (works in all email clients without JS).
-
-### `/<locale>/otp-copy` page — success state
-
-```
-┌─────────────────────────────────────┐
-│                                     │
-│           ✓                         │
-│    (CheckCircle, color=success)      │
-│                                     │
-│  "Code copied to clipboard!"        │
-│                                     │
-│  ┌─────────────────────────────────┐│
-│  │          1 2 3 4 5 6            ││  ← code displayed in case user wants
-│  └─────────────────────────────────┘│     to type it manually
-│                                     │
-│      [ Go to sign in ]              │
-│                                     │
-└─────────────────────────────────────┘
-```
-
-### `/<locale>/otp-copy` page — clipboard blocked state (fallback)
-
-```
-┌─────────────────────────────────────┐
-│                                     │
-│  Your code:                         │
-│                                     │
-│  ┌─────────────────────────────────┐│
-│  │          1 2 3 4 5 6            ││
-│  └─────────────────────────────────┘│
-│                                     │
-│      [ Copy code ]  [ Sign in ]     │
-│                                     │
-└─────────────────────────────────────┘
-```
 
 ---
 
 ## Technical Approach
 
-### 1. New route: `app/[locale]/otp-copy/page.tsx`
+### Changes to `generateOTPEmailContent()` in `app/actions/otp-actions.ts`
 
-Minimal Server Component. Reads `code` from `searchParams`. If absent, redirects to `/${locale}`.
-Passes `code` and `locale` as props to `OtpCopyPage` (Client Component).
+**Subject line** — prepend the OTP code:
+```
+"${otpCode} - ${t('otp.subject')}"
+```
+Result: `"123456 - Your Access Code - Prode Mundial"` (EN) / `"123456 - Tu código de acceso - Prode Mundial"` (ES)
 
-Security note: The code is already transmitted in the email body; including it in the URL does not
-increase exposure. The 3-minute TTL limits the window of any misuse.
+This is the standard pattern that triggers:
+- **iOS Mail** AutoFill suggestion ("Use code 123456")
+- **Gmail on Android** smart code detection
+- **Samsung Mail** and other clients using similar heuristics
 
-### 2. New client component: `app/components/auth/otp-copy-page.tsx`
+**Plain-text body** — add a prominent code line at the top of the text version:
+```
+Your code: ${otpCode}
 
-Client Component. On mount (`useEffect`), calls `navigator.clipboard.writeText(code)`:
-- **Success** → shows CheckCircle + "Copied!" message + code display + "Go to sign in" link
-- **Failure** (clipboard blocked) → shows code display + manual "Copy" button + "Go to sign in"
+${t('otp.greeting')}
+...
+```
+iOS and Android scan plain-text for `code: XXXXXX` or `passcode: XXXXXX` patterns on their own
+line. The existing HTML version already displays the code prominently; the plain-text version
+currently buries it mid-sentence (`${t('otp.title')}: ${otpCode}`), which is less detectable.
 
-Clipboard API requires a secure context (HTTPS); available in all production environments.
+**HTML body** — no visual changes. The code block already renders clearly; no new elements needed.
 
-### 3. Modify `generateOTPEmailContent()` in `app/actions/otp-actions.ts`
+### Translation changes
 
-- Add optional `copyUrl?: string` parameter.
-- Subject: prepend the OTP code → `"${otpCode} - ${t('otp.subject')}"`.
-  This is the standard pattern iOS Mail and Gmail use for AutoFill suggestion.
-- HTML: add `<a href="${copyUrl}">` button below the code block when `copyUrl` is provided.
-- Plain text: add the copy URL on its own line; format the code on a line of its own
-  (`Your code: ${otpCode}`) for OS-level OTP detection heuristics.
+**`locales/en/emails.json`** — no key changes; subject is assembled in code as `"${otpCode} - ${t('otp.subject')}"`.
 
-### 4. Modify `sendOTPCode()` in `app/actions/otp-actions.ts`
+**`locales/es/emails.json`** — same; no key changes needed.
 
-Build `copyUrl` from `NEXT_PUBLIC_APP_URL` env var and pass to `generateOTPEmailContent()`.
-`copyUrl` = `${process.env.NEXT_PUBLIC_APP_URL}/${locale}/otp-copy?code=${otpCode}`
-
-### 5. Translation keys
-
-**`locales/en/emails.json`** (under `otp`):
-- `copyCode`: `"Copy code"`
-
-**`locales/es/emails.json`** (under `otp`):
-- `copyCode`: `"Copiar código"`
-
-**`locales/en/auth.json`** (new `otpCopy` section):
-- `otpCopy.title`: `"Code copied to clipboard!"`
-- `otpCopy.fallbackTitle`: `"Your sign-in code"`
-- `otpCopy.copyButton`: `"Copy code"`
-- `otpCopy.signIn`: `"Go to sign in"`
-- `otpCopy.copied`: `"Copied!"`
-
-**`locales/es/auth.json`** (new `otpCopy` section):
-- `otpCopy.title`: `"¡Código copiado al portapapeles!"`
-- `otpCopy.fallbackTitle`: `"Tu código de acceso"`
-- `otpCopy.copyButton`: `"Copiar código"`
-- `otpCopy.signIn`: `"Ir a iniciar sesión"`
-- `otpCopy.copied`: `"¡Copiado!"`
-
-No changes to `types/i18n.ts` — it uses `typeof` inference from the JSON files directly.
+The existing `otp.subject` values (`"Your Access Code - Prode Mundial"` / `"Tu código de acceso - Prode Mundial"`) remain as the suffix; the code is prepended dynamically in `generateOTPEmailContent()`.
 
 ---
-
-## Files to Create
-
-| File | Purpose |
-|------|---------|
-| `app/[locale]/otp-copy/page.tsx` | New Server Component route |
-| `app/components/auth/otp-copy-page.tsx` | New Client Component (clipboard UX) |
-| `app/components/auth/__tests__/otp-copy-page.test.tsx` | Unit tests |
 
 ## Files to Modify
 
 | File | Change |
 |------|--------|
-| `app/actions/otp-actions.ts` | `generateOTPEmailContent()` + `sendOTPCode()` |
-| `locales/en/emails.json` | Add `otp.copyCode` |
-| `locales/es/emails.json` | Add `otp.copyCode` |
-| `locales/en/auth.json` | Add `otpCopy.*` section |
-| `locales/es/auth.json` | Add `otpCopy.*` section |
+| `app/actions/otp-actions.ts` | Update `generateOTPEmailContent()`: subject prefix + plain-text code line |
+
+## Files to Create
+
+None.
 
 ## CODE-STRUCTURE Files to Update
 
 | File | What to update |
 |------|---------------|
-| `docs/code-structure/pages.md` | Add `app/[locale]/otp-copy/page.tsx` entry |
-| `docs/code-structure/components/components-auth-onboarding.md` | Add `OtpCopyPage` entry |
-| `docs/code-structure/actions.md` | Update `generateOTPEmailContent` signature (add `copyUrl?`) |
+| `docs/code-structure/actions.md` | Update `generateOTPEmailContent` — note subject now prefixed with OTP code |
 
 ---
 
@@ -178,99 +84,44 @@ No changes to `types/i18n.ts` — it uses `typeof` inference from the JSON files
 
 ### Call Graph Changes
 
-No new cross-layer call relationships. `sendOTPCode` already calls `generateOTPEmailContent`
-and `sendEmail`. The new page/component flow is purely client-side (no new Server Actions).
-
-**Modified flows:**
-- **Flow: OTP email send** — `sendOTPCode` now builds `copyUrl` and passes it to
-  `generateOTPEmailContent`, which embeds it in HTML/text output.
-
-### `app/[locale]/otp-copy/page.tsx` *(new)*
-
-**Default export: `OtpCopyRoute`**
-- Props: `{ searchParams: Promise<{ code?: string }> }`
-- Reads `code` from `searchParams`; if absent, `redirect('/${locale}')`
-- Renders `<OtpCopyPage code={code} locale={locale} />`
-- Tests:
-  - redirects to home locale path when `code` searchParam is absent
-  - redirects to home locale path when `code` is an empty string
-  - renders OtpCopyPage with the code value passed from searchParams
-
-### `app/components/auth/otp-copy-page.tsx` *(new)*
-
-**`OtpCopyPage({ code, locale }: { code: string; locale: string })`**: `JSX.Element`
-- `'use client'`
-- State: `copied: boolean` (false), `error: boolean` (false)
-- `useEffect` on mount: calls `navigator.clipboard.writeText(code)`, sets `copied=true` on
-  success, `error=true` on failure
-- Success render: CheckCircle icon + `t('otpCopy.title')` + code display + sign-in link
-- Fallback render: code display + manual Copy button (re-attempts clipboard on click) + sign-in link
-- Sign-in link: `/${locale}?openSignin=true`
-- Mocking in tests: `navigator.clipboard.writeText` mocked via `Object.defineProperty` on
-  `navigator` (standard jsdom pattern); `useTranslations` mocked to return an identity fn
-- Tests:
-  - renders success state (CheckCircle + title text) after clipboard.writeText resolves
-  - renders fallback state (Copy button visible) when clipboard.writeText rejects
-  - manual Copy button triggers another clipboard.writeText call and shows Copied label
-  - sign-in link href is `/${locale}?openSignin=true` with the correct locale value
+No call graph changes.
 
 ### `app/actions/otp-actions.ts` *(modified)*
 
-**`generateOTPEmailContent(email, otpCode, locale, copyUrl?)`**:
-`Promise<{ subject: string; html: string; text: string }>` *(was: no copyUrl param)*
-- Subject becomes `"${otpCode} - ${t('otp.subject')}"` for OTP-detection heuristics
-- HTML includes `<a href="${copyUrl}">` styled button after the code block, when `copyUrl` is defined
-- Plain text includes `Your code: ${otpCode}` on own line at top; appends copy URL line when defined
+**`generateOTPEmailContent(email, otpCode, locale)`**:
+`Promise<{ subject: string; html: string; text: string }>` *(signature unchanged)*
+- Subject becomes `"${otpCode} - ${t('otp.subject')}"` for native OTP-detection heuristics
+- Plain text opens with `"Your code: ${otpCode}\n\n"` (or locale equivalent) before the greeting
+- HTML is unchanged
 - Calls: `getTranslations`
 - Tests:
-  - subject starts with the 6-digit OTP code (e.g., `"123456 - ..."`)
-  - html contains an `<a href>` copy link when copyUrl is provided
-  - html does not contain any copy-link anchor when copyUrl is undefined
-  - plain text contains the code on its own line (`"Your code: 123456"`)
-  - subject prefix works for Spanish locale (getTranslations with locale='es')
-
-**`sendOTPCode(email, locale)`**: `Promise<{ success, error? }>` *(signature unchanged)*
-- Now builds `copyUrl` from `NEXT_PUBLIC_APP_URL` before calling `generateOTPEmailContent`
-- Falls back gracefully if `NEXT_PUBLIC_APP_URL` is undefined (passes `undefined` copyUrl → email sent without copy link)
-- Tests:
-  - sends email with copyUrl when `NEXT_PUBLIC_APP_URL` is defined (copyUrl contains locale and code)
-  - sends email without copy link when `NEXT_PUBLIC_APP_URL` env var is undefined (copyUrl passed as `undefined`)
-  - existing error handling (sendEmail failure, rate-limiting) is unchanged regardless of copyUrl presence
+  - subject starts with the 6-digit OTP code followed by ` - `
+  - subject ends with the existing translated suffix (EN and ES)
+  - plain text contains `"Your code: ${otpCode}"` on its own line before the greeting
+  - html output is unchanged (does not contain any new elements)
 
 ---
 
 ## Testing Strategy
 
-### Unit tests (`otp-copy-page.test.tsx`)
+### Unit tests (additions to existing `otp-actions` test file if it exists, or new file)
 
-- Mock `navigator.clipboard.writeText` (success and rejection cases)
-- Mock `next-intl` `useTranslations`
-- Test: success render (CheckCircle, title, code, sign-in link)
-- Test: fallback render (code, Copy button, sign-in link)
-- Test: Copy button triggers another clipboard.writeText call
-- Test: sign-in link contains `openSignin=true` and locale
-
-### Unit tests (`otp-actions.test.ts` — additions to existing test file if it exists)
-
-- Test: `generateOTPEmailContent` subject starts with OTP code
-- Test: HTML contains copy-link anchor when copyUrl provided
-- Test: HTML omits copy-link anchor when copyUrl is absent
-- Test: plain text has code on its own line
+- `generateOTPEmailContent` subject starts with OTP code + separator
+- `generateOTPEmailContent` subject suffix matches existing translation key value
+- Plain-text body opens with `code: <otpCode>` line
+- HTML body does not contain new markup
 
 ### Manual testing
 
-1. Trigger OTP send (sign in with an email)
-2. Inspect email: subject starts with the code, "Copy code" button visible
-3. Click "Copy code" → browser opens `/en/otp-copy?code=XXXXXX`
-4. Verify clipboard has the code (paste into text field)
-5. Verify page shows success state / fallback state when clipboard is blocked (incognito or
-   non-HTTPS preview URL) — manual Copy button must appear and work
-6. Verify same flow in Spanish locale (`/es/otp-copy?code=...`)
-7. Verify original OTP verify form still works unchanged
-8. Verify email is still sent (with graceful no-copy-link fallback) when `NEXT_PUBLIC_APP_URL` is unset
+1. Trigger OTP send (sign in with an email on a real device or email client)
+2. iOS Mail: verify AutoFill banner / "Use Code" suggestion appears
+3. Gmail (Android): verify code is surfaced as a suggestion
+4. Verify subject shows `"123456 - Your Access Code - Prode Mundial"`
+5. Verify email renders correctly (no visual regression) in both EN and ES
+6. Verify existing OTP verify form still works unchanged
 
 ---
 
 ## Open Questions
 
-None — scope is well-defined by the AC.
+None.

--- a/plans/STORY-459-plan.md
+++ b/plans/STORY-459-plan.md
@@ -1,0 +1,276 @@
+# Story 459 Plan: Add copy-to-clipboard UX to OTP authentication email
+
+## Context
+
+The OTP email displays a 6-digit code that users must manually select and type into the verification
+form. On mobile this is error-prone. This story adds two complementary UX improvements:
+
+1. **"Copy code" link in the email** — opens a minimal page that auto-copies the code to clipboard
+   and shows a confirmation. The user can then switch back to the app and paste.
+2. **OTP-detection-friendly subject line** — prepending the code to the email subject triggers
+   iOS Mail, Gmail (Android), and other clients to surface an "AutoFill" or "Copy code" suggestion.
+
+Existing OTP verify form and flow are **unchanged**.
+
+---
+
+## Acceptance Criteria
+
+- [ ] OTP email shows a "Copy code" button/link below the 6-digit code block
+- [ ] Clicking it opens `/<locale>/otp-copy?code=XXXXXX` which auto-copies the code to clipboard
+       and shows a brief success confirmation
+- [ ] Email subject starts with the OTP code (e.g., `"123456 - Your Access Code - Prode Mundial"`)
+       for iOS/Android/Gmail smart-autofill detection
+- [ ] Plain-text fallback contains the copy-page URL and a prominently formatted code line
+- [ ] The otp-copy page supports English and Spanish
+- [ ] Existing OTP verify form and sign-in flow are unchanged
+
+---
+
+## Visual Prototypes
+
+### Email: "Copy code" button (below the code block)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Your Access Code                                            │
+│                                                              │
+│  You have requested a code to sign in to Prode Mundial.     │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │                     1 2 3 4 5 6                        │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                                                              │
+│              [ Copy code → ]        ← NEW LINK BUTTON        │
+│                                                              │
+│  ⏱️ Valid for 3 minutes                                      │
+│  You have a maximum of 3 attempts to enter this code.        │
+│  ...                                                         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The "Copy code" is a plain `<a href>` styled as a button (works in all email clients without JS).
+
+### `/<locale>/otp-copy` page — success state
+
+```
+┌─────────────────────────────────────┐
+│                                     │
+│           ✓                         │
+│    (CheckCircle, color=success)      │
+│                                     │
+│  "Code copied to clipboard!"        │
+│                                     │
+│  ┌─────────────────────────────────┐│
+│  │          1 2 3 4 5 6            ││  ← code displayed in case user wants
+│  └─────────────────────────────────┘│     to type it manually
+│                                     │
+│      [ Go to sign in ]              │
+│                                     │
+└─────────────────────────────────────┘
+```
+
+### `/<locale>/otp-copy` page — clipboard blocked state (fallback)
+
+```
+┌─────────────────────────────────────┐
+│                                     │
+│  Your code:                         │
+│                                     │
+│  ┌─────────────────────────────────┐│
+│  │          1 2 3 4 5 6            ││
+│  └─────────────────────────────────┘│
+│                                     │
+│      [ Copy code ]  [ Sign in ]     │
+│                                     │
+└─────────────────────────────────────┘
+```
+
+---
+
+## Technical Approach
+
+### 1. New route: `app/[locale]/otp-copy/page.tsx`
+
+Minimal Server Component. Reads `code` from `searchParams`. If absent, redirects to `/${locale}`.
+Passes `code` and `locale` as props to `OtpCopyPage` (Client Component).
+
+Security note: The code is already transmitted in the email body; including it in the URL does not
+increase exposure. The 3-minute TTL limits the window of any misuse.
+
+### 2. New client component: `app/components/auth/otp-copy-page.tsx`
+
+Client Component. On mount (`useEffect`), calls `navigator.clipboard.writeText(code)`:
+- **Success** → shows CheckCircle + "Copied!" message + code display + "Go to sign in" link
+- **Failure** (clipboard blocked) → shows code display + manual "Copy" button + "Go to sign in"
+
+Clipboard API requires a secure context (HTTPS); available in all production environments.
+
+### 3. Modify `generateOTPEmailContent()` in `app/actions/otp-actions.ts`
+
+- Add optional `copyUrl?: string` parameter.
+- Subject: prepend the OTP code → `"${otpCode} - ${t('otp.subject')}"`.
+  This is the standard pattern iOS Mail and Gmail use for AutoFill suggestion.
+- HTML: add `<a href="${copyUrl}">` button below the code block when `copyUrl` is provided.
+- Plain text: add the copy URL on its own line; format the code on a line of its own
+  (`Your code: ${otpCode}`) for OS-level OTP detection heuristics.
+
+### 4. Modify `sendOTPCode()` in `app/actions/otp-actions.ts`
+
+Build `copyUrl` from `NEXT_PUBLIC_APP_URL` env var and pass to `generateOTPEmailContent()`.
+`copyUrl` = `${process.env.NEXT_PUBLIC_APP_URL}/${locale}/otp-copy?code=${otpCode}`
+
+### 5. Translation keys
+
+**`locales/en/emails.json`** (under `otp`):
+- `copyCode`: `"Copy code"`
+
+**`locales/es/emails.json`** (under `otp`):
+- `copyCode`: `"Copiar código"`
+
+**`locales/en/auth.json`** (new `otpCopy` section):
+- `otpCopy.title`: `"Code copied to clipboard!"`
+- `otpCopy.fallbackTitle`: `"Your sign-in code"`
+- `otpCopy.copyButton`: `"Copy code"`
+- `otpCopy.signIn`: `"Go to sign in"`
+- `otpCopy.copied`: `"Copied!"`
+
+**`locales/es/auth.json`** (new `otpCopy` section):
+- `otpCopy.title`: `"¡Código copiado al portapapeles!"`
+- `otpCopy.fallbackTitle`: `"Tu código de acceso"`
+- `otpCopy.copyButton`: `"Copiar código"`
+- `otpCopy.signIn`: `"Ir a iniciar sesión"`
+- `otpCopy.copied`: `"¡Copiado!"`
+
+No changes to `types/i18n.ts` — it uses `typeof` inference from the JSON files directly.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `app/[locale]/otp-copy/page.tsx` | New Server Component route |
+| `app/components/auth/otp-copy-page.tsx` | New Client Component (clipboard UX) |
+| `app/components/auth/__tests__/otp-copy-page.test.tsx` | Unit tests |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/actions/otp-actions.ts` | `generateOTPEmailContent()` + `sendOTPCode()` |
+| `locales/en/emails.json` | Add `otp.copyCode` |
+| `locales/es/emails.json` | Add `otp.copyCode` |
+| `locales/en/auth.json` | Add `otpCopy.*` section |
+| `locales/es/auth.json` | Add `otpCopy.*` section |
+
+## CODE-STRUCTURE Files to Update
+
+| File | What to update |
+|------|---------------|
+| `docs/code-structure/pages.md` | Add `app/[locale]/otp-copy/page.tsx` entry |
+| `docs/code-structure/components/components-auth-onboarding.md` | Add `OtpCopyPage` entry |
+| `docs/code-structure/actions.md` | Update `generateOTPEmailContent` signature (add `copyUrl?`) |
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+No new cross-layer call relationships. `sendOTPCode` already calls `generateOTPEmailContent`
+and `sendEmail`. The new page/component flow is purely client-side (no new Server Actions).
+
+**Modified flows:**
+- **Flow: OTP email send** — `sendOTPCode` now builds `copyUrl` and passes it to
+  `generateOTPEmailContent`, which embeds it in HTML/text output.
+
+### `app/[locale]/otp-copy/page.tsx` *(new)*
+
+**Default export: `OtpCopyRoute`**
+- Props: `{ searchParams: Promise<{ code?: string }> }`
+- Reads `code` from `searchParams`; if absent, `redirect('/${locale}')`
+- Renders `<OtpCopyPage code={code} locale={locale} />`
+- Tests:
+  - redirects to home locale path when `code` searchParam is absent
+  - redirects to home locale path when `code` is an empty string
+  - renders OtpCopyPage with the code value passed from searchParams
+
+### `app/components/auth/otp-copy-page.tsx` *(new)*
+
+**`OtpCopyPage({ code, locale }: { code: string; locale: string })`**: `JSX.Element`
+- `'use client'`
+- State: `copied: boolean` (false), `error: boolean` (false)
+- `useEffect` on mount: calls `navigator.clipboard.writeText(code)`, sets `copied=true` on
+  success, `error=true` on failure
+- Success render: CheckCircle icon + `t('otpCopy.title')` + code display + sign-in link
+- Fallback render: code display + manual Copy button (re-attempts clipboard on click) + sign-in link
+- Sign-in link: `/${locale}?openSignin=true`
+- Mocking in tests: `navigator.clipboard.writeText` mocked via `Object.defineProperty` on
+  `navigator` (standard jsdom pattern); `useTranslations` mocked to return an identity fn
+- Tests:
+  - renders success state (CheckCircle + title text) after clipboard.writeText resolves
+  - renders fallback state (Copy button visible) when clipboard.writeText rejects
+  - manual Copy button triggers another clipboard.writeText call and shows Copied label
+  - sign-in link href is `/${locale}?openSignin=true` with the correct locale value
+
+### `app/actions/otp-actions.ts` *(modified)*
+
+**`generateOTPEmailContent(email, otpCode, locale, copyUrl?)`**:
+`Promise<{ subject: string; html: string; text: string }>` *(was: no copyUrl param)*
+- Subject becomes `"${otpCode} - ${t('otp.subject')}"` for OTP-detection heuristics
+- HTML includes `<a href="${copyUrl}">` styled button after the code block, when `copyUrl` is defined
+- Plain text includes `Your code: ${otpCode}` on own line at top; appends copy URL line when defined
+- Calls: `getTranslations`
+- Tests:
+  - subject starts with the 6-digit OTP code (e.g., `"123456 - ..."`)
+  - html contains an `<a href>` copy link when copyUrl is provided
+  - html does not contain any copy-link anchor when copyUrl is undefined
+  - plain text contains the code on its own line (`"Your code: 123456"`)
+  - subject prefix works for Spanish locale (getTranslations with locale='es')
+
+**`sendOTPCode(email, locale)`**: `Promise<{ success, error? }>` *(signature unchanged)*
+- Now builds `copyUrl` from `NEXT_PUBLIC_APP_URL` before calling `generateOTPEmailContent`
+- Falls back gracefully if `NEXT_PUBLIC_APP_URL` is undefined (passes `undefined` copyUrl → email sent without copy link)
+- Tests:
+  - sends email with copyUrl when `NEXT_PUBLIC_APP_URL` is defined (copyUrl contains locale and code)
+  - sends email without copy link when `NEXT_PUBLIC_APP_URL` env var is undefined (copyUrl passed as `undefined`)
+  - existing error handling (sendEmail failure, rate-limiting) is unchanged regardless of copyUrl presence
+
+---
+
+## Testing Strategy
+
+### Unit tests (`otp-copy-page.test.tsx`)
+
+- Mock `navigator.clipboard.writeText` (success and rejection cases)
+- Mock `next-intl` `useTranslations`
+- Test: success render (CheckCircle, title, code, sign-in link)
+- Test: fallback render (code, Copy button, sign-in link)
+- Test: Copy button triggers another clipboard.writeText call
+- Test: sign-in link contains `openSignin=true` and locale
+
+### Unit tests (`otp-actions.test.ts` — additions to existing test file if it exists)
+
+- Test: `generateOTPEmailContent` subject starts with OTP code
+- Test: HTML contains copy-link anchor when copyUrl provided
+- Test: HTML omits copy-link anchor when copyUrl is absent
+- Test: plain text has code on its own line
+
+### Manual testing
+
+1. Trigger OTP send (sign in with an email)
+2. Inspect email: subject starts with the code, "Copy code" button visible
+3. Click "Copy code" → browser opens `/en/otp-copy?code=XXXXXX`
+4. Verify clipboard has the code (paste into text field)
+5. Verify page shows success state / fallback state when clipboard is blocked (incognito or
+   non-HTTPS preview URL) — manual Copy button must appear and work
+6. Verify same flow in Spanish locale (`/es/otp-copy?code=...`)
+7. Verify original OTP verify form still works unchanged
+8. Verify email is still sent (with graceful no-copy-link fallback) when `NEXT_PUBLIC_APP_URL` is unset
+
+---
+
+## Open Questions
+
+None — scope is well-defined by the AC.


### PR DESCRIPTION
Fixes #459

## Summary
Implementation plan for the story.

## Plan Document
See `plans/STORY-459-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)