### PR TITLE
Plan: [Story] Show AI auto-fill button in game card edit mode #464

### DIFF
--- a/app/components/__tests__/flippable-game-card-ai-button.test.tsx
+++ b/app/components/__tests__/flippable-game-card-ai-button.test.tsx
@@ -1,0 +1,174 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders } from '@/__tests__/utils/test-utils';
+import FlippableGameCard from '../flippable-game-card';
+import * as aiPredictionModule from '../../utils/ai-prediction-generator';
+
+// GameView renders GameCountdownDisplay which requires CountdownProvider — stub it out
+vi.mock('../game-view', () => ({
+  default: () => <div data-testid="game-view-stub" />,
+}));
+import type { ExtendedGameData } from '../../definitions';
+import type { Team } from '../../db/tables-definition';
+
+vi.mock('next-intl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next-intl')>();
+  return {
+    ...actual,
+    useTranslations: () => {
+      const t = (key: string) => key;
+      return t;
+    },
+  };
+});
+
+vi.mock('framer-motion', () => ({
+  useReducedMotion: () => false,
+}));
+
+const baseGame: ExtendedGameData = {
+  id: 'game-1',
+  tournament_id: 'tournament-1',
+  game_number: 1,
+  home_team: 'team-a',
+  away_team: 'team-b',
+  game_date: new Date('2026-12-01T15:00:00Z'),
+  location: 'Stadium',
+  group: { tournament_group_id: 'g1', group_letter: 'A' },
+  playoffStage: null,
+  gameResult: null,
+};
+
+const teamsMap: Record<string, Team> = {
+  'team-a': { id: 'team-a', name: 'Team A', short_name: 'TMA', rank: 5 } as Team,
+  'team-b': { id: 'team-b', name: 'Team B', short_name: 'TMB', rank: 10 } as Team,
+};
+
+const defaultProps = {
+  game: baseGame,
+  teamsMap,
+  isPlayoffs: false,
+  isEditing: true,
+  onEditStart: vi.fn(),
+  onEditEnd: vi.fn(),
+};
+
+describe('FlippableGameCard — AI auto-fill in edit mode', () => {
+  beforeEach(() => {
+    vi.spyOn(aiPredictionModule, 'generateAIPrediction').mockReturnValue({
+      homeScore: 2,
+      awayScore: 1,
+      homePenaltyWinner: undefined,
+      awayPenaltyWinner: undefined,
+    });
+  });
+
+  it('does not render AI button in edit mode when onAIGenerateClick prop is absent', () => {
+    renderWithProviders(
+      <FlippableGameCard {...defaultProps} />,
+      { guessesContext: true }
+    );
+    expect(screen.queryByRole('button', { name: 'aiGenerate.tooltipSingle' })).not.toBeInTheDocument();
+  });
+
+  it('renders AI button in edit mode when onAIGenerateClick prop is provided', () => {
+    renderWithProviders(
+      <FlippableGameCard {...defaultProps} onAIGenerateClick={vi.fn()} />,
+      { guessesContext: true }
+    );
+    expect(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' })).toBeInTheDocument();
+  });
+
+  it('does not render AI button when disabled=true', () => {
+    renderWithProviders(
+      <FlippableGameCard {...defaultProps} disabled={true} onAIGenerateClick={vi.fn()} />,
+      { guessesContext: true }
+    );
+    expect(screen.queryByRole('button', { name: 'aiGenerate.tooltipSingle' })).not.toBeInTheDocument();
+  });
+
+  it('calls generateAIPrediction with team ranks on button click', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <FlippableGameCard {...defaultProps} onAIGenerateClick={vi.fn()} />,
+      { guessesContext: true }
+    );
+    await user.click(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' }));
+    expect(aiPredictionModule.generateAIPrediction).toHaveBeenCalledWith(5, 10, false);
+  });
+
+  it('sets score inputs to AI-generated values, overwriting existing values', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <FlippableGameCard
+        {...defaultProps}
+        homeScore={9}
+        awayScore={9}
+        onAIGenerateClick={vi.fn()}
+      />,
+      { guessesContext: true }
+    );
+    await user.click(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' }));
+    // After AI fill, score inputs should show 2 and 1 (not 9 and 9)
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs[0]).toHaveValue(2);
+    expect(inputs[1]).toHaveValue(1);
+  });
+
+  it('sets penalty winner fields for playoff game when AI predicts a tie', async () => {
+    vi.spyOn(aiPredictionModule, 'generateAIPrediction').mockReturnValue({
+      homeScore: 1,
+      awayScore: 1,
+      homePenaltyWinner: false,
+      awayPenaltyWinner: true,
+    });
+    const user = userEvent.setup();
+    const playoffGame: ExtendedGameData = {
+      ...baseGame,
+      group: null,
+      playoffStage: { tournament_playoff_round_id: 'r1', round_name: 'Final', is_final: true, is_third_place: false },
+    };
+    renderWithProviders(
+      <FlippableGameCard
+        {...defaultProps}
+        game={playoffGame}
+        isPlayoffs={true}
+        onAIGenerateClick={vi.fn()}
+      />,
+      { guessesContext: true }
+    );
+    await user.click(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' }));
+    expect(aiPredictionModule.generateAIPrediction).toHaveBeenCalledWith(5, 10, true);
+  });
+
+  it('does not show penalty section for group-stage game (no playoff)', async () => {
+    vi.spyOn(aiPredictionModule, 'generateAIPrediction').mockReturnValue({
+      homeScore: 2,
+      awayScore: 2,
+      homePenaltyWinner: undefined,
+      awayPenaltyWinner: undefined,
+    });
+    const user = userEvent.setup();
+    renderWithProviders(
+      <FlippableGameCard {...defaultProps} isPlayoffs={false} onAIGenerateClick={vi.fn()} />,
+      { guessesContext: true }
+    );
+    await user.click(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' }));
+    expect(screen.queryByText('edit.penaltyWinnerFull')).not.toBeInTheDocument();
+  });
+
+  it('passes undefined rank to generateAIPrediction when team is missing from teamsMap', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <FlippableGameCard
+        {...defaultProps}
+        teamsMap={{}} // empty — teams not found
+        onAIGenerateClick={vi.fn()}
+      />,
+      { guessesContext: true }
+    );
+    await user.click(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' }));
+    expect(aiPredictionModule.generateAIPrediction).toHaveBeenCalledWith(undefined, undefined, false);
+  });
+});

--- a/app/components/__tests__/game-prediction-edit-controls-ai-button.test.tsx
+++ b/app/components/__tests__/game-prediction-edit-controls-ai-button.test.tsx
@@ -1,0 +1,66 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders } from '@/__tests__/utils/test-utils';
+import GamePredictionEditControls from '../game-prediction-edit-controls';
+
+vi.mock('next-intl', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next-intl')>();
+  return {
+    ...actual,
+    useTranslations: () => {
+      const t = (key: string) => key;
+      return t;
+    },
+  };
+});
+
+const defaultProps = {
+  gameId: 'game-1',
+  homeTeamName: 'Team A',
+  awayTeamName: 'Team B',
+  isPlayoffGame: false,
+  onHomeScoreChange: vi.fn(),
+  onAwayScoreChange: vi.fn(),
+  onHomePenaltyWinnerChange: vi.fn(),
+  onAwayPenaltyWinnerChange: vi.fn(),
+  onBoostTypeChange: vi.fn(),
+};
+
+describe('GamePredictionEditControls — AI auto-fill button', () => {
+  it('renders AI button when onAIGenerateClick is provided', () => {
+    renderWithProviders(
+      <GamePredictionEditControls {...defaultProps} onAIGenerateClick={vi.fn()} />,
+      { guessesContext: true }
+    );
+    expect(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' })).toBeInTheDocument();
+  });
+
+  it('does not render AI button when onAIGenerateClick is not provided', () => {
+    renderWithProviders(
+      <GamePredictionEditControls {...defaultProps} />,
+      { guessesContext: true }
+    );
+    expect(screen.queryByRole('button', { name: 'aiGenerate.tooltipSingle' })).not.toBeInTheDocument();
+  });
+
+  it('calls onAIGenerateClick when button is clicked', async () => {
+    const user = userEvent.setup();
+    const onAIGenerateClick = vi.fn();
+    renderWithProviders(
+      <GamePredictionEditControls {...defaultProps} onAIGenerateClick={onAIGenerateClick} />,
+      { guessesContext: true }
+    );
+    await user.click(screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' }));
+    expect(onAIGenerateClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('button aria-label equals tooltip title (aiGenerate.tooltipSingle)', () => {
+    renderWithProviders(
+      <GamePredictionEditControls {...defaultProps} onAIGenerateClick={vi.fn()} />,
+      { guessesContext: true }
+    );
+    const btn = screen.getByRole('button', { name: 'aiGenerate.tooltipSingle' });
+    expect(btn).toHaveAttribute('aria-label', 'aiGenerate.tooltipSingle');
+  });
+});

--- a/app/components/flippable-game-card.tsx
+++ b/app/components/flippable-game-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useRef, useEffect, useState, useContext } from 'react';
+import React, { useRef, useEffect, useState, useContext, useMemo } from 'react';
 import { Box, Card, CardContent, useTheme, useMediaQuery } from '@mui/material';
 import { useReducedMotion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
@@ -10,6 +10,7 @@ import { ExtendedGameData } from '../definitions';
 import { Team } from '../db/tables-definition';
 import { GuessesContext } from './context-providers/guesses-context-provider';
 import { getTeamNames } from '../utils/team-name-helper';
+import { generateAIPrediction } from '../utils/ai-prediction-generator';
 
 // Type alias for boost type (SonarQube S4323)
 type BoostType = 'silver' | 'golden' | null;
@@ -107,6 +108,20 @@ export default function FlippableGameCard({
 
   // Flip animation duration (slightly slower on mobile)
   const flipDuration = isMobile ? 0.5 : 0.4;
+
+  // AI generate handler for edit mode — updates local edit state instead of context
+  const handleAIGenerateInEditMode = useMemo(() => {
+    if (!onAIGenerateClick || !game.home_team || !game.away_team || disabled) return undefined;
+    return () => {
+      const homeRank = (teamsMap[game.home_team!] as { rank?: number | null })?.rank;
+      const awayRank = (teamsMap[game.away_team!] as { rank?: number | null })?.rank;
+      const { homeScore: aiHome, awayScore: aiAway, homePenaltyWinner, awayPenaltyWinner } = generateAIPrediction(homeRank, awayRank, isPlayoffs);
+      setEditHomeScore(aiHome);
+      setEditAwayScore(aiAway);
+      if (homePenaltyWinner !== undefined) setEditHomePenaltyWinner(homePenaltyWinner);
+      if (awayPenaltyWinner !== undefined) setEditAwayPenaltyWinner(awayPenaltyWinner);
+    };
+  }, [onAIGenerateClick, game.home_team, game.away_team, disabled, teamsMap, isPlayoffs]);
 
   // Initialize local state when entering edit mode
   useEffect(() => {
@@ -365,6 +380,7 @@ export default function FlippableGameCard({
                   onEscapePressed={handleCancel}
                   retryCallback={handleSave}
                   isGuidedMode={isGuidedMode}
+                  onAIGenerateClick={handleAIGenerateInEditMode}
                 />
               </CardContent>
             </Card>

--- a/app/components/game-prediction-edit-controls.tsx
+++ b/app/components/game-prediction-edit-controls.tsx
@@ -19,12 +19,15 @@ import {
   Button,
   useTheme,
   useMediaQuery,
-  alpha
+  alpha,
+  Tooltip,
+  IconButton
 } from '@mui/material';
 import {
   EmojiEvents as TrophyIcon,
   Star as StarIcon,
-  Warning as WarningIcon
+  Warning as WarningIcon,
+  AutoAwesome as AutoAwesomeIcon
 } from '@mui/icons-material';
 import StepperScoreInput from './stepper-score-input';
 
@@ -90,6 +93,9 @@ interface GamePredictionEditControlsProps {
 
   // Guided mode: shows "Save & Next" as primary desktop action
   readonly isGuidedMode?: boolean;
+
+  // AI auto-fill callback
+  readonly onAIGenerateClick?: () => void;
 }
 
 export default function GamePredictionEditControls({
@@ -128,7 +134,8 @@ export default function GamePredictionEditControls({
   onShiftTabFromFirstField,
   onEscapePressed,
   retryCallback,
-  isGuidedMode = false
+  isGuidedMode = false,
+  onAIGenerateClick
 }: GamePredictionEditControlsProps) {
   const t = useTranslations('predictions');
   const theme = useTheme();
@@ -1309,6 +1316,21 @@ export default function GamePredictionEditControls({
 
       {/* Penalty information */}
       {renderPenaltySelection()}
+
+      {/* AI auto-fill */}
+      {onAIGenerateClick && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1 }}>
+          <Tooltip title={t('aiGenerate.tooltipSingle')}>
+            <IconButton
+              size="small"
+              onClick={onAIGenerateClick}
+              aria-label={t('aiGenerate.tooltipSingle')}
+            >
+              <AutoAwesomeIcon sx={{ width: '20px', height: '20px' }} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      )}
 
       {/* Boost Selection */}
       {renderBoostSelection()}

--- a/docs/code-structure/components/components-tournament-games.md
+++ b/docs/code-structure/components/components-tournament-games.md
@@ -61,8 +61,8 @@ Compact dashboard showing game and tournament prediction progress with urgency i
 
 **File:** `app/components/flippable-game-card.tsx`
 3D flip card for inline game editing. Shows game view on front, edit controls on back with keyboard navigation support.
-- **FlippableGameCard** (FC) - `[Client]` - Calls: none - Uses: `useContext(GuessesContext), useTheme, useMediaQuery, useReducedMotion` - Renders: `Box, GameView, Card, GamePredictionEditControls`
-- Props include: `onStageClick?: () => void` — passed through to `GameView`; `isGuidedMode?: boolean` — threaded to `GamePredictionEditControls`; `onAIGenerateClick?: (gameId: string) => void` — passed through to `GameView`
+- **FlippableGameCard** (FC) - `[Client]` - Calls: `generateAIPrediction` - Uses: `useContext(GuessesContext), useTheme, useMediaQuery, useReducedMotion, useMemo` - Renders: `Box, GameView, Card, GamePredictionEditControls`
+- Props include: `onStageClick?: () => void` — passed through to `GameView`; `isGuidedMode?: boolean` — threaded to `GamePredictionEditControls`; `onAIGenerateClick?: (gameId: string) => void` — passed through to `GameView` (view mode) and as a local-state handler to `GamePredictionEditControls` (edit mode)
 
 **File:** `app/components/game-boost-selector.tsx`
 Interactive boost selector with silver/golden buttons, count badges, and dialog for boost limit warnings.
@@ -86,8 +86,8 @@ Game filter selector with counts for all/groups/playoffs/unpredicted/closingSoon
 
 **File:** `app/components/game-prediction-edit-controls.tsx`
 Full game prediction edit form with scores, penalties, boosts, keyboard navigation, and save/cancel controls. When `isGuidedMode=true` and `onSaveAndAdvance` is provided, renders "Save & Next" as the primary desktop action instead of "Save".
-- **GamePredictionEditControls** (FC) - `[Client]` - Calls: none - Uses: `useContext(GuessesContext), useTheme, useMediaQuery, useTranslations` - Renders: `Box, TextField, Checkbox, ToggleButtonGroup, GameBoostSelector, StepperScoreInput, Alert`
-- Props include: `isGuidedMode?: boolean` — when true and `onSaveAndAdvance` is provided, desktop shows [Cancel] [Save & Next] instead of [Cancel] [Save]
+- **GamePredictionEditControls** (FC) - `[Client]` - Calls: none - Uses: `useContext(GuessesContext), useTheme, useMediaQuery, useTranslations` - Renders: `Box, TextField, Checkbox, ToggleButtonGroup, GameBoostSelector, StepperScoreInput, Alert, IconButton, Tooltip`
+- Props include: `isGuidedMode?: boolean` — when true and `onSaveAndAdvance` is provided, desktop shows [Cancel] [Save & Next] instead of [Cancel] [Save]; `onAIGenerateClick?: () => void` — when provided, renders a centered `AutoAwesomeIcon` button between the penalty section and boost section
 
 **File:** `app/components/game-result-edit-dialog.tsx`
 Dialog for editing game results or guesses. Supports penalty shootouts, game date (for results), and game guess forms.

--- a/docs/code-structure/components/components-tournament-games.md
+++ b/docs/code-structure/components/components-tournament-games.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-18
+**Last updated:** 2026-05-26
 
 ---
 
@@ -86,7 +86,7 @@ Game filter selector with counts for all/groups/playoffs/unpredicted/closingSoon
 
 **File:** `app/components/game-prediction-edit-controls.tsx`
 Full game prediction edit form with scores, penalties, boosts, keyboard navigation, and save/cancel controls. When `isGuidedMode=true` and `onSaveAndAdvance` is provided, renders "Save & Next" as the primary desktop action instead of "Save".
-- **GamePredictionEditControls** (FC) - `[Client]` - Calls: none - Uses: `useContext(GuessesContext), useTheme, useMediaQuery, useTranslations` - Renders: `Box, TextField, Checkbox, ToggleButtonGroup, GameBoostSelector, StepperScoreInput, Alert, IconButton, Tooltip`
+- **GamePredictionEditControls** (FC) - `[Client]` - Calls: none - Uses: `useContext(GuessesContext), useTheme, useMediaQuery, useTranslations` - Renders: `Box, TextField, Typography, Checkbox, FormControlLabel, Divider, ToggleButtonGroup, ToggleButton, Chip, Button, StepperScoreInput, Alert, CircularProgress, IconButton, Tooltip`
 - Props include: `isGuidedMode?: boolean` — when true and `onSaveAndAdvance` is provided, desktop shows [Cancel] [Save & Next] instead of [Cancel] [Save]; `onAIGenerateClick?: () => void` — when provided, renders a centered `AutoAwesomeIcon` button between the penalty section and boost section
 
 **File:** `app/components/game-result-edit-dialog.tsx`

--- a/plans/STORY-464-context.md
+++ b/plans/STORY-464-context.md
@@ -1,0 +1,26 @@
+# Story #464 Context
+
+## Story Metadata
+- **STORY_NUMBER**: 464
+- **STORY_TITLE**: [Story] Show AI auto-fill button in game card edit mode
+- **BRANCH_NAME**: feature/story-464
+- **MAIN_WORKTREE**: /Users/gvinokur/Personal/qatar-prode
+- **WORKTREE_PATH**: /Users/gvinokur/Personal/qatar-prode-story-464
+
+## Status
+- Phase: Planning complete
+- Plan file: `plans/STORY-464-plan.md`
+
+## Summary
+Wire the AI prediction auto-fill button (sparkle / AutoAwesome icon) into game card edit mode (`GamePredictionEditControls`), positioned below score inputs and above the Boost section. Currently the button only appears in view mode. The handler updates local edit state in `FlippableGameCard` rather than the `GuessesContext`.
+
+## Files to Modify
+1. `app/components/flippable-game-card.tsx` — Add `handleAIGenerateInEditMode`, pass to `GamePredictionEditControls`
+2. `app/components/game-prediction-edit-controls.tsx` — Add `onAIGenerateClick` prop + render AI button
+3. `docs/code-structure/components/components-tournament-games.md` — Update CODE-STRUCTURE entries
+
+## Key Technical Notes
+- No new translation keys — reuse `predictions.aiGenerate.tooltipSingle`
+- No new cross-layer flows; handler stays in local component state
+- `generateAIPrediction` already imported in `GameView` (same file pattern)
+- Penalty winner fields set only for playoff games with tied AI prediction

--- a/plans/STORY-464-plan.md
+++ b/plans/STORY-464-plan.md
@@ -1,0 +1,172 @@
+# Story #464: Show AI auto-fill button in game card edit mode
+
+## Context
+The AI auto-fill button (sparkle / `AutoAwesome` icon) is currently only available in game card **view mode** — rendered inside `CompactGameViewCard` when `onAIGenerateClick` is provided. When the user flips the card to **edit mode**, the button disappears, forcing a cancel → AI fill → re-enter edit cycle.
+
+This story wires the same AI prediction logic into `GamePredictionEditControls` (the edit-mode back face), positioned below the score inputs and above the Boost section, centered.
+
+## Acceptance Criteria
+- AI auto-fill button (sparkle icon) visible in edit mode, below score inputs and above Boost section, centered
+- Clicking fills both score inputs with AI-generated predictions, overwriting any values already entered
+- For playoff games where AI predicts a tie, the penalties winner field is also filled
+- Works in EN and ES (no new translation keys needed — reuse `aiGenerate.tooltipSingle`)
+
+## Out of Scope
+- Changing AI auto-fill behavior in view mode
+- Keyboard navigation integration for the new button
+
+---
+
+## Technical Approach
+
+### Architecture Overview
+
+The `FlippableGameCard` already has:
+- `onAIGenerateClick?: (gameId: string) => void` prop
+- It passes this prop to `GameView` (front face) ✅
+- It does **not** pass anything to `GamePredictionEditControls` (back face) ❌
+
+`GameView` contains `handleAIGenerateClick` which calls `generateAIPrediction(homeRank, awayRank, isPlayoffGame)` and updates the `GuessesContext` directly.
+
+For **edit mode**, we cannot update the context directly because `FlippableGameCard` maintains local edit state (`editHomeScore`, `editAwayScore`, etc.) that is only committed on Save. Instead, the AI prediction must update the **local edit state** in `FlippableGameCard`.
+
+### Changes Required
+
+#### 1. `app/components/flippable-game-card.tsx`
+- Import `generateAIPrediction` from `'../utils/ai-prediction-generator'` (already used in `GameView`, same pattern)
+- Add `useMemo` import if not present (already imported)
+- Create `handleAIGenerateInEditMode` handler:
+  - Only defined if `onAIGenerateClick` is provided and game has both teams and is not `disabled`
+  - Reads `homeRank`/`awayRank` from `teamsMap`
+  - Calls `generateAIPrediction(homeRank, awayRank, isPlayoffs)`
+  - Updates local edit state: `setEditHomeScore`, `setEditAwayScore`, and conditionally `setEditHomePenaltyWinner`/`setEditAwayPenaltyWinner`
+- Pass `handleAIGenerateInEditMode` to `GamePredictionEditControls` as `onAIGenerateClick`
+
+#### 2. `app/components/game-prediction-edit-controls.tsx`
+- Add `AutoAwesome as AutoAwesomeIcon` to MUI icons import
+- Add `Tooltip, IconButton` to MUI components import (already imported)
+- Add `onAIGenerateClick?: () => void` to `GamePredictionEditControlsProps` interface (readonly)
+- Destructure in component function
+- Add AI button render inline between `renderPenaltySelection()` and `renderBoostSelection()` calls:
+  ```tsx
+  {onAIGenerateClick && (
+    <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1 }}>
+      <Tooltip title={t('aiGenerate.tooltipSingle')}>
+        <IconButton
+          size="small"
+          onClick={onAIGenerateClick}
+          aria-label={t('aiGenerate.tooltipSingle')}
+        >
+          <AutoAwesomeIcon sx={{ width: '20px', height: '20px' }} />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  )}
+  ```
+
+### No translation changes needed
+Reuse existing key: `predictions.aiGenerate.tooltipSingle` ("Generate prediction") — same string works in both modes.
+
+### No worktree-level code structure changes to layers
+- `game-prediction-edit-controls.tsx` and `flippable-game-card.tsx` are both tracked in `docs/code-structure/components/components-tournament-games.md`
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+No new cross-layer flows. The handler stays entirely within `FlippableGameCard`'s local state — no new server action or repository call.
+
+**Modified flows:**
+- **Edit-mode flip card** — `FlippableGameCard` now passes `onAIGenerateClick` (edit variant) to `GamePredictionEditControls`. The callback calls `generateAIPrediction` and updates local edit state rather than context.
+
+### `app/components/flippable-game-card.tsx` *(modified)*
+
+**New logic (not a separate export):**
+
+- **`handleAIGenerateInEditMode`**: `(() => void) | undefined`  
+  Computed via `useMemo`. Defined only when `onAIGenerateClick && game.home_team && game.away_team && !disabled`.  
+  Calls `generateAIPrediction(homeRank, awayRank, isPlayoffs)` and updates `editHomeScore`, `editAwayScore`, and optionally `editHomePenaltyWinner` / `editAwayPenaltyWinner`.  
+  Calls: `generateAIPrediction`  
+  Tests:
+  - returns `undefined` when `onAIGenerateClick` is not provided
+  - returns `undefined` when `disabled` is true
+  - calls `setEditHomeScore` and `setEditAwayScore` with AI-generated values, overwriting any existing values
+  - sets penalty winner fields when AI predicts a tie in a playoff game
+  - does not set penalty winner fields for group-stage games
+  - returns `undefined` when either team is missing from `teamsMap` (passes `undefined` rank to generator gracefully)
+
+### `app/components/game-prediction-edit-controls.tsx` *(modified)*
+
+**Interface change:**
+
+- Add `readonly onAIGenerateClick?: () => void` to `GamePredictionEditControlsProps`
+
+**Render change (no new exported function):**
+
+- Renders centered `IconButton` with `AutoAwesomeIcon` and `Tooltip` between score/penalty and boost sections, only when `onAIGenerateClick` is defined  
+  Tests:
+  - renders AI button when `onAIGenerateClick` prop is provided
+  - does not render AI button when `onAIGenerateClick` is not provided
+  - calls `onAIGenerateClick` when button is clicked
+  - button `aria-label` equals the tooltip title (same `aiGenerate.tooltipSingle` value)
+
+---
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `app/components/flippable-game-card.tsx` | Add `handleAIGenerateInEditMode`, pass to `GamePredictionEditControls` |
+| `app/components/game-prediction-edit-controls.tsx` | Add `onAIGenerateClick` prop + render AI button |
+| `docs/code-structure/components/components-tournament-games.md` | Update entries for `FlippableGameCard` and `GamePredictionEditControls` |
+
+---
+
+## Visual Prototype
+
+```
+┌─────────────────────────────────────────┐
+│   TeamA  [  2  ]  vs  [  1  ]  TeamB    │  ← score inputs (existing)
+├─────────────────────────────────────────┤
+│                   ✨                     │  ← NEW: centered sparkle icon button
+├─────────────────────────────────────────┤
+│  Boost: [None] [2x Silver] [3x Golden]  │  ← boost section (existing)
+├─────────────────────────────────────────┤
+│            [Cancel]  [Save]             │  ← action buttons (existing)
+└─────────────────────────────────────────┘
+```
+
+The button uses `AutoAwesomeIcon` (same icon as view mode), wrapped in `Tooltip` with `aiGenerate.tooltipSingle` text.
+
+---
+
+## Testing Strategy
+
+### Unit tests for `GamePredictionEditControls`
+- Test file: `app/components/__tests__/game-prediction-edit-controls.test.tsx` (if exists) or create new
+- Test: renders button when `onAIGenerateClick` provided
+- Test: does not render button when `onAIGenerateClick` not provided
+- Test: calls `onAIGenerateClick` on click
+
+### Unit tests for `FlippableGameCard`
+- Test file: `app/components/__tests__/flippable-game-card.test.tsx` (if exists) or create new
+- Test: `handleAIGenerateInEditMode` is undefined when `onAIGenerateClick` prop absent
+- Test: `handleAIGenerateInEditMode` updates edit state with AI values
+- Test: playoff tie case sets penalty winner
+
+### Manual verification
+1. Open a tournament games page
+2. Click edit (flip) on a game card
+3. Verify sparkle button appears below the score inputs and above the Boost section
+4. Click the sparkle button
+5. Verify scores are populated with AI-generated values
+6. For a playoff game: verify penalty winner is set when scores are tied
+7. Verify in both EN and ES locales
+
+---
+
+## Validation
+- `npm run test` — ensure no regressions
+- `npm run lint` — no new lint issues
+- `npm run build` — clean build


### PR DESCRIPTION
Fixes #464

## Summary
Implementation plan for the story.

## Plan Document
See `plans/STORY-464-plan.md` for full details.

## Next Steps
- Review and approve plan
- Iterate on plan based on feedback
- Execute plan once approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)