### PR TITLE
Plan: Fix player import: DOB parsing failures and delete-existing-players not working #461

### DIFF
--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -534,9 +534,12 @@ Key flows:
       │     └── findTeamInTournament, findPlayersByTeamId
       ├── getTransfermarktPlayerData [server action] (on import submit)
       │     └── getTournamentStartDate → findFirstGameInTournament
-      ├── createTournamentTeamPlayers [server action] (after scrape)
+      ├── createTournamentTeamPlayers [server action] (inserts new players)
       │     └── createPlayer
-      ├── deleteTournamentTeamPlayers [server action] (when deleteExisting checked)
+      ├── updateTournamentTeamPlayer [server action] (updates age/position for name-matched players)
+      │     └── updatePlayer
+      ├── deleteSpecificTeamPlayers [server action] (when deleteExisting checked, for removed players)
+      │     ├── clearPlayerAwardSelections → db.updateTable('tournament_guesses')
       │     └── deletePlayer
       └── saveTeamTransfermarktId [server action] (fire-and-forget after successful import)
             └── updateTeaminDb

--- a/__tests__/actions/team-actions-player-management.test.ts
+++ b/__tests__/actions/team-actions-player-management.test.ts
@@ -1,0 +1,210 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import {
+  updateTournamentTeamPlayer,
+  deleteSpecificTeamPlayers,
+} from '../../app/actions/team-actions';
+
+// Mock auth module
+vi.mock('../../auth', () => ({
+  auth: vi.fn(),
+}));
+
+// Mock user actions
+vi.mock('../../app/actions/user-actions', () => ({
+  getLoggedInUser: vi.fn(),
+}));
+
+// Mock player repository
+vi.mock('../../app/db/player-repository', () => ({
+  updatePlayer: vi.fn(),
+  deletePlayer: vi.fn(),
+  createPlayer: vi.fn(),
+  findAllPlayersInTournamentWithTeamData: vi.fn(),
+  deleteAllPlayersInTournamentTeam: vi.fn(),
+}));
+
+// Mock tournament-guess-repository
+vi.mock('../../app/db/tournament-guess-repository', () => ({
+  clearPlayerAwardSelections: vi.fn(),
+}));
+
+// Mock team repository (required by team-actions module)
+vi.mock('../../app/db/team-repository', () => ({
+  createTeam: vi.fn(),
+  updateTeam: vi.fn(),
+  findTeamInTournament: vi.fn(),
+}));
+
+// Mock tournament-repository (required by team-actions module)
+vi.mock('../../app/db/tournament-repository', () => ({
+  createTournamentTeam: vi.fn(),
+}));
+
+// Mock tournament actions
+vi.mock('../../app/actions/tournament-actions', () => ({
+  getTournamentStartDate: vi.fn(),
+}));
+
+// Mock S3 actions
+vi.mock('../../app/actions/s3', () => ({
+  createS3Client: vi.fn(() => ({
+    uploadFile: vi.fn(),
+    deleteFile: vi.fn(),
+  })),
+  deleteThemeLogoFromS3: vi.fn(),
+}));
+
+// Mock next-intl
+vi.mock('next-intl/server', () => ({
+  getLocale: vi.fn(() => 'es'),
+}));
+
+import { getLoggedInUser } from '../../app/actions/user-actions';
+import { updatePlayer, deletePlayer } from '../../app/db/player-repository';
+import { clearPlayerAwardSelections } from '../../app/db/tournament-guess-repository';
+
+const mockGetLoggedInUser = vi.mocked(getLoggedInUser);
+const mockUpdatePlayer = vi.mocked(updatePlayer);
+const mockDeletePlayer = vi.mocked(deletePlayer);
+const mockClearPlayerAwardSelections = vi.mocked(clearPlayerAwardSelections);
+
+const mockAdminUser = {
+  id: 'admin-1',
+  email: 'admin@example.com',
+  isAdmin: true,
+};
+
+const mockRegularUser = {
+  id: 'user-1',
+  email: 'user@example.com',
+  isAdmin: false,
+};
+
+describe('Team Actions - Player Management', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('updateTournamentTeamPlayer', () => {
+    it('should throw Unauthorized when user is not admin', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockRegularUser as any);
+
+      await expect(
+        updateTournamentTeamPlayer('player-1', { age_at_tournament: 25, position: 'GK' })
+      ).rejects.toThrow('Unauthorized: Only administrators can access this data');
+    });
+
+    it('should throw Unauthorized when no user is logged in', async () => {
+      mockGetLoggedInUser.mockResolvedValue(null);
+
+      await expect(
+        updateTournamentTeamPlayer('player-1', { age_at_tournament: 25, position: 'GK' })
+      ).rejects.toThrow();
+    });
+
+    it('should call updatePlayer with the correct playerId and data', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockAdminUser as any);
+      mockUpdatePlayer.mockResolvedValue(undefined as any);
+
+      await updateTournamentTeamPlayer('player-1', { age_at_tournament: 28, position: 'DF' });
+
+      expect(mockUpdatePlayer).toHaveBeenCalledWith('player-1', {
+        age_at_tournament: 28,
+        position: 'DF',
+      });
+    });
+
+    it('should update age_at_tournament when it has changed', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockAdminUser as any);
+      mockUpdatePlayer.mockResolvedValue(undefined as any);
+
+      await updateTournamentTeamPlayer('player-99', { age_at_tournament: 32, position: 'FW' });
+
+      expect(mockUpdatePlayer).toHaveBeenCalledWith(
+        'player-99',
+        expect.objectContaining({ age_at_tournament: 32 })
+      );
+    });
+
+    it('should update position when it has changed', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockAdminUser as any);
+      mockUpdatePlayer.mockResolvedValue(undefined as any);
+
+      await updateTournamentTeamPlayer('player-99', { age_at_tournament: 25, position: 'MF' });
+
+      expect(mockUpdatePlayer).toHaveBeenCalledWith(
+        'player-99',
+        expect.objectContaining({ position: 'MF' })
+      );
+    });
+  });
+
+  describe('deleteSpecificTeamPlayers', () => {
+    it('should throw Unauthorized when user is not admin', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockRegularUser as any);
+
+      await expect(
+        deleteSpecificTeamPlayers('tournament-1', 'team-1', ['player-1'])
+      ).rejects.toThrow('Unauthorized: Only administrators can access this data');
+    });
+
+    it('should throw Unauthorized when no user is logged in', async () => {
+      mockGetLoggedInUser.mockResolvedValue(null);
+
+      await expect(
+        deleteSpecificTeamPlayers('tournament-1', 'team-1', ['player-1'])
+      ).rejects.toThrow();
+    });
+
+    it('should no-op when playerIds is empty', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockAdminUser as any);
+
+      await deleteSpecificTeamPlayers('tournament-1', 'team-1', []);
+
+      expect(mockClearPlayerAwardSelections).not.toHaveBeenCalled();
+      expect(mockDeletePlayer).not.toHaveBeenCalled();
+    });
+
+    it('should call clearPlayerAwardSelections before deleting players', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockAdminUser as any);
+      mockClearPlayerAwardSelections.mockResolvedValue(undefined);
+      mockDeletePlayer.mockResolvedValue(undefined as any);
+
+      const callOrder: string[] = [];
+      mockClearPlayerAwardSelections.mockImplementation(async () => {
+        callOrder.push('clearAwards');
+      });
+      mockDeletePlayer.mockImplementation(async () => {
+        callOrder.push('deletePlayer');
+        return undefined as any;
+      });
+
+      await deleteSpecificTeamPlayers('tournament-1', 'team-1', ['player-1']);
+
+      expect(callOrder[0]).toBe('clearAwards');
+      expect(callOrder).toContain('deletePlayer');
+    });
+
+    it('should call clearPlayerAwardSelections with the given player IDs', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockAdminUser as any);
+      mockClearPlayerAwardSelections.mockResolvedValue(undefined);
+      mockDeletePlayer.mockResolvedValue(undefined as any);
+
+      await deleteSpecificTeamPlayers('tournament-1', 'team-1', ['player-1', 'player-2']);
+
+      expect(mockClearPlayerAwardSelections).toHaveBeenCalledWith(['player-1', 'player-2']);
+    });
+
+    it('should call deletePlayer for each specified player ID', async () => {
+      mockGetLoggedInUser.mockResolvedValue(mockAdminUser as any);
+      mockClearPlayerAwardSelections.mockResolvedValue(undefined);
+      mockDeletePlayer.mockResolvedValue(undefined as any);
+
+      await deleteSpecificTeamPlayers('tournament-1', 'team-1', ['player-1', 'player-2']);
+
+      expect(mockDeletePlayer).toHaveBeenCalledWith('player-1');
+      expect(mockDeletePlayer).toHaveBeenCalledWith('player-2');
+      expect(mockDeletePlayer).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/__tests__/components/backoffice/PlayersTab.test.tsx
+++ b/__tests__/components/backoffice/PlayersTab.test.tsx
@@ -152,7 +152,7 @@ describe('PlayersTab', () => {
       // This is indirectly tested by the modal opening correctly with the populated form
     });
 
-    it('should pre-fill transfermarkt team name with team.name.replace(" ", "-") + "-fc-players"', async () => {
+    it('should pre-fill transfermarkt team name using English locale name (lowercased, hyphenated)', async () => {
       const user = userEvent.setup();
       renderWithTheme(<PlayersTab tournamentId={mockTournamentId} />);
 
@@ -165,7 +165,8 @@ describe('PlayersTab', () => {
       await user.click(importButtonElement!);
 
       await waitFor(() => {
-        const nameInput = screen.getByDisplayValue('Test-Team-fc-players');
+        // Falls back to team.name when name_i18n.en is not set; lowercased and hyphenated, no suffix
+        const nameInput = screen.getByDisplayValue('test-team');
         expect(nameInput).toBeInTheDocument();
       });
     });

--- a/__tests__/components/backoffice/PlayersTab.test.tsx
+++ b/__tests__/components/backoffice/PlayersTab.test.tsx
@@ -11,6 +11,8 @@ vi.mock('../../../app/actions/team-actions', () => ({
   getTransfermarktPlayerData: vi.fn(),
   createTournamentTeamPlayers: vi.fn(),
   deleteTournamentTeamPlayers: vi.fn(),
+  deleteSpecificTeamPlayers: vi.fn(),
+  updateTournamentTeamPlayer: vi.fn(),
   saveTeamTransfermarktId: vi.fn(),
 }));
 
@@ -30,6 +32,8 @@ const mockGetPlayersInTournament = vi.mocked(teamActions.getPlayersInTournament)
 const mockGetTransfermarktPlayerData = vi.mocked(teamActions.getTransfermarktPlayerData);
 const mockCreateTournamentTeamPlayers = vi.mocked(teamActions.createTournamentTeamPlayers);
 const mockDeleteTournamentTeamPlayers = vi.mocked(teamActions.deleteTournamentTeamPlayers);
+const mockDeleteSpecificTeamPlayers = vi.mocked(teamActions.deleteSpecificTeamPlayers);
+const mockUpdateTournamentTeamPlayer = vi.mocked(teamActions.updateTournamentTeamPlayer);
 const mockSaveTeamTransfermarktId = vi.mocked(teamActions.saveTeamTransfermarktId);
 
 describe('PlayersTab', () => {
@@ -80,6 +84,8 @@ describe('PlayersTab', () => {
       }),
     ]);
 
+    mockDeleteSpecificTeamPlayers.mockResolvedValue(undefined);
+    mockUpdateTournamentTeamPlayer.mockResolvedValue(undefined);
     mockSaveTeamTransfermarktId.mockResolvedValue(undefined);
   });
 
@@ -338,6 +344,222 @@ describe('PlayersTab', () => {
       const dialogButtons = screen.getAllByRole('button', { name: /importar/i });
       const submitButton = dialogButtons[dialogButtons.length - 1];
       expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Import Logic - Upsert by Name', () => {
+    const mockExistingPlayer = testFactories.player({
+      id: 'player-existing',
+      name: 'John Doe',
+      position: 'GK',
+      age_at_tournament: 18, // stale age from old broken parser
+      team_id: 'team-1',
+    });
+
+    beforeEach(() => {
+      mockGetPlayersInTournament.mockResolvedValue([
+        {
+          team: mockTeamWithTransfermarktId,
+          players: [mockExistingPlayer],
+        },
+      ]);
+
+      // Transfermarkt returns the same player with corrected age
+      mockGetTransfermarktPlayerData.mockResolvedValue([
+        {
+          name: 'John Doe',
+          position: 'GK',
+          ageAtTournament: 28, // correct age
+        },
+      ]);
+
+      mockCreateTournamentTeamPlayers.mockResolvedValue([]);
+    });
+
+    it('should call updateTournamentTeamPlayer for a matched player to fix stale age', async () => {
+      const user = userEvent.setup();
+      renderWithTheme(<PlayersTab tournamentId={mockTournamentId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Team')).toBeInTheDocument();
+      });
+
+      const importButtons = screen.getAllByText('Import Players');
+      await user.click(importButtons[0]!.closest('button')!);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('583')).toBeInTheDocument();
+      });
+
+      const dialogButtons = screen.getAllByRole('button', { name: /importar/i });
+      await user.click(dialogButtons[dialogButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mockUpdateTournamentTeamPlayer).toHaveBeenCalledWith('player-existing', {
+          age_at_tournament: 28,
+          position: 'GK',
+        });
+      });
+    });
+
+    it('should call updateTournamentTeamPlayer with the new position when it changed', async () => {
+      mockGetTransfermarktPlayerData.mockResolvedValue([
+        { name: 'John Doe', position: 'DF', ageAtTournament: 28 },
+      ]);
+
+      const user = userEvent.setup();
+      renderWithTheme(<PlayersTab tournamentId={mockTournamentId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Team')).toBeInTheDocument();
+      });
+
+      const importButtons = screen.getAllByText('Import Players');
+      await user.click(importButtons[0]!.closest('button')!);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('583')).toBeInTheDocument();
+      });
+
+      const dialogButtons = screen.getAllByRole('button', { name: /importar/i });
+      await user.click(dialogButtons[dialogButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mockUpdateTournamentTeamPlayer).toHaveBeenCalledWith(
+          'player-existing',
+          expect.objectContaining({ position: 'DF' })
+        );
+      });
+    });
+
+    it('should NOT call deleteSpecificTeamPlayers when deleteExistingPlayers is false', async () => {
+      // Add an extra existing player who is NOT in the new import
+      const playerNotInImport = testFactories.player({
+        id: 'player-removed',
+        name: 'Old Player',
+        position: 'FW',
+        age_at_tournament: 30,
+        team_id: 'team-1',
+      });
+      mockGetPlayersInTournament.mockResolvedValue([
+        {
+          team: mockTeamWithTransfermarktId,
+          players: [mockExistingPlayer, playerNotInImport],
+        },
+      ]);
+
+      const user = userEvent.setup();
+      renderWithTheme(<PlayersTab tournamentId={mockTournamentId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Team')).toBeInTheDocument();
+      });
+
+      const importButtons = screen.getAllByText('Import Players');
+      await user.click(importButtons[0]!.closest('button')!);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('583')).toBeInTheDocument();
+      });
+
+      // Do NOT check the deleteExistingPlayers checkbox — leave it unchecked
+      const dialogButtons = screen.getAllByRole('button', { name: /importar/i });
+      await user.click(dialogButtons[dialogButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mockUpdateTournamentTeamPlayer).toHaveBeenCalled();
+      });
+
+      expect(mockDeleteSpecificTeamPlayers).not.toHaveBeenCalled();
+    });
+
+    it('should call deleteSpecificTeamPlayers with removed player IDs when deleteExistingPlayers is true', async () => {
+      const playerNotInImport = testFactories.player({
+        id: 'player-removed',
+        name: 'Old Player',
+        position: 'FW',
+        age_at_tournament: 30,
+        team_id: 'team-1',
+      });
+      mockGetPlayersInTournament.mockResolvedValue([
+        {
+          team: mockTeamWithTransfermarktId,
+          players: [mockExistingPlayer, playerNotInImport],
+        },
+      ]);
+
+      const user = userEvent.setup();
+      renderWithTheme(<PlayersTab tournamentId={mockTournamentId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Team')).toBeInTheDocument();
+      });
+
+      const importButtons = screen.getAllByText('Import Players');
+      await user.click(importButtons[0]!.closest('button')!);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('583')).toBeInTheDocument();
+      });
+
+      // Check the "delete existing players" checkbox
+      const deleteCheckbox = screen.getByRole('checkbox');
+      await user.click(deleteCheckbox);
+
+      const dialogButtons = screen.getAllByRole('button', { name: /importar/i });
+      await user.click(dialogButtons[dialogButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mockDeleteSpecificTeamPlayers).toHaveBeenCalledWith(
+          mockTournamentId,
+          'team-1',
+          ['player-removed']
+        );
+      });
+    });
+
+    it('should NOT include matched players in deleteSpecificTeamPlayers call', async () => {
+      const playerNotInImport = testFactories.player({
+        id: 'player-removed',
+        name: 'Old Player',
+        position: 'FW',
+        age_at_tournament: 30,
+        team_id: 'team-1',
+      });
+      mockGetPlayersInTournament.mockResolvedValue([
+        {
+          team: mockTeamWithTransfermarktId,
+          players: [mockExistingPlayer, playerNotInImport],
+        },
+      ]);
+
+      const user = userEvent.setup();
+      renderWithTheme(<PlayersTab tournamentId={mockTournamentId} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Test Team')).toBeInTheDocument();
+      });
+
+      const importButtons = screen.getAllByText('Import Players');
+      await user.click(importButtons[0]!.closest('button')!);
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('583')).toBeInTheDocument();
+      });
+
+      const deleteCheckbox = screen.getByRole('checkbox');
+      await user.click(deleteCheckbox);
+
+      const dialogButtons = screen.getAllByRole('button', { name: /importar/i });
+      await user.click(dialogButtons[dialogButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mockDeleteSpecificTeamPlayers).toHaveBeenCalled();
+      });
+
+      // 'player-existing' (John Doe) is in the new import — must NOT be in the delete list
+      const deleteCall = mockDeleteSpecificTeamPlayers.mock.calls[0];
+      expect(deleteCall[2]).not.toContain('player-existing');
     });
   });
 });

--- a/__tests__/db/tournament-guess-repository.test.ts
+++ b/__tests__/db/tournament-guess-repository.test.ts
@@ -901,4 +901,102 @@ describe('Tournament Guess Repository - Materialization', () => {
       );
     });
   });
+
+  describe('clearPlayerAwardSelections', () => {
+    it('should no-op when playerIds is empty', async () => {
+      const { clearPlayerAwardSelections } = await import('../../app/db/tournament-guess-repository');
+
+      await clearPlayerAwardSelections([]);
+
+      expect(mockDb.updateTable).not.toHaveBeenCalled();
+    });
+
+    it('should update all 4 award columns for the given player IDs', async () => {
+      const { clearPlayerAwardSelections } = await import('../../app/db/tournament-guess-repository');
+
+      const mockUpdateQuery = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.updateTable.mockReturnValue(mockUpdateQuery);
+
+      await clearPlayerAwardSelections(['player-1', 'player-2']);
+
+      expect(mockDb.updateTable).toHaveBeenCalledTimes(4);
+      expect(mockDb.updateTable).toHaveBeenCalledWith('tournament_guesses');
+    });
+
+    it('should set best_player_id to null where it matches a deleted player', async () => {
+      const { clearPlayerAwardSelections } = await import('../../app/db/tournament-guess-repository');
+
+      const mockUpdateQuery = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.updateTable.mockReturnValue(mockUpdateQuery);
+
+      await clearPlayerAwardSelections(['player-deleted']);
+
+      expect(mockUpdateQuery.set).toHaveBeenCalledWith(
+        expect.objectContaining({ best_player_id: null })
+      );
+      expect(mockUpdateQuery.where).toHaveBeenCalledWith('best_player_id', 'in', ['player-deleted']);
+    });
+
+    it('should set top_goalscorer_player_id to null where it matches a deleted player', async () => {
+      const { clearPlayerAwardSelections } = await import('../../app/db/tournament-guess-repository');
+
+      const mockUpdateQuery = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.updateTable.mockReturnValue(mockUpdateQuery);
+
+      await clearPlayerAwardSelections(['player-deleted']);
+
+      expect(mockUpdateQuery.set).toHaveBeenCalledWith(
+        expect.objectContaining({ top_goalscorer_player_id: null })
+      );
+      expect(mockUpdateQuery.where).toHaveBeenCalledWith('top_goalscorer_player_id', 'in', ['player-deleted']);
+    });
+
+    it('should set best_goalkeeper_player_id to null where it matches a deleted player', async () => {
+      const { clearPlayerAwardSelections } = await import('../../app/db/tournament-guess-repository');
+
+      const mockUpdateQuery = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.updateTable.mockReturnValue(mockUpdateQuery);
+
+      await clearPlayerAwardSelections(['player-deleted']);
+
+      expect(mockUpdateQuery.set).toHaveBeenCalledWith(
+        expect.objectContaining({ best_goalkeeper_player_id: null })
+      );
+      expect(mockUpdateQuery.where).toHaveBeenCalledWith('best_goalkeeper_player_id', 'in', ['player-deleted']);
+    });
+
+    it('should set best_young_player_id to null where it matches a deleted player', async () => {
+      const { clearPlayerAwardSelections } = await import('../../app/db/tournament-guess-repository');
+
+      const mockUpdateQuery = {
+        set: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        execute: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.updateTable.mockReturnValue(mockUpdateQuery);
+
+      await clearPlayerAwardSelections(['player-deleted']);
+
+      expect(mockUpdateQuery.set).toHaveBeenCalledWith(
+        expect.objectContaining({ best_young_player_id: null })
+      );
+      expect(mockUpdateQuery.where).toHaveBeenCalledWith('best_young_player_id', 'in', ['player-deleted']);
+    });
+  });
 });

--- a/app/actions/team-actions.ts
+++ b/app/actions/team-actions.ts
@@ -293,7 +293,8 @@ export async function getTransfermarktPlayerData(
       let ageAtTournament = 18;
 
       if (dobElement.length) {
-        const dobText = dobElement.text().trim().replace(/\s*\([^)]*\)\s*/g, '').trim();
+        const rawDobText = dobElement.text().trim();
+        const dobText = rawDobText.includes('(') ? rawDobText.slice(0, rawDobText.indexOf('(')).trim() : rawDobText;
         // Server-side Transfermarkt returns DD/MM/YYYY (confirmed). Browser-side shows MM/DD/YYYY
         // but backend Accept-Language handling differs. Do NOT include both slash formats — ambiguous
         // dates (day ≤ 12) would silently mis-parse.

--- a/app/actions/team-actions.ts
+++ b/app/actions/team-actions.ts
@@ -294,11 +294,10 @@ export async function getTransfermarktPlayerData(
 
       if (dobElement.length) {
         const dobText = dobElement.text().trim().replace(/\s*\([^)]*\)\s*/g, '').trim();
-        // MM/DD/YYYY is the confirmed browser-side Transfermarkt format (e.g. "05/25/1995").
-        // Server-side format may differ depending on Accept-Language handling — keep fallbacks.
-        // Do NOT add DD/MM/YYYY alongside MM/DD/YYYY; ambiguous dates (day ≤ 12) would silently mis-parse.
-        const formats = ['MM/DD/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD'];
-        console.warn('Transfermarkt raw DOB:', dobText);
+        // Server-side Transfermarkt returns DD/MM/YYYY (confirmed). Browser-side shows MM/DD/YYYY
+        // but backend Accept-Language handling differs. Do NOT include both slash formats — ambiguous
+        // dates (day ≤ 12) would silently mis-parse.
+        const formats = ['DD/MM/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD'];
         const parsed = formats.reduce<dayjs.Dayjs | null>((found, fmt) => {
           if (found) return found;
           const d = dayjs(dobText, fmt, true);

--- a/app/actions/team-actions.ts
+++ b/app/actions/team-actions.ts
@@ -8,12 +8,16 @@ import {createS3Client, deleteThemeLogoFromS3} from "./s3";
 import {createTeam as createTeamInDb, updateTeam as updateTeaminDb, findTeamInTournament} from "../db/team-repository";
 import {createTournamentTeam} from "../db/tournament-repository";
 import * as cheerio from 'cheerio';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
 import {
   createPlayer,
   findAllPlayersInTournamentWithTeamData,
   deleteAllPlayersInTournamentTeam as deleteAllPlayersInTournamentTeamDb,
   deletePlayer, updatePlayer
 } from "../db/player-repository";
+import { clearPlayerAwardSelections } from "../db/tournament-guess-repository";
 import {getTournamentStartDate} from "./tournament-actions";
 
 const s3Client = createS3Client('team_logos')
@@ -289,20 +293,21 @@ export async function getTransfermarktPlayerData(
       let ageAtTournament = 18;
 
       if (dobElement.length) {
-        // Get the text and remove any content in parentheses (age)
-        let dobText = dobElement.text().trim().replace(/\s*\([^)]*\)\s*/g, '');
-
-        try {
-          // Parse the date string
-          const date = new Date(dobText);
-
-          // Check if date is valid
-          if (!isNaN(date.getTime())) {
-            // Format as MM/DD/YYYY
-            ageAtTournament = calculateAge(date, tournamentStartDate);
-          }
-        } catch (e) {
-          console.error(`Error parsing date: ${dobText}`, e);
+        const dobText = dobElement.text().trim().replace(/\s*\([^)]*\)\s*/g, '').trim();
+        // MM/DD/YYYY is the confirmed browser-side Transfermarkt format (e.g. "05/25/1995").
+        // Server-side format may differ depending on Accept-Language handling — keep fallbacks.
+        // Do NOT add DD/MM/YYYY alongside MM/DD/YYYY; ambiguous dates (day ≤ 12) would silently mis-parse.
+        const formats = ['MM/DD/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD'];
+        console.warn('Transfermarkt raw DOB:', dobText);
+        const parsed = formats.reduce<dayjs.Dayjs | null>((found, fmt) => {
+          if (found) return found;
+          const d = dayjs(dobText, fmt, true);
+          return d.isValid() ? d : null;
+        }, null);
+        if (parsed) {
+          ageAtTournament = calculateAge(parsed.toDate(), tournamentStartDate);
+        } else {
+          console.error(`Could not parse DOB: "${dobText}"`);
         }
       }
 
@@ -369,4 +374,29 @@ export async function saveTeamTransfermarktId(teamId: string, transfermarktId: s
   }
 
   await updateTeaminDb(teamId, { transfermarkt_id: transfermarktId });
+}
+
+export async function updateTournamentTeamPlayer(
+  playerId: string,
+  data: { age_at_tournament: number; position: string }
+): Promise<void> {
+  const user = await getLoggedInUser();
+  if (!user?.isAdmin) {
+    throw new Error('Unauthorized: Only administrators can access this data');
+  }
+  await updatePlayer(playerId, data);
+}
+
+export async function deleteSpecificTeamPlayers(
+  tournamentId: string,
+  teamId: string,
+  playerIds: string[]
+): Promise<void> {
+  const user = await getLoggedInUser();
+  if (!user?.isAdmin) {
+    throw new Error('Unauthorized: Only administrators can access this data');
+  }
+  if (playerIds.length === 0) return;
+  await clearPlayerAwardSelections(playerIds);
+  await Promise.all(playerIds.map(id => deletePlayer(id)));
 }

--- a/app/components/backoffice/PlayersTab.tsx
+++ b/app/components/backoffice/PlayersTab.tsx
@@ -139,7 +139,7 @@ export default function PlayersTab({tournamentId, transfermarktUrlTemplate}: Pla
 
   const openImportPlayersModal = (team: Team) => {
     setSelectedTeam(team);
-    const englishName = (team.name_i18n as Record<string, string> | undefined)?.en ?? team.name;
+    const englishName = team.name_i18n?.en ?? team.name;
     setTransfermarktName(englishName.replaceAll(' ', '-').toLowerCase());
     setTransfermarktId(team.transfermarkt_id ?? '');
     setDeleteExistingPlayers(false);

--- a/app/components/backoffice/PlayersTab.tsx
+++ b/app/components/backoffice/PlayersTab.tsx
@@ -140,7 +140,7 @@ export default function PlayersTab({tournamentId, transfermarktUrlTemplate}: Pla
   const openImportPlayersModal = (team: Team) => {
     setSelectedTeam(team);
     const englishName = (team.name_i18n as Record<string, string> | undefined)?.en ?? team.name;
-    setTransfermarktName(englishName.replaceAll(' ', '-').toLowerCase() + '-fc-players');
+    setTransfermarktName(englishName.replaceAll(' ', '-').toLowerCase());
     setTransfermarktId(team.transfermarkt_id ?? '');
     setDeleteExistingPlayers(false);
     setOpenImportModal(true);

--- a/app/components/backoffice/PlayersTab.tsx
+++ b/app/components/backoffice/PlayersTab.tsx
@@ -4,7 +4,8 @@ import {useState, useEffect, useCallback} from 'react';
 import {Player, PlayerNew, Team} from "../../db/tables-definition";
 import {
   createTournamentTeamPlayers,
-  deleteTournamentTeamPlayers,
+  deleteSpecificTeamPlayers,
+  updateTournamentTeamPlayer,
   getPlayersInTournament,
   getTransfermarktPlayerData,
   saveTeamTransfermarktId
@@ -73,55 +74,64 @@ export default function PlayersTab({tournamentId, transfermarktUrlTemplate}: Pla
     }
     try {
       setImportLoading(true);
-      let existingPlayers = teamsWithPlayers.find(teamWithPlayers => teamWithPlayers.team.id === selectedTeam.id)?.players || [];
-      const players = await getTransfermarktPlayerData(transfermarktName, transfermarktId, tournamentId, transfermarktUrlTemplate)
-      if(deleteExistingPlayers && existingPlayers.length > 0) {
-        const toDelete =
-          existingPlayers.filter(player =>
-            //Delete players that are not in the new players list
-            !players.some(p =>
-              p.name === player.name &&
-              p.ageAtTournament === player.age_at_tournament))
-        if(toDelete.length > 0) {
-          existingPlayers = existingPlayers.filter(player =>
-            !toDelete.some(p => p.id === player.id))
-          await deleteTournamentTeamPlayers(toDelete)
+      let existingPlayers = teamsWithPlayers.find(t => t.team.id === selectedTeam.id)?.players || [];
+      const newPlayers = await getTransfermarktPlayerData(transfermarktName, transfermarktId, tournamentId, transfermarktUrlTemplate);
+
+      // Delete players removed from the squad (diff by name, with award selection cleanup)
+      if (deleteExistingPlayers && existingPlayers.length > 0) {
+        const toDelete = existingPlayers.filter(
+          existing => !newPlayers.some(p => p.name === existing.name)
+        );
+        if (toDelete.length > 0) {
+          await deleteSpecificTeamPlayers(tournamentId, selectedTeam.id, toDelete.map(p => p.id));
+          existingPlayers = existingPlayers.filter(p => !toDelete.some(d => d.id === p.id));
         }
       }
-      const toCreate: PlayerNew[] = players
-        //Only create players that are not already in the tournament
-        .filter(
-          player => !existingPlayers.some(p =>
-              p.name === player.name &&
-              p.age_at_tournament === player.ageAtTournament)
-        ).map(player => ({
-          name: player.name,
-          position: player.position,
+
+      // Update age and position for players still in the squad (fixes stale DOB-derived ages)
+      const toUpdate = existingPlayers.filter(
+        existing => newPlayers.some(p => p.name === existing.name)
+      );
+      await Promise.all(
+        toUpdate.map(existing => {
+          const fresh = newPlayers.find(p => p.name === existing.name)!;
+          return updateTournamentTeamPlayer(existing.id, {
+            age_at_tournament: fresh.ageAtTournament,
+            position: fresh.position,
+          });
+        })
+      );
+      // Reflect updates in local state
+      existingPlayers = existingPlayers.map(existing => {
+        const fresh = newPlayers.find(p => p.name === existing.name);
+        return fresh
+          ? { ...existing, age_at_tournament: fresh.ageAtTournament, position: fresh.position }
+          : existing;
+      });
+
+      // Insert players not yet in the DB
+      const toCreate: PlayerNew[] = newPlayers
+        .filter(p => !existingPlayers.some(existing => existing.name === p.name))
+        .map(p => ({
+          name: p.name,
+          position: p.position,
           team_id: selectedTeam.id,
           tournament_id: tournamentId,
-          age_at_tournament: player.ageAtTournament
-        }))
+          age_at_tournament: p.ageAtTournament,
+        }));
       const createdPlayers = await createTournamentTeamPlayers(toCreate);
 
-      const allPlayers = [...existingPlayers, ...createdPlayers]
+      const allPlayers = [...existingPlayers, ...createdPlayers];
+      setTeamsWithPlayers(teamsWithPlayers.map(t =>
+        t.team.id === selectedTeam.id ? { team: t.team, players: allPlayers } : t
+      ));
 
-      const newTeamsWithPlayers = teamsWithPlayers.map(teamWithPlayers => {
-        if (teamWithPlayers.team.id === selectedTeam.id) {
-          return {
-            team: teamWithPlayers.team,
-            players: allPlayers
-          };
-        }
-        return teamWithPlayers;
-      });
-      setTeamsWithPlayers(newTeamsWithPlayers);
-
-      // Persist the Transfermarkt ID for pre-filling on re-import (fire-and-forget)
-      saveTeamTransfermarktId(selectedTeam.id, transfermarktId).catch((err) => {
+      // Persist Transfermarkt ID for pre-filling on re-import (fire-and-forget)
+      saveTeamTransfermarktId(selectedTeam.id, transfermarktId).catch(err => {
         console.error('Failed to persist Transfermarkt team ID:', err);
       });
     } catch (error) {
-      console.error(`Error loading Transfermarkt players for team ${selectedTeam.name}:`, error);
+      console.error(`Error importing players for team ${selectedTeam.name}:`, error);
     } finally {
       setImportLoading(false);
     }

--- a/app/components/backoffice/PlayersTab.tsx
+++ b/app/components/backoffice/PlayersTab.tsx
@@ -139,7 +139,8 @@ export default function PlayersTab({tournamentId, transfermarktUrlTemplate}: Pla
 
   const openImportPlayersModal = (team: Team) => {
     setSelectedTeam(team);
-    setTransfermarktName(team.name.replace(' ', '-') + '-fc-players');
+    const englishName = (team.name_i18n as Record<string, string> | undefined)?.en ?? team.name;
+    setTransfermarktName(englishName.replaceAll(' ', '-').toLowerCase() + '-fc-players');
     setTransfermarktId(team.transfermarkt_id ?? '');
     setDeleteExistingPlayers(false);
     setOpenImportModal(true);

--- a/app/db/tournament-guess-repository.ts
+++ b/app/db/tournament-guess-repository.ts
@@ -103,6 +103,24 @@ export async function deleteAllTournamentGuessesByTournamentId(tournamentId: str
     .execute();
 }
 
+export async function clearPlayerAwardSelections(playerIds: string[]): Promise<void> {
+  if (playerIds.length === 0) return;
+  const awardColumns = [
+    'best_player_id',
+    'top_goalscorer_player_id',
+    'best_goalkeeper_player_id',
+    'best_young_player_id',
+  ] as const;
+  await Promise.all(
+    awardColumns.map(col =>
+      db.updateTable('tournament_guesses')
+        .set({ [col]: null })
+        .where(col, 'in', playerIds)
+        .execute()
+    )
+  );
+}
+
 /**
  * Recalculate and materialize game scores for users in a tournament
  * Story #147: Performance optimization to materialize expensive SQL aggregations

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -280,14 +280,18 @@ Team and player management for backoffice — creates/updates teams, imports pla
   Calls: getLoggedInUser, validateRank, updateTeaminDb, deleteThemeLogoFromS3, applyLocalization
 - **getPlayersInTournament(tournamentId: string)**: `Promise<{team: Team, players: Player[]}[]>` — Returns all teams in a tournament with their player rosters.
   Calls: findTeamInTournament, findPlayersByTeamId
-- **getTransfermarktPlayerData(transfermarktTeamName: string, transfermarktTeamId: string, tournamentId: string, urlTemplate?: string | null)**: `Promise<PlayerData[]>` — Scrapes player data from Transfermarkt. Uses urlTemplate (with `{teamName}` and `{teamId}` placeholders) when provided and valid; falls back to hardcoded club URL (admin only).
+- **getTransfermarktPlayerData(transfermarktTeamName: string, transfermarktTeamId: string, tournamentId: string, urlTemplate?: string | null)**: `Promise<PlayerData[]>` — Scrapes player data from Transfermarkt. Uses urlTemplate (with `{teamName}` and `{teamId}` placeholders) when provided and valid; falls back to hardcoded club URL (admin only). Parses DOB using dayjs with format list ['MM/DD/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD']; falls back to age 18 on parse failure.
   Calls: getLoggedInUser, getTournamentStartDate
 - **deleteAllTeamPlayersInTournament(tournamentId: string, teamId: string)**: `Promise<void>` — Deletes all players for a team in a tournament (admin only).
-  Calls: getLoggedInUser, findPlayersByTeamId, deletePlayer
+  Calls: getLoggedInUser, deleteAllPlayersInTournamentTeamDb
 - **createTournamentTeamPlayers(players: PlayerNew[])**: `Promise<Player[]>` — Bulk-creates player records (admin only).
   Calls: getLoggedInUser, createPlayer
-- **deleteTournamentTeamPlayers(players: Player[])**: `Promise<void>` — Bulk-deletes player records (admin only).
+- **deleteTournamentTeamPlayers(players: Player[])**: `Promise<void>` — Bulk-deletes player records by Player objects (admin only).
   Calls: getLoggedInUser, deletePlayer
+- **updateTournamentTeamPlayer(playerId: string, data: { age_at_tournament: number; position: string })**: `Promise<void>` — Updates age and position for an existing player record. Used on re-import to correct stale DOB-derived age (admin only).
+  Calls: getLoggedInUser, updatePlayer
+- **deleteSpecificTeamPlayers(tournamentId: string, teamId: string, playerIds: string[])**: `Promise<void>` — Clears award selections then deletes the specified player records. No-ops on empty array (admin only).
+  Calls: getLoggedInUser, clearPlayerAwardSelections, deletePlayer
 - **moveTournamentTeamPlayer(player: Player, newTeamId: string)**: `Promise<Player>` — Moves a player to a different team (admin only).
   Calls: getLoggedInUser, updatePlayer
 - **saveTeamTransfermarktId(teamId: string, transfermarktId: string)**: `Promise<void>` — Persists a team's Transfermarkt ID after a successful import for pre-filling on re-import (admin only).

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-21
+**Last updated:** 2026-05-26
 
 ---
 
@@ -280,7 +280,7 @@ Team and player management for backoffice — creates/updates teams, imports pla
   Calls: getLoggedInUser, validateRank, updateTeaminDb, deleteThemeLogoFromS3, applyLocalization
 - **getPlayersInTournament(tournamentId: string)**: `Promise<{team: Team, players: Player[]}[]>` — Returns all teams in a tournament with their player rosters.
   Calls: findTeamInTournament, findPlayersByTeamId
-- **getTransfermarktPlayerData(transfermarktTeamName: string, transfermarktTeamId: string, tournamentId: string, urlTemplate?: string | null)**: `Promise<PlayerData[]>` — Scrapes player data from Transfermarkt. Uses urlTemplate (with `{teamName}` and `{teamId}` placeholders) when provided and valid; falls back to hardcoded club URL (admin only). Parses DOB using dayjs with format list ['MM/DD/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD']; falls back to age 18 on parse failure.
+- **getTransfermarktPlayerData(transfermarktTeamName: string, transfermarktTeamId: string, tournamentId: string, urlTemplate?: string | null)**: `Promise<PlayerData[]>` — Scrapes player data from Transfermarkt. Uses urlTemplate (with `{teamName}` and `{teamId}` placeholders) when provided and valid; falls back to hardcoded club URL (admin only). Parses DOB using dayjs with format list ['DD/MM/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD'] (DD/MM/YYYY is first — confirmed server-side format); falls back to age 18 on parse failure.
   Calls: getLoggedInUser, getTournamentStartDate
 - **deleteAllTeamPlayersInTournament(tournamentId: string, teamId: string)**: `Promise<void>` — Deletes all players for a team in a tournament (admin only).
   Calls: getLoggedInUser, deleteAllPlayersInTournamentTeamDb

--- a/docs/code-structure/components/components-backoffice.md
+++ b/docs/code-structure/components/components-backoffice.md
@@ -96,8 +96,8 @@ Admin user list with search, pagination, and ad-free toggle. [Client] self-fetch
 
 ### app/components/backoffice/PlayersTab.tsx
 Player management with Transfermarkt import. [Client] import interface and player list.
-- **PlayersTab({ tournamentId, transfermarktUrlTemplate }: PlayersTabProps)**: `JSX.Element` — [Client] Displays teams with player lists and Transfermarkt import dialog. Pre-fills team's stored Transfermarkt ID on modal open; persists it after a successful import (Story #306).
-  Calls: getPlayersInTournament, getTransfermarktPlayerData, createTournamentTeamPlayers, deleteTournamentTeamPlayers, saveTeamTransfermarktId
+- **PlayersTab({ tournamentId, transfermarktUrlTemplate }: PlayersTabProps)**: `JSX.Element` — [Client] Displays teams with player lists and Transfermarkt import dialog. Import uses upsert-by-name logic: updates age/position for matched players, deletes removed players (with award cleanup) when checkbox checked, inserts new players. Pre-fills stored Transfermarkt ID on modal open; persists it after successful import (Story #306, #461).
+  Calls: getPlayersInTournament, getTransfermarktPlayerData, createTournamentTeamPlayers, updateTournamentTeamPlayer, deleteSpecificTeamPlayers, saveTeamTransfermarktId
   Uses: useCallback, useEffect, useState
   Renders: Accordion, Dialog, TextField, Checkbox, Table, Button, Alert
 

--- a/docs/code-structure/components/components-backoffice.md
+++ b/docs/code-structure/components/components-backoffice.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-20
+**Last updated:** 2026-05-26
 
 ---
 

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -271,6 +271,7 @@ Repository for tournament_guesses table. Tracks overall tournament scores and ma
 - **deleteAllUserTournamentGuesses(userId: string)**: `Promise<void>` — Deletes all for user (account deletion).
 - **deleteAllTournamentGuessesByTournamentId(tournamentId: string)**: `Promise<void>` — Deletes all for tournament.
 - **recalculateGameScoresForUsers(userIds: string[], tournamentId: string)**: `Promise<TournamentGuess[]>` — Recalculates and materializes game scores from aggregation, including goal_difference counts. Also writes a daily score snapshot (writeScoreSnapshot) per user inside the loop.
+- **clearPlayerAwardSelections(playerIds: string[])**: `Promise<void>` — NULLs out all 4 award FK columns (best_player_id, top_goalscorer_player_id, best_goalkeeper_player_id, best_young_player_id) for the given player IDs. No-ops on empty array. Used before deleting players to prevent orphaned award references.
 
 ### app/db/tournament-playoff-repository.ts
 Repository for tournament_playoff_rounds and playoff games. Manages playoff bracket structure.

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-20
+**Last updated:** 2026-05-26
 
 ---
 

--- a/plans/STORY-461-context.md
+++ b/plans/STORY-461-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** Fix player import: DOB parsing failures and delete-existing-players not working
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-461
 - **Branch:** feature/story-461
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 462
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/462
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-461-context.md
+++ b/plans/STORY-461-context.md
@@ -1,0 +1,16 @@
+# Story 461 Context
+
+## Metadata
+- **Story Number:** 461
+- **Story Title:** Fix player import: DOB parsing failures and delete-existing-players not working
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-461
+- **Branch:** feature/story-461
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-461-plan.md
+
+## Quick Summary
+Two bug fixes in the Transfermarkt player import flow: (1) DOB parsing uses `new Date()` which fails for non-US formats, fixed by using `dayjs` with explicit format list; (2) "delete existing players" checkbox never deleted anything due to age mismatches, fixed by doing a full wipe via `deleteAllTeamPlayersInTournament` before reimporting.

--- a/plans/STORY-461-context.md
+++ b/plans/STORY-461-context.md
@@ -9,7 +9,7 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/462
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** implementing
 - **Plan File:** plans/STORY-461-plan.md
 
 ## Quick Summary

--- a/plans/STORY-461-plan.md
+++ b/plans/STORY-461-plan.md
@@ -81,9 +81,12 @@ New call path added: `PlayersTab (handleImportPlayers)` → `deleteSpecificTeamP
 
 - **getTransfermarktPlayerData(...)** — internal parsing change only, signature unchanged
   - Add `import dayjs from 'dayjs'` and `import customParseFormat from 'dayjs/plugin/customParseFormat'`
-  - Replace `new Date(dobText)` block with `dayjs(dobText, formats, true)` where `formats = ['MM/DD/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD']` — `MM/DD/YYYY` first because that is Transfermarkt's confirmed format (e.g. `"05/25/1995 (31)"` → after stripping parens → `"05/25/1995"`); others are defensive fallbacks
+  - The backend fetch already sends `Accept-Language: en-US,en;q=0.5` but Transfermarkt may not honor it for date formatting — the URL path is in German (`/kader/verein/`) and date format can vary independently of the language header
+  - Replace `new Date(dobText)` block with `dayjs(dobText, formats, true)` where `formats = ['MM/DD/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD']`
+  - `MM/DD/YYYY` is first because `"05/25/1995 (31)"` is the confirmed browser-side format; if the server returns a different format, the next formats in the list will catch it
+  - **Important ambiguity:** `MM/DD/YYYY` vs `DD/MM/YYYY` cannot be distinguished for dates where day ≤ 12. Do NOT add `DD/MM/YYYY` to the list — it would silently mis-parse ambiguous dates. If the server-side format turns out to be `DD/MM/YYYY`, we need to remove `MM/DD/YYYY` and add `DD/MM/YYYY` instead (not both).
+  - Add `console.info('Transfermarkt raw DOB:', dobText)` in the parsing block **during this implementation** so the first test deploy reveals the actual server-side format. Remove this log once confirmed.
   - Log `console.error` with raw `dobText` when no format matches (keeps age-18 fallback but makes failures visible)
-  - Transfermarkt is always fetched in English so month abbreviations are always English
   - Tests:
     - parses `"Jan 5, 1998"` (US format) correctly
     - parses `"05.01.1998"` (European DD.MM.YYYY) correctly — not mis-read as May 3rd

--- a/plans/STORY-461-plan.md
+++ b/plans/STORY-461-plan.md
@@ -19,7 +19,7 @@ Two bugs in the Transfermarkt player import flow in the backoffice Players tab.
 |------|--------|
 | `app/actions/team-actions.ts` | Fix DOB parsing: replace `new Date()` with `dayjs` + `customParseFormat` |
 | `app/db/tournament-guess-repository.ts` | Add `clearPlayerAwardSelections(playerIds)` |
-| `app/actions/team-actions.ts` | Export new `deleteSpecificTeamPlayers` action wrapping award cleanup + player delete |
+| `app/actions/team-actions.ts` | Export `deleteSpecificTeamPlayers` (award cleanup + delete) and `updateTournamentTeamPlayer` (correct stale age/position) |
 | `app/components/backoffice/PlayersTab.tsx` | Fix delete logic: diff-delete by name-only, with award cleanup for removed players |
 
 ## Background: Award Selections
@@ -60,6 +60,14 @@ New call path added: `PlayersTab (handleImportPlayers)` → `deleteSpecificTeamP
 
 **New functions:**
 
+- **updateTournamentTeamPlayer(playerId: string, data: { age_at_tournament: number, position: string })**: `Promise<void>`
+  Server Action. Admin-only. Updates age and position for an existing player record. Used to correct stale data on re-import.
+  Calls: getLoggedInUser, updatePlayer
+  Tests:
+  - throws Unauthorized when non-admin
+  - updates age_at_tournament and position on the player record
+  - no-ops on fields not passed
+
 - **deleteSpecificTeamPlayers(tournamentId: string, teamId: string, playerIds: string[])**: `Promise<void>`
   Server Action. Admin-only. Clears award selections for the given playerIds, then deletes those player records.
   Calls: getLoggedInUser, clearPlayerAwardSelections, deleteTournamentTeamPlayers
@@ -89,12 +97,15 @@ New call path added: `PlayersTab (handleImportPlayers)` → `deleteSpecificTeamP
 
 - **handleImportPlayers()** — internal logic change, no signature
   - Replace `deleteTournamentTeamPlayers` import with `deleteSpecificTeamPlayers` from `team-actions`
-  - When `deleteExistingPlayers === true`: compute `toDelete` by matching existing vs new import **by name only** (remove age comparison). Call `deleteSpecificTeamPlayers(tournamentId, selectedTeam.id, toDelete.map(p => p.id))`.
-  - Update local `existingPlayers` to remove deleted players before dedup filter runs
-  - Keep existing dedup logic for insert (prevents re-adding kept players)
+  - Import `updateTournamentTeamPlayer` from `team-actions` (new action, see below)
+  - **Always** (regardless of checkbox): for each Transfermarkt player whose name matches an existing player, call `updateTournamentTeamPlayer(existingPlayer.id, { age_at_tournament, position })`. This corrects stale ages from the old broken DOB parser.
+  - When `deleteExistingPlayers === true`: compute `toDelete` by matching existing vs new import **by name only**. Call `deleteSpecificTeamPlayers(tournamentId, selectedTeam.id, toDelete.map(p => p.id))`. Update local `existingPlayers` to remove deleted entries.
+  - Insert only players not already in DB by name (unchanged logic, now correct because updates handled separately)
   - Note: name-only matching assumes player names are unique per team (standard for real squad data).
   - Tests:
-    - when `deleteExistingPlayers === false`, existing players are preserved and only new ones added
+    - matched player with stale age is updated to the new age from Transfermarkt
+    - matched player's position is updated if it changed
+    - when `deleteExistingPlayers === false`, unmatched existing players are preserved (not deleted)
     - when `deleteExistingPlayers === true`, players not in the new import are identified by name and passed to `deleteSpecificTeamPlayers`
     - when `deleteExistingPlayers === true`, players whose name appears in the new import are NOT deleted (award selections survive)
     - when `deleteExistingPlayers === true` and a player is removed from squad, `deleteSpecificTeamPlayers` is called with that player's ID (verifies award cleanup integration)
@@ -103,8 +114,8 @@ New call path added: `PlayersTab (handleImportPlayers)` → `deleteSpecificTeamP
 ## Implementation Steps
 
 1. `app/db/tournament-guess-repository.ts`: add `clearPlayerAwardSelections`
-2. `app/actions/team-actions.ts`: add dayjs imports + fix DOB parsing; add `deleteSpecificTeamPlayers` action
-3. `app/components/backoffice/PlayersTab.tsx`: update import, switch to name-only diff-delete via `deleteSpecificTeamPlayers`
+2. `app/actions/team-actions.ts`: add dayjs imports + fix DOB parsing; add `deleteSpecificTeamPlayers` and `updateTournamentTeamPlayer` actions
+3. `app/components/backoffice/PlayersTab.tsx`: update imports; on import — update matched players (age+position), delete removed players with award cleanup, insert new players
 
 ## CODE-STRUCTURE Files to Update
 - `docs/code-structure/db.md` — add `clearPlayerAwardSelections` to tournament-guess-repository section

--- a/plans/STORY-461-plan.md
+++ b/plans/STORY-461-plan.md
@@ -126,6 +126,18 @@ New call path added: `PlayersTab (handleImportPlayers)` → `deleteSpecificTeamP
 - `docs/code-structure/components/components-backoffice.md` — update `handleImportPlayers` note
 - Call graph: Add new flow for `deleteSpecificTeamPlayers`
 
+## Implementation Amendments
+
+### Amendment 1: DOB format confirmed as DD/MM/YYYY server-side
+**Date:** 2026-05-25
+**Reason:** Plan initially assumed MM/DD/YYYY based on browser observation. After deploying with debug logging (`console.warn` of raw DOB), server logs confirmed Transfermarkt returns DD/MM/YYYY server-side despite the `Accept-Language: en-US` header.
+**Change:** Swapped primary format to `DD/MM/YYYY`, removed `MM/DD/YYYY` from list (can't have both due to ambiguity for days ≤ 12), removed debug log.
+
+### Amendment 2: Team name pre-fill uses English locale name, no suffix
+**Date:** 2026-05-25
+**Reason:** User feedback — the pre-fill should use the English version of the team name (from `name_i18n.en`) rather than the localized display name, and should not append `-fc-players`.
+**Change:** `openImportPlayersModal` now reads `team.name_i18n?.en ?? team.name`, applies `replaceAll(' ', '-').toLowerCase()`, and uses that as the pre-filled value with no suffix.
+
 ## Verification
 - Import a team from Transfermarkt → verify ages look correct (not all 18)
 - A user selects a player for "best player" award → re-import same team with "delete existing players" checked → that player's award selection is preserved (player kept by name match)

--- a/plans/STORY-461-plan.md
+++ b/plans/STORY-461-plan.md
@@ -18,14 +18,56 @@ Two bugs in the Transfermarkt player import flow in the backoffice Players tab.
 | File | Change |
 |------|--------|
 | `app/actions/team-actions.ts` | Fix DOB parsing: replace `new Date()` with `dayjs` + `customParseFormat` |
-| `app/components/backoffice/PlayersTab.tsx` | Fix delete logic: full wipe via `deleteAllTeamPlayersInTournament` when checkbox checked |
+| `app/db/tournament-guess-repository.ts` | Add `clearPlayerAwardSelections(playerIds)` |
+| `app/actions/team-actions.ts` | Export new `deleteSpecificTeamPlayers` action wrapping award cleanup + player delete |
+| `app/components/backoffice/PlayersTab.tsx` | Fix delete logic: diff-delete by name-only, with award cleanup for removed players |
+
+## Background: Award Selections
+
+`tournament_guesses` stores per-user award picks with 4 player FK columns:
+`best_player_id`, `top_goalscorer_player_id`, `best_goalkeeper_player_id`, `best_young_player_id`.
+**There is no FK cascade** — deleting a player leaves orphaned UUIDs silently.
+We must NULL these out before deleting any players.
+`tournaments` has the same 4 columns for final results (admin-set); we do NOT auto-clear those.
+
+## Why diff-delete (not full wipe)
+
+A full wipe assigns new UUIDs on reimport → all award selections for the team are lost.
+Diff-delete (match by name) keeps existing player records for players still in the squad,
+preserving their IDs and award selections. Only players removed from the squad are deleted,
+and their award selections are cleaned up.
 
 ## Mid-Level Design
 
 ### Call Graph Changes
-No call graph changes. `PlayersTab.tsx` will import `deleteAllTeamPlayersInTournament` which already exists in `team-actions.ts` but wasn't used from this component.
+New call path added: `PlayersTab (handleImportPlayers)` → `deleteSpecificTeamPlayers` → `clearPlayerAwardSelections` + `deleteTournamentTeamPlayers`.
+
+### `app/db/tournament-guess-repository.ts` *(modified)*
+
+**New functions:**
+
+- **clearPlayerAwardSelections(playerIds: string[])**: `Promise<void>`
+  No-ops when `playerIds` is empty. Runs 4 separate `UPDATE tournament_guesses SET col = NULL WHERE col IN (playerIds)` queries (one per award column) using Kysely.
+  Tests:
+  - no-ops when playerIds is empty
+  - clears `best_player_id` where it matches a deleted player
+  - clears `top_goalscorer_player_id` where it matches
+  - clears `best_goalkeeper_player_id` where it matches
+  - clears `best_young_player_id` where it matches
+  - does not affect rows whose award columns reference other players
 
 ### `app/actions/team-actions.ts` *(modified)*
+
+**New functions:**
+
+- **deleteSpecificTeamPlayers(tournamentId: string, teamId: string, playerIds: string[])**: `Promise<void>`
+  Server Action. Admin-only. Clears award selections for the given playerIds, then deletes those player records.
+  Calls: getLoggedInUser, clearPlayerAwardSelections, deleteTournamentTeamPlayers
+  Tests:
+  - throws Unauthorized when non-admin
+  - calls clearPlayerAwardSelections before deleting players
+  - no-ops when playerIds is empty
+  - deletes only the specified player IDs
 
 **Changed functions:**
 
@@ -33,10 +75,10 @@ No call graph changes. `PlayersTab.tsx` will import `deleteAllTeamPlayersInTourn
   - Add `import dayjs from 'dayjs'` and `import customParseFormat from 'dayjs/plugin/customParseFormat'`
   - Replace `new Date(dobText)` block with `dayjs(dobText, formats, true)` where `formats = ['MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD', 'MM/DD/YYYY']`
   - Log `console.error` with raw `dobText` when no format matches (keeps age-18 fallback but makes failures visible)
-  - Transfermarkt is always fetched in English (`?locale=page`) so month abbreviations are always English
+  - Transfermarkt is always fetched in English so month abbreviations are always English
   - Tests:
     - parses `"Jan 5, 1998"` (US format) correctly
-    - parses `"05.01.1998"` (European DD.MM.YYYY) correctly → NOT mis-read as May 3rd
+    - parses `"05.01.1998"` (European DD.MM.YYYY) correctly — not mis-read as May 3rd
     - parses `"5 Jan 1998"` (D MMM YYYY) correctly
     - parses `"01.01.1998"` (zero-padded European) correctly
     - falls back to age 18 and logs error when DOB is unparseable (e.g. `"99/99/9999"`)
@@ -46,28 +88,32 @@ No call graph changes. `PlayersTab.tsx` will import `deleteAllTeamPlayersInTourn
 **Changed functions:**
 
 - **handleImportPlayers()** — internal logic change, no signature
-  - Import `deleteAllTeamPlayersInTournament` from `../../actions/team-actions`
-  - When `deleteExistingPlayers === true`: call `deleteAllTeamPlayersInTournament(tournamentId, selectedTeam.id)` BEFORE fetching Transfermarkt data, set `existingPlayers = []`
-  - Remove the old diff-delete block (lines ~78–89 in current file)
-  - Note: delete-then-import is not atomic. If delete succeeds but the Transfermarkt fetch fails, the team has no players. User retries the import (delete runs again, then import). This is acceptable UX for a backoffice admin operation.
+  - Replace `deleteTournamentTeamPlayers` import with `deleteSpecificTeamPlayers` from `team-actions`
+  - When `deleteExistingPlayers === true`: compute `toDelete` by matching existing vs new import **by name only** (remove age comparison). Call `deleteSpecificTeamPlayers(tournamentId, selectedTeam.id, toDelete.map(p => p.id))`.
+  - Update local `existingPlayers` to remove deleted players before dedup filter runs
+  - Keep existing dedup logic for insert (prevents re-adding kept players)
+  - Note: name-only matching assumes player names are unique per team (standard for real squad data).
   - Tests:
-    - when `deleteExistingPlayers === false`, existing players preserved and only new ones added
-    - when `deleteExistingPlayers === true`, `deleteAllTeamPlayersInTournament` is called with correct `tournamentId` and `selectedTeam.id` before the fetch
-    - when `deleteExistingPlayers === true`, `existingPlayers` is set to `[]` before dedup filter runs
-    - when `deleteExistingPlayers === true`, all Transfermarkt players are created (no dedup against empty list)
-    - when `deleteAllTeamPlayersInTournament` throws, the error is caught and import aborts
+    - when `deleteExistingPlayers === false`, existing players are preserved and only new ones added
+    - when `deleteExistingPlayers === true`, players not in the new import are identified by name and passed to `deleteSpecificTeamPlayers`
+    - when `deleteExistingPlayers === true`, players whose name appears in the new import are NOT deleted (award selections survive)
+    - when `deleteExistingPlayers === true` and a player is removed from squad, `deleteSpecificTeamPlayers` is called with that player's ID (verifies award cleanup integration)
+    - when `deleteSpecificTeamPlayers` throws, the error propagates and import aborts
 
 ## Implementation Steps
 
-1. `app/actions/team-actions.ts`: add dayjs imports, replace `new Date(dobText)` block
-2. `app/components/backoffice/PlayersTab.tsx`: add `deleteAllTeamPlayersInTournament` import, replace diff-delete block with full wipe
+1. `app/db/tournament-guess-repository.ts`: add `clearPlayerAwardSelections`
+2. `app/actions/team-actions.ts`: add dayjs imports + fix DOB parsing; add `deleteSpecificTeamPlayers` action
+3. `app/components/backoffice/PlayersTab.tsx`: update import, switch to name-only diff-delete via `deleteSpecificTeamPlayers`
 
 ## CODE-STRUCTURE Files to Update
-- `docs/code-structure/actions.md` — update `getTransfermarktPlayerData` description
+- `docs/code-structure/db.md` — add `clearPlayerAwardSelections` to tournament-guess-repository section
+- `docs/code-structure/actions.md` — add `deleteSpecificTeamPlayers`; update `getTransfermarktPlayerData`
 - `docs/code-structure/components/components-backoffice.md` — update `handleImportPlayers` note
-- Call graph: No changes
+- Call graph: Add new flow for `deleteSpecificTeamPlayers`
 
 ## Verification
 - Import a team from Transfermarkt → verify ages look correct (not all 18)
-- Re-import same team with "delete existing players" checked → all old players removed, fresh set imported
-- Re-import same team WITHOUT checkbox → existing players preserved, only new ones added
+- A user selects a player for "best player" award → re-import same team with "delete existing players" checked → that player's award selection is preserved (player kept by name match)
+- Re-import with a player removed from the squad → that player's award selection is NULLed out in `tournament_guesses`
+- Re-import without checkbox → existing players and award selections fully preserved

--- a/plans/STORY-461-plan.md
+++ b/plans/STORY-461-plan.md
@@ -81,7 +81,7 @@ New call path added: `PlayersTab (handleImportPlayers)` → `deleteSpecificTeamP
 
 - **getTransfermarktPlayerData(...)** — internal parsing change only, signature unchanged
   - Add `import dayjs from 'dayjs'` and `import customParseFormat from 'dayjs/plugin/customParseFormat'`
-  - Replace `new Date(dobText)` block with `dayjs(dobText, formats, true)` where `formats = ['MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD', 'MM/DD/YYYY']`
+  - Replace `new Date(dobText)` block with `dayjs(dobText, formats, true)` where `formats = ['MM/DD/YYYY', 'MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD']` — `MM/DD/YYYY` first because that is Transfermarkt's confirmed format (e.g. `"05/25/1995 (31)"` → after stripping parens → `"05/25/1995"`); others are defensive fallbacks
   - Log `console.error` with raw `dobText` when no format matches (keeps age-18 fallback but makes failures visible)
   - Transfermarkt is always fetched in English so month abbreviations are always English
   - Tests:

--- a/plans/STORY-461-plan.md
+++ b/plans/STORY-461-plan.md
@@ -1,0 +1,73 @@
+# Plan: Fix Player Import — DOB Parsing & Delete Existing Players (#461)
+
+## Story
+[GitHub Issue #461](https://github.com/gvinokur/qatar-prode/issues/461)
+- **Worktree:** `/Users/gvinokur/Personal/qatar-prode-story-461`
+- **Branch:** `feature/story-461`
+
+## Context
+
+Two bugs in the Transfermarkt player import flow in the backoffice Players tab.
+
+**Bug 1 — DOB parsing failures:** `getTransfermarktPlayerData` in `app/actions/team-actions.ts` parses the scraped DOB with `new Date(dobText)`. This silently fails for non-US date formats (e.g. `"05.03.1998"`, which `new Date` interprets as May 3rd or returns `Invalid Date`). Failed parses fall back to age 18.
+
+**Bug 2 — Delete existing players not working:** The "delete existing players" checkbox does a diff-delete: removes players NOT in the new Transfermarkt list by matching on name+age. Because Bug 1 causes all new-import ages to default to 18, the age comparison always fails (e.g. `18 !== 28`), so `toDelete` ends up containing all existing players or none. The simpler and more reliable fix: when the checkbox is checked, wipe all existing players for the team first via `deleteAllTeamPlayersInTournament` (already exists in `team-actions.ts`), then import fresh.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `app/actions/team-actions.ts` | Fix DOB parsing: replace `new Date()` with `dayjs` + `customParseFormat` |
+| `app/components/backoffice/PlayersTab.tsx` | Fix delete logic: full wipe via `deleteAllTeamPlayersInTournament` when checkbox checked |
+
+## Mid-Level Design
+
+### Call Graph Changes
+No call graph changes. `PlayersTab.tsx` will import `deleteAllTeamPlayersInTournament` which already exists in `team-actions.ts` but wasn't used from this component.
+
+### `app/actions/team-actions.ts` *(modified)*
+
+**Changed functions:**
+
+- **getTransfermarktPlayerData(...)** — internal parsing change only, signature unchanged
+  - Add `import dayjs from 'dayjs'` and `import customParseFormat from 'dayjs/plugin/customParseFormat'`
+  - Replace `new Date(dobText)` block with `dayjs(dobText, formats, true)` where `formats = ['MMM D, YYYY', 'DD.MM.YYYY', 'D MMM YYYY', 'YYYY-MM-DD', 'MM/DD/YYYY']`
+  - Log `console.error` with raw `dobText` when no format matches (keeps age-18 fallback but makes failures visible)
+  - Transfermarkt is always fetched in English (`?locale=page`) so month abbreviations are always English
+  - Tests:
+    - parses `"Jan 5, 1998"` (US format) correctly
+    - parses `"05.01.1998"` (European DD.MM.YYYY) correctly → NOT mis-read as May 3rd
+    - parses `"5 Jan 1998"` (D MMM YYYY) correctly
+    - parses `"01.01.1998"` (zero-padded European) correctly
+    - falls back to age 18 and logs error when DOB is unparseable (e.g. `"99/99/9999"`)
+
+### `app/components/backoffice/PlayersTab.tsx` *(modified)*
+
+**Changed functions:**
+
+- **handleImportPlayers()** — internal logic change, no signature
+  - Import `deleteAllTeamPlayersInTournament` from `../../actions/team-actions`
+  - When `deleteExistingPlayers === true`: call `deleteAllTeamPlayersInTournament(tournamentId, selectedTeam.id)` BEFORE fetching Transfermarkt data, set `existingPlayers = []`
+  - Remove the old diff-delete block (lines ~78–89 in current file)
+  - Note: delete-then-import is not atomic. If delete succeeds but the Transfermarkt fetch fails, the team has no players. User retries the import (delete runs again, then import). This is acceptable UX for a backoffice admin operation.
+  - Tests:
+    - when `deleteExistingPlayers === false`, existing players preserved and only new ones added
+    - when `deleteExistingPlayers === true`, `deleteAllTeamPlayersInTournament` is called with correct `tournamentId` and `selectedTeam.id` before the fetch
+    - when `deleteExistingPlayers === true`, `existingPlayers` is set to `[]` before dedup filter runs
+    - when `deleteExistingPlayers === true`, all Transfermarkt players are created (no dedup against empty list)
+    - when `deleteAllTeamPlayersInTournament` throws, the error is caught and import aborts
+
+## Implementation Steps
+
+1. `app/actions/team-actions.ts`: add dayjs imports, replace `new Date(dobText)` block
+2. `app/components/backoffice/PlayersTab.tsx`: add `deleteAllTeamPlayersInTournament` import, replace diff-delete block with full wipe
+
+## CODE-STRUCTURE Files to Update
+- `docs/code-structure/actions.md` — update `getTransfermarktPlayerData` description
+- `docs/code-structure/components/components-backoffice.md` — update `handleImportPlayers` note
+- Call graph: No changes
+
+## Verification
+- Import a team from Transfermarkt → verify ages look correct (not all 18)
+- Re-import same team with "delete existing players" checked → all old players removed, fresh set imported
+- Re-import same team WITHOUT checkbox → existing players preserved, only new ones added


### PR DESCRIPTION
Fixes #461

## Summary
Implementation plan for fixing two bugs in the Transfermarkt player import flow:
1. DOB parsing failures when dates are in non-US formats (e.g. `05.03.1998`)
2. "Delete existing players" checkbox not working due to age mismatches caused by Bug 1

## Plan Document
See `plans/STORY-461-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)