### PR TITLE
Plan: [Story] Group admins can remove members from a group #471

### DIFF
--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -422,6 +422,9 @@ Key flows:
             └── deleteParticipantFromGroup
     AdminSectionTabs [Client] (admin view — 4 tabs)
       ├── JoinRequestManager [renders] → approveJoinRequestAction / rejectJoinRequestAction
+      │     └── RemoveMembersDialog [renders, conditional]
+      │           └── removeGroupMembersAction [server action]
+      │                 └── deleteParticipantFromGroup
       ├── GroupPrivacySettings [renders]
       │     └── updateGroupPrivacyAction [server action]
       │           └── updateGroupPrivacy

--- a/__tests__/actions/prode-group-actions.remove-members.test.ts
+++ b/__tests__/actions/prode-group-actions.remove-members.test.ts
@@ -1,0 +1,122 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import * as userActions from '../../app/actions/user-actions'
+import * as groupRepository from '../../app/db/prode-group-repository'
+import { removeGroupMembersAction } from '../../app/actions/prode-group-actions'
+import { testFactories } from '../db/test-factories'
+
+vi.mock('../../auth', () => ({ auth: vi.fn() }))
+vi.mock('../../app/actions/user-actions')
+vi.mock('../../app/db/prode-group-repository')
+
+const mockGetLoggedInUser = vi.mocked(userActions.getLoggedInUser)
+const mockFindProdeGroupById = vi.mocked(groupRepository.findProdeGroupById)
+const mockFindParticipantsInGroup = vi.mocked(groupRepository.findParticipantsInGroup)
+const mockDeleteParticipantFromGroup = vi.mocked(groupRepository.deleteParticipantFromGroup)
+
+const OWNER_ID = 'owner-1'
+const ADMIN_ID = 'admin-1'
+const MEMBER_ID = 'member-1'
+const GROUP_ID = 'group-1'
+
+const defaultGroup = testFactories.prodeGroup({ id: GROUP_ID, owner_user_id: OWNER_ID })
+const ownerUser = testFactories.user({ id: OWNER_ID })
+const adminUser = testFactories.user({ id: ADMIN_ID })
+const memberUser = testFactories.user({ id: MEMBER_ID })
+
+const participants = [
+  { user_id: ADMIN_ID, is_admin: true },
+  { user_id: MEMBER_ID, is_admin: false },
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFindProdeGroupById.mockResolvedValue(defaultGroup as any)
+  mockFindParticipantsInGroup.mockResolvedValue(participants as any)
+  mockDeleteParticipantFromGroup.mockResolvedValue(undefined as any)
+})
+
+describe('removeGroupMembersAction', () => {
+  it('throws when caller is not authenticated', async () => {
+    mockGetLoggedInUser.mockResolvedValue(null as any)
+
+    await expect(removeGroupMembersAction(GROUP_ID, [MEMBER_ID])).rejects.toThrow(
+      'Should not call this action from a logged out page'
+    )
+    expect(mockDeleteParticipantFromGroup).not.toHaveBeenCalled()
+  })
+
+  it('throws when group does not exist', async () => {
+    mockGetLoggedInUser.mockResolvedValue(ownerUser as any)
+    mockFindProdeGroupById.mockResolvedValue(undefined as any)
+
+    await expect(removeGroupMembersAction(GROUP_ID, [MEMBER_ID])).rejects.toThrow('Group not found')
+    expect(mockDeleteParticipantFromGroup).not.toHaveBeenCalled()
+  })
+
+  it('throws when caller is neither owner nor admin of the group', async () => {
+    const outsider = testFactories.user({ id: 'outsider-1' })
+    mockGetLoggedInUser.mockResolvedValue(outsider as any)
+
+    await expect(removeGroupMembersAction(GROUP_ID, [MEMBER_ID])).rejects.toThrow(
+      'Only group admins can remove members'
+    )
+    expect(mockDeleteParticipantFromGroup).not.toHaveBeenCalled()
+  })
+
+  it('throws when admin attempts to remove another admin', async () => {
+    mockGetLoggedInUser.mockResolvedValue(adminUser as any)
+
+    await expect(removeGroupMembersAction(GROUP_ID, [ADMIN_ID])).rejects.toThrow(
+      'Only the group owner can remove admins'
+    )
+    expect(mockDeleteParticipantFromGroup).not.toHaveBeenCalled()
+  })
+
+  it('allows owner to remove a mix of admins and regular members', async () => {
+    mockGetLoggedInUser.mockResolvedValue(ownerUser as any)
+
+    await removeGroupMembersAction(GROUP_ID, [ADMIN_ID, MEMBER_ID])
+
+    expect(mockDeleteParticipantFromGroup).toHaveBeenCalledWith(GROUP_ID, ADMIN_ID)
+    expect(mockDeleteParticipantFromGroup).toHaveBeenCalledWith(GROUP_ID, MEMBER_ID)
+    expect(mockDeleteParticipantFromGroup).toHaveBeenCalledTimes(2)
+  })
+
+  it('allows admin to remove regular members only', async () => {
+    mockGetLoggedInUser.mockResolvedValue(adminUser as any)
+
+    await removeGroupMembersAction(GROUP_ID, [MEMBER_ID])
+
+    expect(mockDeleteParticipantFromGroup).toHaveBeenCalledWith(GROUP_ID, MEMBER_ID)
+    expect(mockDeleteParticipantFromGroup).toHaveBeenCalledTimes(1)
+  })
+
+  it('no-ops silently if memberIds is empty', async () => {
+    mockGetLoggedInUser.mockResolvedValue(ownerUser as any)
+
+    await expect(removeGroupMembersAction(GROUP_ID, [])).resolves.toBeUndefined()
+    expect(mockDeleteParticipantFromGroup).not.toHaveBeenCalled()
+  })
+
+  it('silently skips the owner when owner id is in memberIds', async () => {
+    mockGetLoggedInUser.mockResolvedValue(ownerUser as any)
+
+    await removeGroupMembersAction(GROUP_ID, [OWNER_ID, MEMBER_ID])
+
+    expect(mockDeleteParticipantFromGroup).not.toHaveBeenCalledWith(GROUP_ID, OWNER_ID)
+    expect(mockDeleteParticipantFromGroup).toHaveBeenCalledWith(GROUP_ID, MEMBER_ID)
+  })
+
+  it('calls deleteParticipantFromGroup once per valid memberId', async () => {
+    mockGetLoggedInUser.mockResolvedValue(ownerUser as any)
+    const extraMember = 'member-2'
+    mockFindParticipantsInGroup.mockResolvedValue([
+      ...participants,
+      { user_id: extraMember, is_admin: false },
+    ] as any)
+
+    await removeGroupMembersAction(GROUP_ID, [MEMBER_ID, extraMember])
+
+    expect(mockDeleteParticipantFromGroup).toHaveBeenCalledTimes(2)
+  })
+})

--- a/__tests__/components/friend-groups/join-request-manager.test.tsx
+++ b/__tests__/components/friend-groups/join-request-manager.test.tsx
@@ -13,6 +13,20 @@ vi.mock('@/app/actions/prode-group-join-request-actions', () => ({
   rejectJoinRequestAction: vi.fn(),
 }));
 
+vi.mock('@/app/actions/prode-group-actions', () => ({
+  removeGroupMembersAction: vi.fn(),
+}));
+
+vi.mock('@/app/components/friend-groups/remove-members-dialog', () => ({
+  default: ({ open, onClose, onSuccess }: { open: boolean; onClose: () => void; onSuccess: (ids: string[]) => void }) =>
+    open ? (
+      <div data-testid="remove-members-dialog">
+        <button onClick={() => onSuccess(['member-1'])}>confirm-remove</button>
+        <button onClick={onClose}>close-dialog</button>
+      </div>
+    ) : null,
+}));
+
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(),
 }));
@@ -263,6 +277,66 @@ describe('JoinRequestManager', () => {
       expect(screen.getByRole('button', { name: /Rechazar/i })).toBeInTheDocument();
       // Rejected request has "Aprobar de todas formas" button
       expect(screen.getByRole('button', { name: /Aprobar de todas formas/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Remove Members button', () => {
+    const removableMembers = [
+      { id: 'member-1', nombre: 'Carol', is_admin: false },
+      { id: 'member-2', nombre: 'David', is_admin: false },
+    ];
+
+    it('does not render Remove Members button when members prop is absent', () => {
+      renderWithTheme(<JoinRequestManager {...defaultProps} />);
+
+      expect(screen.queryByRole('button', { name: /Eliminar Miembros/i })).not.toBeInTheDocument();
+    });
+
+    it('renders Remove Members button when members prop has removable members', () => {
+      renderWithTheme(
+        <JoinRequestManager
+          {...defaultProps}
+          members={removableMembers}
+          ownerId="owner-1"
+          isOwner={false}
+        />
+      );
+
+      expect(screen.getByRole('button', { name: /Eliminar Miembros/i })).toBeInTheDocument();
+    });
+
+    it('opens RemoveMembersDialog on Remove Members click', () => {
+      renderWithTheme(
+        <JoinRequestManager
+          {...defaultProps}
+          members={removableMembers}
+          ownerId="owner-1"
+          isOwner={false}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Eliminar Miembros/i }));
+
+      expect(screen.getByTestId('remove-members-dialog')).toBeInTheDocument();
+    });
+
+    it('shows success Alert after successful removal and closes dialog', async () => {
+      renderWithTheme(
+        <JoinRequestManager
+          {...defaultProps}
+          members={removableMembers}
+          ownerId="owner-1"
+          isOwner={false}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /Eliminar Miembros/i }));
+      fireEvent.click(screen.getByRole('button', { name: 'confirm-remove' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Miembros eliminados correctamente')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('remove-members-dialog')).not.toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/friend-groups/remove-members-dialog.test.tsx
+++ b/__tests__/components/friend-groups/remove-members-dialog.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import RemoveMembersDialog from '../../../app/components/friend-groups/remove-members-dialog';
+import { renderWithTheme } from '../../utils/test-utils';
+
+vi.mock('@/app/actions/prode-group-actions', () => ({
+  removeGroupMembersAction: vi.fn(),
+}));
+
+import * as groupActions from '@/app/actions/prode-group-actions';
+const mockRemoveGroupMembersAction = vi.mocked(groupActions.removeGroupMembersAction)
+
+const OWNER_ID = 'owner-1'
+const GROUP_ID = 'group-1'
+
+const ownerMember = { id: OWNER_ID, nombre: 'Alice', is_admin: false }
+const adminMember = { id: 'admin-1', nombre: 'Bob', is_admin: true }
+const regularMember1 = { id: 'member-1', nombre: 'Carol', is_admin: false }
+const regularMember2 = { id: 'member-2', nombre: 'David', is_admin: false }
+
+const allMembers = [ownerMember, adminMember, regularMember1, regularMember2]
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+  groupId: GROUP_ID,
+  members: allMembers,
+  ownerId: OWNER_ID,
+  isOwner: false,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRemoveGroupMembersAction.mockResolvedValue(undefined)
+})
+
+describe('RemoveMembersDialog', () => {
+  it('renders only non-admin members when viewer is a non-owner admin', () => {
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} isOwner={false} />)
+
+    expect(screen.getByText('Carol')).toBeInTheDocument()
+    expect(screen.getByText('David')).toBeInTheDocument()
+    expect(screen.queryByText('Bob')).not.toBeInTheDocument()
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument()
+  })
+
+  it('renders admin and regular members (excluding owner) when viewer is owner', () => {
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} isOwner={true} />)
+
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+    expect(screen.getByText('Carol')).toBeInTheDocument()
+    expect(screen.getByText('David')).toBeInTheDocument()
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument()
+  })
+
+  it('"Remove" button is disabled when no member is selected', () => {
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} />)
+
+    const removeButton = screen.getByRole('button', { name: /Eliminar \(0\)/i })
+    expect(removeButton).toBeDisabled()
+  })
+
+  it('selecting a member enables the Remove button with count label', () => {
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('Carol'))
+
+    const removeButton = screen.getByRole('button', { name: /Eliminar \(1\)/i })
+    expect(removeButton).not.toBeDisabled()
+  })
+
+  it('calls removeGroupMembersAction with correct groupId and selectedIds on confirm', async () => {
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('Carol'))
+    fireEvent.click(screen.getByRole('button', { name: /Eliminar \(1\)/i }))
+
+    await waitFor(() => {
+      expect(mockRemoveGroupMembersAction).toHaveBeenCalledWith(GROUP_ID, ['member-1'])
+    })
+  })
+
+  it('calls onSuccess with removed IDs after successful removal', async () => {
+    const onSuccess = vi.fn()
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} onSuccess={onSuccess} />)
+
+    fireEvent.click(screen.getByText('Carol'))
+    fireEvent.click(screen.getByRole('button', { name: /Eliminar \(1\)/i }))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(['member-1'])
+    })
+  })
+
+  it('shows error Alert inside dialog when removeGroupMembersAction throws; dialog stays open', async () => {
+    mockRemoveGroupMembersAction.mockRejectedValue(new Error('Only the group owner can remove admins'))
+    const onClose = vi.fn()
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} onClose={onClose} />)
+
+    fireEvent.click(screen.getByText('Carol'))
+    fireEvent.click(screen.getByRole('button', { name: /Eliminar \(1\)/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Only the group owner can remove admins')).toBeInTheDocument()
+    })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('Cancel button calls onClose without removing anyone', () => {
+    const onClose = vi.fn()
+    renderWithTheme(<RemoveMembersDialog {...defaultProps} onClose={onClose} />)
+
+    fireEvent.click(screen.getByText('Carol'))
+    fireEvent.click(screen.getByRole('button', { name: /Cancelar/i }))
+
+    expect(onClose).toHaveBeenCalled()
+    expect(mockRemoveGroupMembersAction).not.toHaveBeenCalled()
+  })
+})

--- a/app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx
+++ b/app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx
@@ -322,6 +322,8 @@ export default async function TournamentScopedFriendGroup(props : Props){
                 payments={payments}
                 group={prodeGroup}
                 pendingRequestCount={pendingRequestCount}
+                ownerId={prodeGroup.owner_user_id}
+                isOwner={isOwner}
               />
             }
           />

--- a/app/actions/prode-group-actions.ts
+++ b/app/actions/prode-group-actions.ts
@@ -250,6 +250,32 @@ export async function leaveGroupAction(groupId: string) {
   return { success: true };
 }
 
+export async function removeGroupMembersAction(groupId: string, memberIds: string[]): Promise<void> {
+  const user = await getLoggedInUser();
+  if (!user) {
+    throw new Error('Should not call this action from a logged out page');
+  }
+  const group = await findProdeGroupById(groupId);
+  if (!group) {
+    throw new Error('Group not found');
+  }
+  const participants = await findParticipantsInGroup(groupId);
+  const callerParticipant = participants.find(p => p.user_id === user.id);
+  const isOwner = group.owner_user_id === user.id;
+  const isAdmin = isOwner || !!callerParticipant?.is_admin;
+  if (!isAdmin) {
+    throw new Error('Only group admins can remove members');
+  }
+  for (const memberId of memberIds) {
+    if (memberId === group.owner_user_id) continue;
+    const targetParticipant = participants.find(p => p.user_id === memberId);
+    if (targetParticipant?.is_admin && !isOwner) {
+      throw new Error('Only the group owner can remove admins');
+    }
+    await deleteParticipantFromGroup(groupId, memberId);
+  }
+}
+
 export async function getUsersForGroup(groupId: string): Promise<string[]> {
   const group = await findProdeGroupById(groupId);
   if (!group) {

--- a/app/components/friend-groups/admin-section-tabs.tsx
+++ b/app/components/friend-groups/admin-section-tabs.tsx
@@ -42,13 +42,16 @@ type Props = {
   initialDescription: string | null;
   // GroupTournamentBettingAdmin
   isAdmin: boolean;
-  members: { id: string; nombre: string }[];
+  members: { id: string; nombre: string; is_admin: boolean }[];
   config: ProdeGroupTournamentBetting | null;
   payments: ProdeGroupTournamentBettingPayment[];
   // ProdeGroupThemer
   group: ProdeGroup;
   // Tab logic
   pendingRequestCount: number;
+  // Remove members
+  ownerId: string;
+  isOwner: boolean;
 };
 
 export default function AdminSectionTabs({
@@ -65,6 +68,8 @@ export default function AdminSectionTabs({
   payments,
   group,
   pendingRequestCount,
+  ownerId,
+  isOwner,
 }: Readonly<Props>) {
   const t = useTranslations('groups.adminSectionTabs');
 
@@ -121,6 +126,9 @@ export default function AdminSectionTabs({
             initialRequests={initialRequests}
             locale={locale}
             tournamentId={tournamentId}
+            members={members}
+            ownerId={ownerId}
+            isOwner={isOwner}
           />
         </TabPanel>
         <TabPanel value="privacy" sx={{ px: 0 }}>

--- a/app/components/friend-groups/join-request-manager.tsx
+++ b/app/components/friend-groups/join-request-manager.tsx
@@ -14,14 +14,16 @@ import {
   Typography,
   Box,
   CircularProgress,
-  Alert
+  Alert,
+  Divider,
 } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { approveJoinRequestAction, rejectJoinRequestAction } from '@/app/actions/prode-group-join-request-actions';
 import { Locale } from '@/i18n.config';
-import { PersonAdd as PersonAddIcon, Check as CheckIcon, Close as CloseIcon } from '@mui/icons-material';
+import { PersonAdd as PersonAddIcon, Check as CheckIcon, Close as CloseIcon, PersonRemove as PersonRemoveIcon } from '@mui/icons-material';
 import { trackEvent } from '@/app/utils/ga4';
+import RemoveMembersDialog from './remove-members-dialog';
 
 interface JoinRequest {
   id: string;
@@ -34,27 +36,37 @@ interface JoinRequest {
   message?: string | null;
 }
 
+interface Member {
+  id: string;
+  nombre: string;
+  is_admin: boolean;
+}
+
 type Props = {
   groupId: string;
   initialRequests: JoinRequest[];
   locale?: Locale;
   tournamentId?: string;
+  members?: Member[];
+  ownerId?: string;
+  isOwner?: boolean;
 };
 
-export default function JoinRequestManager({ groupId, initialRequests, locale = 'es', tournamentId }: Readonly<Props>) {
+export default function JoinRequestManager({ groupId, initialRequests, locale = 'es', tournamentId, members: initialMembers, ownerId, isOwner = false }: Readonly<Props>) {
   const t = useTranslations('groups.joinRequests');
   const router = useRouter();
   const [requests, setRequests] = useState<JoinRequest[]>(initialRequests);
   const [loadingRequests, setLoadingRequests] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [removeMembersOpen, setRemoveMembersOpen] = useState(false);
+  const [members, setMembers] = useState<Member[]>(initialMembers ?? []);
 
   const handleApprove = async (requestId: string) => {
     setLoadingRequests(prev => new Set(prev).add(requestId));
     setError(null);
     setSuccessMessage(null);
 
-    // Optimistic update: remove from list
     const previousRequests = [...requests];
     setRequests(prev => prev.filter(r => r.id !== requestId));
 
@@ -66,9 +78,7 @@ export default function JoinRequestManager({ groupId, initialRequests, locale = 
       if (result && result.success && result.analyticsEvent) {
         trackEvent(result.analyticsEvent.name, result.analyticsEvent.params);
       }
-
     } catch (err) {
-      // Revert optimistic update on error
       setRequests(previousRequests);
       setError(err instanceof Error ? err.message : t('approveFailed'));
       console.error('Error approving join request:', err);
@@ -86,7 +96,6 @@ export default function JoinRequestManager({ groupId, initialRequests, locale = 
     setError(null);
     setSuccessMessage(null);
 
-    // Optimistic update: remove from list
     const previousRequests = [...requests];
     setRequests(prev => prev.filter(r => r.id !== requestId));
 
@@ -95,7 +104,6 @@ export default function JoinRequestManager({ groupId, initialRequests, locale = 
       setSuccessMessage(t('rejectSuccess'));
       router.refresh();
     } catch (err) {
-      // Revert optimistic update on error
       setRequests(previousRequests);
       setError(err instanceof Error ? err.message : t('rejectFailed'));
       console.error('Error rejecting join request:', err);
@@ -106,6 +114,13 @@ export default function JoinRequestManager({ groupId, initialRequests, locale = 
         return newSet;
       });
     }
+  };
+
+  const handleRemoveSuccess = (removedIds: string[]) => {
+    setMembers(prev => prev.filter(m => !removedIds.includes(m.id)));
+    setSuccessMessage(t('removeMembersDialog.success'));
+    setRemoveMembersOpen(false);
+    router.refresh();
   };
 
   const formatDate = (date: Date) => {
@@ -129,18 +144,11 @@ export default function JoinRequestManager({ groupId, initialRequests, locale = 
   const pendingRequests = requests.filter(r => r.status === 'pending');
   const rejectedRequests = requests.filter(r => r.status === 'rejected');
 
-  if (pendingRequests.length === 0 && rejectedRequests.length === 0) {
-    return (
-      <Card>
-        <CardHeader title={t('title')} avatar={<PersonAddIcon />} />
-        <CardContent>
-          <Typography variant="body2" color="text.secondary" align="center" sx={{ py: 2 }}>
-            {t('noPendingRequests')}
-          </Typography>
-        </CardContent>
-      </Card>
-    );
-  }
+  const hasRemovableMembers = ownerId !== undefined && members.some(m => {
+    if (m.id === ownerId) return false;
+    if (m.is_admin && !isOwner) return false;
+    return true;
+  });
 
   const renderRequestItem = (request: JoinRequest, isPending: boolean) => (
     <ListItem
@@ -203,37 +211,75 @@ export default function JoinRequestManager({ groupId, initialRequests, locale = 
   );
 
   return (
-    <Card>
-      <CardHeader title={t('title')} avatar={<PersonAddIcon />} />
-      <CardContent>
-        {error && (
-          <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
-            {error}
-          </Alert>
-        )}
-        {successMessage && (
-          <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccessMessage(null)}>
-            {successMessage}
-          </Alert>
-        )}
+    <>
+      <Card>
+        <CardHeader title={t('title')} avatar={<PersonAddIcon />} />
+        <CardContent>
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+          {successMessage && (
+            <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccessMessage(null)}>
+              {successMessage}
+            </Alert>
+          )}
 
-        {pendingRequests.length > 0 && (
-          <List>
-            {pendingRequests.map((request) => renderRequestItem(request, true))}
-          </List>
-        )}
-
-        {rejectedRequests.length > 0 && (
-          <Box sx={{ mt: pendingRequests.length > 0 ? 2 : 0 }}>
-            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
-              {t('recentlyRejectedTitle')}
+          {pendingRequests.length === 0 && rejectedRequests.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" align="center" sx={{ py: 2 }}>
+              {t('noPendingRequests')}
             </Typography>
-            <List>
-              {rejectedRequests.map((request) => renderRequestItem(request, false))}
-            </List>
-          </Box>
-        )}
-      </CardContent>
-    </Card>
+          ) : (
+            <>
+              {pendingRequests.length > 0 && (
+                <List>
+                  {pendingRequests.map((request) => renderRequestItem(request, true))}
+                </List>
+              )}
+              {rejectedRequests.length > 0 && (
+                <Box sx={{ mt: pendingRequests.length > 0 ? 2 : 0 }}>
+                  <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1 }}>
+                    {t('recentlyRejectedTitle')}
+                  </Typography>
+                  <List>
+                    {rejectedRequests.map((request) => renderRequestItem(request, false))}
+                  </List>
+                </Box>
+              )}
+            </>
+          )}
+
+          {hasRemovableMembers && (
+            <>
+              <Divider sx={{ mt: 2, mb: 2 }} />
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  size="small"
+                  startIcon={<PersonRemoveIcon />}
+                  onClick={() => setRemoveMembersOpen(true)}
+                >
+                  {t('removeMembersButton')}
+                </Button>
+              </Box>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {hasRemovableMembers && ownerId && (
+        <RemoveMembersDialog
+          open={removeMembersOpen}
+          onClose={() => setRemoveMembersOpen(false)}
+          onSuccess={handleRemoveSuccess}
+          groupId={groupId}
+          members={members}
+          ownerId={ownerId}
+          isOwner={isOwner}
+        />
+      )}
+    </>
   );
 }

--- a/app/components/friend-groups/remove-members-dialog.tsx
+++ b/app/components/friend-groups/remove-members-dialog.tsx
@@ -137,8 +137,10 @@ export default function RemoveMembersDialog({
                   <ListItemText
                     primary={member.nombre}
                     secondary={member.is_admin ? t('roles.admin') : t('roles.member')}
-                    primaryTypographyProps={{ variant: 'body2' }}
-                    secondaryTypographyProps={{ variant: 'caption' }}
+                    slotProps={{
+                      primary: { variant: 'body2' },
+                      secondary: { variant: 'caption' },
+                    }}
                   />
                 </ListItem>
               </React.Fragment>

--- a/app/components/friend-groups/remove-members-dialog.tsx
+++ b/app/components/friend-groups/remove-members-dialog.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Alert,
+  Avatar,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { useTranslations } from 'next-intl';
+import { removeGroupMembersAction } from '@/app/actions/prode-group-actions';
+
+interface Member {
+  id: string;
+  nombre: string;
+  is_admin: boolean;
+}
+
+interface RemoveMembersDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (ids: string[]) => void;
+  groupId: string;
+  members: Member[];
+  ownerId: string;
+  isOwner: boolean;
+}
+
+export default function RemoveMembersDialog({
+  open,
+  onClose,
+  onSuccess,
+  groupId,
+  members,
+  ownerId,
+  isOwner,
+}: Readonly<RemoveMembersDialogProps>) {
+  const t = useTranslations('groups.joinRequests.removeMembersDialog');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const removableMembers = members.filter(m => {
+    if (m.id === ownerId) return false;
+    if (m.is_admin && !isOwner) return false;
+    return true;
+  });
+
+  const handleToggle = (id: string) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirm = async () => {
+    const ids = Array.from(selected);
+    setLoading(true);
+    setError(null);
+    try {
+      await removeGroupMembersAction(groupId, ids);
+      setSelected(new Set());
+      onSuccess(ids);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : t('error'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    setSelected(new Set());
+    setError(null);
+    onClose();
+  };
+
+  const selectedCount = selected.size;
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle>{t('title')}</DialogTitle>
+      <DialogContent sx={{ px: 0, pb: 0 }}>
+        {error && (
+          <Box px={3} pb={1}>
+            <Alert severity="error" onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          </Box>
+        )}
+        {removableMembers.length === 0 ? (
+          <Box px={3} pb={2}>
+            <Typography variant="body2" color="text.secondary">
+              No members available to remove.
+            </Typography>
+          </Box>
+        ) : (
+          <List disablePadding>
+            {removableMembers.map((member, index) => (
+              <React.Fragment key={member.id}>
+                {index > 0 && <Divider component="li" />}
+                <ListItem
+                  dense
+                  onClick={() => handleToggle(member.id)}
+                  sx={{ cursor: 'pointer', px: 3 }}
+                >
+                  <Checkbox
+                    edge="start"
+                    checked={selected.has(member.id)}
+                    tabIndex={-1}
+                    disableRipple
+                    size="small"
+                    sx={{ mr: 1 }}
+                  />
+                  <ListItemAvatar sx={{ minWidth: 36 }}>
+                    <Avatar sx={{ width: 28, height: 28, fontSize: 12 }}>
+                      {member.nombre[0].toUpperCase()}
+                    </Avatar>
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={member.nombre}
+                    secondary={member.is_admin ? t('roles.admin') : t('roles.member')}
+                    primaryTypographyProps={{ variant: 'body2' }}
+                    secondaryTypographyProps={{ variant: 'caption' }}
+                  />
+                </ListItem>
+              </React.Fragment>
+            ))}
+          </List>
+        )}
+        {selectedCount > 0 && (
+          <Box px={3} py={1} sx={{ borderTop: 1, borderColor: 'divider' }}>
+            <Typography variant="caption" color="text.secondary">
+              {t('selectionCount', { count: selectedCount })}
+            </Typography>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={loading}>
+          {t('cancelButton')}
+        </Button>
+        <Button
+          variant="contained"
+          color="error"
+          disabled={selectedCount === 0 || loading}
+          onClick={handleConfirm}
+          startIcon={loading ? <CircularProgress size={16} color="inherit" /> : undefined}
+        >
+          {t('confirmButton', { count: selectedCount })}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-06-08
+**Last updated:** 2026-06-11
 
 ---
 

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -177,6 +177,8 @@ Friend group management — creation, membership, scoring, and theme updates.
   Calls: getLoggedInUser, findProdeGroupById, findParticipantsInGroup, updateGroupPrivacy
 - **leaveGroupAction(groupId)**: `Promise<{ success: true }>` — Current user leaves a group.
   Calls: getLoggedInUser, findProdeGroupById, deleteParticipantFromGroup
+- **removeGroupMembersAction(groupId, memberIds)**: `Promise<void>` — Owner or admin removes one or more members. Owner can remove admins and members; admins can only remove regular members; owner cannot be removed.
+  Calls: getLoggedInUser, findProdeGroupById, findParticipantsInGroup, deleteParticipantFromGroup
 - **getUsersForGroup(groupId)**: `Promise<string[]>` — Gets all user IDs in a group.
   Calls: findProdeGroupById, findParticipantsInGroup
 - **getUserScoresForTournament(userIds, tournamentId)**: `Promise<UserScore[]>` — Calculates tournament scores for a set of users. Return shape includes badge fields (totalExactGuesses, totalCorrectGuesses, qualifiedTeamsCorrect, boostsUsed, scoredBoosts). Does not include yesterdayTotalPoints (removed in Story #277); snapshot fields (latestSnapshotPoints, penultimateSnapshotPoints) are patched on by pages after calling computeSnapshotScores.

--- a/docs/code-structure/components/components-friend-groups.md
+++ b/docs/code-structure/components/components-friend-groups.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-04-22
+**Last updated:** 2026-06-11
 
 ---
 

--- a/docs/code-structure/components/components-friend-groups.md
+++ b/docs/code-structure/components/components-friend-groups.md
@@ -74,11 +74,12 @@ Tooltip icon showing group privacy status. [Client]
   Uses: useTranslations
 
 ### app/components/friend-groups/join-request-manager.tsx
-Admin card to view, approve, and reject pending join requests. [Client]
+Admin card to view, approve, and reject pending join requests. Shows a "Remove Members" button when members prop is provided. [Client]
 
-- **JoinRequestManager(props: Props)**: `JSX.Element` — [Client] List pending and rejected requests with approve/reject buttons, formatted timestamps, and source info.
+- **JoinRequestManager(props: Props)**: `JSX.Element` — [Client] List pending and rejected requests with approve/reject buttons, formatted timestamps, source info, and optional member-removal section.
   Calls: approveJoinRequestAction, rejectJoinRequestAction, trackEvent
   Uses: useTranslations, useRouter
+  Renders: RemoveMembersDialog (conditional)
 
 ### app/components/friend-groups/public-groups-browser.tsx
 Searchable paginated browser for discovering and requesting to join public groups. [Client]
@@ -128,10 +129,17 @@ Four use case cards showing example group scenarios. [Client]
 - **UseCases()**: `JSX.Element` — [Client] Grid of four use case cards.
   Uses: useTranslations
 
-### app/components/friend-groups/admin-section-tabs.tsx
-Four-tab admin interface for requests, privacy, betting, and customization. [Client]
+### app/components/friend-groups/remove-members-dialog.tsx
+Dialog with a checkbox list for selecting and confirming removal of group members. [Client]
 
-- **AdminSectionTabs(props: Props)**: `JSX.Element` — [Client] Tabs for join requests (with badge), privacy settings, betting config, and group customization.
+- **RemoveMembersDialog(props: RemoveMembersDialogProps)**: `JSX.Element` — [Client] Multiselect dialog; filters visible members by caller permissions (owner sees admins+members, non-owner admin sees only regular members). Calls removeGroupMembersAction on confirm.
+  Calls: removeGroupMembersAction
+  Uses: useTranslations
+
+### app/components/friend-groups/admin-section-tabs.tsx
+Four-tab admin interface for requests, privacy, betting, and customization. Passes member list and ownership props to JoinRequestManager to enable member removal. [Client]
+
+- **AdminSectionTabs(props: Props)**: `JSX.Element` — [Client] Tabs for join requests (with badge), privacy settings, betting config, and group customization. Props include ownerId and isOwner for member-removal feature.
   Renders: JoinRequestManager, GroupPrivacySettings, GroupTournamentBettingAdmin, ProdeGroupThemer
 
 ### app/components/friend-groups/friend-groups-themer.tsx

--- a/locales/en/groups.json
+++ b/locales/en/groups.json
@@ -242,6 +242,19 @@
       "invite_link": "via invite link",
       "discovery": "via discovery",
       "email_invite": "via email invite"
+    },
+    "removeMembersButton": "Remove Members",
+    "removeMembersDialog": {
+      "title": "Remove Members",
+      "selectionCount": "{count} member(s) selected",
+      "confirmButton": "Remove ({count})",
+      "cancelButton": "Cancel",
+      "roles": {
+        "admin": "Admin",
+        "member": "Member"
+      },
+      "success": "Members removed successfully",
+      "error": "Failed to remove members"
     }
   },
   "pendingRequest": {

--- a/locales/es/groups.json
+++ b/locales/es/groups.json
@@ -242,6 +242,19 @@
       "invite_link": "mediante enlace de invitación",
       "discovery": "mediante descubrimiento",
       "email_invite": "mediante invitación por email"
+    },
+    "removeMembersButton": "Eliminar Miembros",
+    "removeMembersDialog": {
+      "title": "Eliminar Miembros",
+      "selectionCount": "{count} miembro(s) seleccionado(s)",
+      "confirmButton": "Eliminar ({count})",
+      "cancelButton": "Cancelar",
+      "roles": {
+        "admin": "Admin",
+        "member": "Miembro"
+      },
+      "success": "Miembros eliminados correctamente",
+      "error": "Error al eliminar miembros"
     }
   },
   "pendingRequest": {

--- a/plans/STORY-471-context.md
+++ b/plans/STORY-471-context.md
@@ -1,0 +1,16 @@
+# Story 471 Context
+
+## Metadata
+- **Story Number:** 471
+- **Story Title:** [Story] Group admins can remove members from a group
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-471
+- **Branch:** feature/story-471
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-471-plan.md
+
+## Quick Summary
+Adds a "Members" tab to the group admin interface allowing owners and admins to remove members. Owners can remove admins and regular members; admins can only remove regular members. The owner themselves cannot be removed. Implements a confirmation dialog, success/error snackbar feedback, and supports both EN and ES locales.

--- a/plans/STORY-471-context.md
+++ b/plans/STORY-471-context.md
@@ -9,7 +9,7 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/472
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** review-ready
 - **Plan File:** plans/STORY-471-plan.md
 
 ## Quick Summary

--- a/plans/STORY-471-context.md
+++ b/plans/STORY-471-context.md
@@ -5,8 +5,8 @@
 - **Story Title:** [Story] Group admins can remove members from a group
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-471
 - **Branch:** feature/story-471
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** 472
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/472
 
 ## State
 - **Current Phase:** planning

--- a/plans/STORY-471-plan.md
+++ b/plans/STORY-471-plan.md
@@ -2,76 +2,67 @@
 
 ## Context
 
-Group owners and admins currently have no way to remove a member who joined by mistake, is inactive, or should no longer be in the group. Members can only leave voluntarily. This story closes that gap by adding a "Members" admin tab with per-member remove controls, respecting a two-tier permission model (owner can remove admins and members; admins can only remove regular members).
+Group owners and admins currently have no way to remove a member who joined by mistake, is inactive, or should no longer be in the group. Members can only leave voluntarily. This story closes that gap by adding a "Remove Users" button inside the existing **Solicitudes (Requests)** admin tab, opening a multiselect dialog where the admin picks members to remove, then confirms.
 
 ## Acceptance Criteria (from issue)
-- Members tab in group admin area lists all current members with their role
-- Admins see Remove button next to each regular member
-- Owner sees Remove button next to regular members AND admins
-- Confirmation dialog before removal
-- Removed user immediately loses access
-- Owner cannot be removed
+- Group admins can remove regular members
+- Group owner can remove regular members AND admins
+- Owner themselves cannot be removed
 - Admins cannot remove other admins (only owner can)
+- Removed user immediately loses access
+- Confirmation before removal
 - Works in EN and ES
 
 ---
 
-## Technical Approach
+## Design Decision
 
-### Existing infrastructure to reuse
-- **`deleteParticipantFromGroup(groupId, userId)`** in `app/db/prode-group-repository.ts` — already works, used by `leaveGroupAction`
-- **`leaveGroupAction`** in `app/actions/prode-group-actions.ts` — exact auth/DB pattern to follow
-- **`promoteParticipantToAdmin` / `demoteParticipantFromAdmin`** — authorization check pattern (owner-only)
-- **`GroupTournamentBettingAdmin`** component (`app/components/friend-groups/group-tournament-betting-admin.tsx`) — exact table + button + snackbar pattern to follow
-- **`AdminSectionTabs`** (`app/components/friend-groups/admin-section-tabs.tsx`) — add 5th tab here
-- The page already builds `members` with `is_admin` field; the type just needs to be updated to expose it
+**No new tab.** The remove functionality lives inside the existing "Solicitudes" tab (`JoinRequestManager`), below the join-request list. A single "Remove Members" button opens a dialog with checkboxes to select members, then a "Remove (N)" confirm button. This keeps the admin interface minimal.
 
 ---
 
 ## Visual Prototype
 
-### Members Tab Layout
+### Solicitudes Tab — with Remove Members button
 
 ```
-┌────────────────────────────────────────────┐
-│  ● Requests  🔒 Privacy  ♟ Betting         │
-│  🎨 Customize  👥 Members                  │
-├────────────────────────────────────────────┤
-│  Group Members                             │
-│                                            │
-│  ┌──────────────┬──────────┬───────────┐   │
-│  │ Name         │ Role     │ Actions   │   │
-│  ├──────────────┼──────────┼───────────┤   │
-│  │ Alice        │ Owner    │           │   │
-│  ├──────────────┼──────────┼───────────┤   │
-│  │ Bob          │ Admin    │ [Remove]* │   │
-│  ├──────────────┼──────────┼───────────┤   │
-│  │ Carol        │ Member   │ [Remove]  │   │
-│  ├──────────────┼──────────┼───────────┤   │
-│  │ David        │ Member   │ [Remove]  │   │
-│  └──────────────┴──────────┴───────────┘   │
-│  * Remove button on admin rows only        │
-│    visible to group owner                  │
-└────────────────────────────────────────────┘
+┌────────────────────────────────────────┐
+│  👤 Solicitudes de ingreso             │
+│  [No pending requests]                 │
+│                                        │
+│  ──────────────────────────────────    │
+│                                        │
+│  [ Remove Members ]   ← new button     │
+└────────────────────────────────────────┘
 ```
 
-### Confirmation Dialog
+### Remove Members Dialog
 
 ```
-┌──────────────────────────────────────────┐
-│  Remove Member                           │
-│                                          │
-│  Are you sure you want to remove Carol   │
-│  from the group? This cannot be undone.  │
-│                                          │
-│                    [Cancel]  [Remove]    │
-└──────────────────────────────────────────┘
+┌────────────────────────────────────────┐
+│  Remove Members                        │
+│  ────────────────────────────────────  │
+│  ☐  Bob        Admin  ← owner only     │
+│  ☑  Carol      Member                  │
+│  ☐  David      Member                  │
+│  ☐  Eva        Member                  │
+│  ────────────────────────────────────  │
+│  1 member selected                     │
+│                                        │
+│               [Cancel]  [Remove (1)]   │
+└────────────────────────────────────────┘
 ```
+
+**Permission rules in dialog:**
+- Viewer is **owner**: sees all members except themselves (admins + regular members)
+- Viewer is **admin**: sees only regular members (not other admins, not owner)
+- Owner row never appears in the list
 
 **States:**
-- Removing: "Remove" button shows loading spinner, disabled
-- Success: Snackbar "Carol has been removed" (1000ms)
-- Error: Snackbar with error message (6000ms); row remains in list
+- No selection: "Remove" button disabled
+- Removing: button shows loading spinner
+- Success: dialog closes, JoinRequestManager shows success Alert
+- Error: snackbar with error message, dialog stays open
 
 ---
 
@@ -79,14 +70,15 @@ Group owners and admins currently have no way to remove a member who joined by m
 
 | File | Change |
 |------|--------|
-| `app/actions/prode-group-actions.ts` | Add `removeGroupMemberAction` server action |
-| `app/components/friend-groups/group-members-admin.tsx` | **New** — member table with remove button + confirm dialog |
-| `app/components/friend-groups/admin-section-tabs.tsx` | Add 5th "Members" tab; update Props type |
-| `app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx` | Pass `ownerId` prop to AdminSectionTabs |
-| `locales/en/groups.json` | Add `adminSectionTabs.members` and `members` namespace |
+| `app/actions/prode-group-actions.ts` | Add `removeGroupMembersAction` (batch removal) |
+| `app/components/friend-groups/remove-members-dialog.tsx` | **New** — multiselect dialog component |
+| `app/components/friend-groups/join-request-manager.tsx` | Add "Remove Members" button + wire dialog |
+| `app/components/friend-groups/admin-section-tabs.tsx` | Pass `members` (with `is_admin`) + `ownerId` + `isOwner` to `JoinRequestManager` |
+| `app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx` | Pass `ownerId` + `isOwner` to `AdminSectionTabs` |
+| `locales/en/groups.json` | Add `joinRequests.removeMembers` keys |
 | `locales/es/groups.json` | Same for Spanish |
-| `docs/code-structure/actions.md` | Add `removeGroupMemberAction` entry |
-| `docs/code-structure/components/components-friend-groups.md` | Add `GroupMembersAdmin` entry; update `AdminSectionTabs` entry |
+| `docs/code-structure/actions.md` | Add `removeGroupMembersAction` entry |
+| `docs/code-structure/components/components-friend-groups.md` | Add `RemoveMembersDialog`; update `JoinRequestManager` and `AdminSectionTabs` entries |
 
 ---
 
@@ -95,7 +87,7 @@ Group owners and admins currently have no way to remove a member who joined by m
 ### Call Graph Changes
 
 **Modified flows:**
-- **Flow 13 (Friend group management)** — `AdminSectionTabs` now renders `GroupMembersAdmin` (5th tab), which calls `removeGroupMemberAction` → `deleteParticipantFromGroup`
+- **Flow 13 (Friend group management)** — `JoinRequestManager` gains a "Remove Members" button that opens `RemoveMembersDialog`, which calls `removeGroupMembersAction` → `deleteParticipantFromGroup` (looped per member)
 
 **New flows:**
 - None (extends existing Flow 13)
@@ -106,135 +98,122 @@ Group owners and admins currently have no way to remove a member who joined by m
 
 **New functions:**
 
-- **`removeGroupMemberAction(groupId: string, memberId: string): Promise<void>`**
-  Server Action. Allows group owner or admin to remove a member from the group.
-  Authorization rules:
-  - Current user must be owner or admin of the group
-  - Cannot remove the group owner (throw)
-  - Admins cannot remove other admins (only owner can)
+- **`removeGroupMembersAction(groupId: string, memberIds: string[]): Promise<void>`**
+  Server Action. Allows group owner or admin to remove one or more members from the group in a single call. Iterates over `memberIds` and calls `deleteParticipantFromGroup` for each valid target. Authorization rules:
+  - Current user must be owner or admin (fetches participants to verify)
+  - Skips (does not throw) if `memberId === ownerId` — owner is never removable
+  - Admins cannot remove other admins — throws if any target is an admin and caller is not owner
   Calls: `getLoggedInUser`, `findProdeGroupById`, `findParticipantsInGroup`, `deleteParticipantFromGroup`
   Tests:
   - throws when caller is not authenticated
   - throws when group does not exist
-  - throws when caller is not admin or owner
-  - throws when attempting to remove the group owner
-  - throws when admin attempts to remove another admin
-  - allows owner to remove an admin
-  - allows owner to remove a regular member
-  - allows admin to remove a regular member
-  - calls deleteParticipantFromGroup with correct groupId and memberId
+  - throws when caller is neither owner nor admin of the group
+  - throws when admin attempts to remove an admin (any target is admin and caller is not owner)
+  - allows owner to remove a mix of admins and regular members
+  - allows admin to remove regular members only
+  - no-ops silently if memberIds is empty
+  - calls deleteParticipantFromGroup once per valid memberId
 
 ---
 
-### `app/components/friend-groups/group-members-admin.tsx` *(new)*
+### `app/components/friend-groups/remove-members-dialog.tsx` *(new)*
 
 **New component:**
 
-- **`GroupMembersAdmin`** (default export, Client Component)
-  Props: `{ groupId: string; members: { id: string; nombre: string; is_admin: boolean }[]; ownerId: string; isOwner: boolean; locale: Locale }`
-  Renders a MUI Table with one row per member. Owner row has no action; admin rows show Remove only if `isOwner`; member rows always show Remove. Clicking Remove opens a MUI Dialog for confirmation. On confirm, calls `removeGroupMemberAction` and on success removes the row from local state; on error shows snackbar.
-  Calls: `removeGroupMemberAction`
+- **`RemoveMembersDialog`** (default export, Client Component)
+  Props: `{ open: boolean; onClose: () => void; onSuccess: (removedIds: string[]) => void; groupId: string; members: { id: string; nombre: string; is_admin: boolean }[]; ownerId: string; isOwner: boolean }`
+  Renders a MUI Dialog with a scrollable List of Checkbox items. Visible members: if `isOwner`, all except owner (`id !== ownerId`); otherwise only non-admins. Tracks a `Set<string>` of selected IDs. "Remove (N)" button calls `removeGroupMembersAction`, then calls `onSuccess(selectedIds)` on completion. Error shown as Alert inside the dialog.
+  Calls: `removeGroupMembersAction`
   Tests:
-  - renders all members in the table
-  - does not show Remove button for the owner row
-  - shows Remove button for admin rows only when viewer is owner
-  - does not show Remove button for admin rows when viewer is non-owner admin
-  - shows Remove button for regular member rows for both owner and admin viewers
-  - opens confirmation dialog on Remove click
-  - calls removeGroupMemberAction with correct args on dialog confirm
-  - removes member row from list on successful removal
-  - closes dialog without removing member when user clicks Cancel
-  - renders no Remove buttons when viewer is a regular member (non-admin)
-  - shows error snackbar when removeGroupMemberAction throws
+  - renders only non-admin members when viewer is a non-owner admin
+  - renders admin and regular members (excluding owner) when viewer is owner
+  - "Remove" button is disabled when no member is selected
+  - selecting a member enables the "Remove" button with count label
+  - calls removeGroupMembersAction with correct groupId and selectedIds on confirm
+  - calls onSuccess with removed IDs after successful removal
+  - shows error Alert inside dialog when removeGroupMembersAction throws; dialog stays open
+  - Cancel button calls onClose without removing anyone
   - (all tests use `testFactories.user()` and `testFactories.prodeGroup()` for test data)
+
+---
+
+### `app/components/friend-groups/join-request-manager.tsx` *(modified)*
+
+**Changed types:**
+- Add new optional props: `members?: { id: string; nombre: string; is_admin: boolean }[]`, `ownerId?: string`, `isOwner?: boolean`
+
+**New UI:**
+- Below the join-request list (always, not just when there are requests), render a "Remove Members" button if `members` prop is provided and has at least one removable member
+- Button opens `RemoveMembersDialog`
+- On `onSuccess`: remove the returned IDs from a local `removedIds` state (or show a success Alert); call `router.refresh()`
+
+**Changed functions:**
+- **`JoinRequestManager`**: same signature return type `JSX.Element`, but props extended with the three optional members fields above
+  Tests (additions to existing suite):
+  - does not render Remove Members button when members prop is absent
+  - renders Remove Members button when members prop has removable members
+  - opens RemoveMembersDialog on Remove Members click
+  - shows success Alert after successful removal and refreshes
 
 ---
 
 ### `app/components/friend-groups/admin-section-tabs.tsx` *(modified)*
 
 **Changed types:**
-
 - `Props.members`: was `{ id: string; nombre: string }[]`, now `{ id: string; nombre: string; is_admin: boolean }[]`
 - Add `Props.ownerId: string`
-- `AdminSectionTabValue`: add `'members'` to union type
+- Add `Props.isOwner: boolean`
 
-**UI changes:**
-- Import `GroupMembersAdmin` and `PeopleIcon` from `@mui/icons-material`
-- Add 5th Tab with `PeopleIcon` and `t('members')` label
-- Add 5th TabPanel rendering `<GroupMembersAdmin>`
+**Changed calls:**
+- Pass `members`, `ownerId`, `isOwner` through to `JoinRequestManager`
 
 ---
 
 ### `app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx` *(modified)*
 
 **Changed calls:**
-- Pass `ownerId={prodeGroup.owner_user_id}` to `AdminSectionTabs`
+- Pass `ownerId={prodeGroup.owner_user_id}` and `isOwner={isOwner}` to `AdminSectionTabs`
 
 ---
 
 ## Translation Keys
 
-### `locales/en/groups.json` additions
-
+### `locales/en/groups.json` — additions under `joinRequests`
 ```json
-"adminSectionTabs": {
-  // existing keys...
-  "members": "Members"
-},
-"members": {
-  "title": "Group Members",
-  "tableHeaders": {
-    "name": "Name",
-    "role": "Role",
-    "actions": "Actions"
-  },
-  "roles": {
-    "owner": "Owner",
-    "admin": "Admin",
-    "member": "Member"
-  },
-  "removeButton": "Remove",
-  "confirmDialog": {
-    "title": "Remove Member",
-    "message": "Are you sure you want to remove {name} from the group? This cannot be undone.",
-    "confirm": "Remove",
-    "cancel": "Cancel"
-  },
-  "feedback": {
-    "removedSuccess": "{name} has been removed from the group",
-    "removeError": "Failed to remove member"
+"joinRequests": {
+  // ...existing keys...
+  "removeMembersButton": "Remove Members",
+  "removeMembersDialog": {
+    "title": "Remove Members",
+    "selectionCount": "{count} member(s) selected",
+    "confirmButton": "Remove ({count})",
+    "cancelButton": "Cancel",
+    "roles": {
+      "admin": "Admin",
+      "member": "Member"
+    },
+    "success": "Members removed successfully",
+    "error": "Failed to remove members"
   }
 }
 ```
 
-### `locales/es/groups.json` additions (Spanish equivalents)
+### `locales/es/groups.json` — additions under `joinRequests`
 ```json
-"adminSectionTabs": {
-  // existing keys...
-  "members": "Miembros"
-},
-"members": {
-  "title": "Miembros del Grupo",
-  "tableHeaders": {
-    "name": "Nombre",
-    "role": "Rol",
-    "actions": "Acciones"
-  },
-  "roles": {
-    "owner": "Dueño",
-    "admin": "Admin",
-    "member": "Miembro"
-  },
-  "removeButton": "Eliminar",
-  "confirmDialog": {
-    "title": "Eliminar Miembro",
-    "message": "¿Estás seguro de que quieres eliminar a {name} del grupo? Esta acción no se puede deshacer.",
-    "confirm": "Eliminar",
-    "cancel": "Cancelar"
-  },
-  "feedback": {
-    "removedSuccess": "{name} ha sido eliminado del grupo",
-    "removeError": "Error al eliminar miembro"
+"joinRequests": {
+  // ...existing keys...
+  "removeMembersButton": "Eliminar Miembros",
+  "removeMembersDialog": {
+    "title": "Eliminar Miembros",
+    "selectionCount": "{count} miembro(s) seleccionado(s)",
+    "confirmButton": "Eliminar ({count})",
+    "cancelButton": "Cancelar",
+    "roles": {
+      "admin": "Admin",
+      "member": "Miembro"
+    },
+    "success": "Miembros eliminados correctamente",
+    "error": "Error al eliminar miembros"
   }
 }
 ```
@@ -243,35 +222,38 @@ Group owners and admins currently have no way to remove a member who joined by m
 
 ## Implementation Steps
 
-1. **Server action** (`prode-group-actions.ts`): Add `removeGroupMemberAction` with auth/permission guards, calling `deleteParticipantFromGroup`
-2. **New component** (`group-members-admin.tsx`): Build `GroupMembersAdmin` with table, confirm dialog, snackbar — following the `GroupTournamentBettingAdmin` pattern
-3. **Update AdminSectionTabs**: Add Props (`ownerId`, updated `members` type), add "Members" tab + panel
-4. **Update page**: Pass `ownerId` prop
-5. **Translations**: Add keys to both `locales/en/groups.json` and `locales/es/groups.json`
-6. **CODE-STRUCTURE updates**: Update `actions.md` and `components-friend-groups.md`
+1. **Server action** (`prode-group-actions.ts`): Add `removeGroupMembersAction` with auth/permission guards
+2. **New dialog component** (`remove-members-dialog.tsx`): Checkbox multiselect + confirm, following `JoinRequestManager` patterns
+3. **Update `JoinRequestManager`**: Add optional members props, "Remove Members" button, wire dialog and success handling
+4. **Update `AdminSectionTabs`**: Add `ownerId` + `isOwner` props; pass members+ownerId+isOwner to JoinRequestManager
+5. **Update page**: Pass `ownerId` and `isOwner` to AdminSectionTabs
+6. **Translations**: Add keys to both locales
+7. **CODE-STRUCTURE updates**: Update `actions.md` and `components-friend-groups.md`
 
 ---
 
 ## Testing Strategy
 
-### Unit Tests (new file: `__tests__/actions/prode-group-actions.remove-member.test.ts`)
-- 9 test cases covering all auth/permission branches of `removeGroupMemberAction` (listed in Mid-Level Design)
+### Unit Tests — `__tests__/actions/prode-group-actions.remove-members.test.ts`
+8 test cases for `removeGroupMembersAction` (listed in Mid-Level Design)
 
-### Component Tests (new file: `__tests__/components/friend-groups/group-members-admin.test.tsx`)
-- 9 test cases covering render, permission display, dialog flow, success/error states (listed in Mid-Level Design)
+### Component Tests — `__tests__/components/friend-groups/remove-members-dialog.test.tsx`
+9 test cases for `RemoveMembersDialog` (listed in Mid-Level Design)
+
+### Component Tests — additions to existing `__tests__/components/friend-groups/join-request-manager.test.tsx`
+4 additional test cases (listed in Mid-Level Design)
 
 ### Manual verification
-1. Log in as group owner → Members tab appears → can remove regular members and admins
-2. Log in as group admin → Members tab appears → Remove button only on regular members, not on admins
-3. Log in as regular member → Admin tab is hidden entirely
-4. Confirm removal dialog shows member's name
-5. After removal, the removed user cannot access the group
-6. Test in both EN and ES locales
+1. Log in as group owner → Solicitudes tab → "Remove Members" button visible → dialog shows admins + members
+2. Log in as group admin → same tab → dialog shows only regular members (no admins)
+3. Select multiple, click Remove → confirmation fires, members gone, page refreshes
+4. Verify removed user can no longer access the group
+5. Test EN and ES locales
 
 ---
 
 ## Validation Considerations (SonarCloud)
-- No new security issues: Server Action validates authentication + authorization before mutation
-- Coverage: ≥80% on new code — covered by the 9 unit tests per new function/component
-- No `any` types — use proper TypeScript types throughout
-- No hardcoded colors — use MUI theme tokens only
+- Auth + authz in Server Action before any mutation
+- ≥80% coverage on new code via test cases above
+- No `any` types
+- No hardcoded colors — MUI theme tokens only

--- a/plans/STORY-471-plan.md
+++ b/plans/STORY-471-plan.md
@@ -1,0 +1,277 @@
+# Story #471 Plan: Group Admins Can Remove Members from a Group
+
+## Context
+
+Group owners and admins currently have no way to remove a member who joined by mistake, is inactive, or should no longer be in the group. Members can only leave voluntarily. This story closes that gap by adding a "Members" admin tab with per-member remove controls, respecting a two-tier permission model (owner can remove admins and members; admins can only remove regular members).
+
+## Acceptance Criteria (from issue)
+- Members tab in group admin area lists all current members with their role
+- Admins see Remove button next to each regular member
+- Owner sees Remove button next to regular members AND admins
+- Confirmation dialog before removal
+- Removed user immediately loses access
+- Owner cannot be removed
+- Admins cannot remove other admins (only owner can)
+- Works in EN and ES
+
+---
+
+## Technical Approach
+
+### Existing infrastructure to reuse
+- **`deleteParticipantFromGroup(groupId, userId)`** in `app/db/prode-group-repository.ts` — already works, used by `leaveGroupAction`
+- **`leaveGroupAction`** in `app/actions/prode-group-actions.ts` — exact auth/DB pattern to follow
+- **`promoteParticipantToAdmin` / `demoteParticipantFromAdmin`** — authorization check pattern (owner-only)
+- **`GroupTournamentBettingAdmin`** component (`app/components/friend-groups/group-tournament-betting-admin.tsx`) — exact table + button + snackbar pattern to follow
+- **`AdminSectionTabs`** (`app/components/friend-groups/admin-section-tabs.tsx`) — add 5th tab here
+- The page already builds `members` with `is_admin` field; the type just needs to be updated to expose it
+
+---
+
+## Visual Prototype
+
+### Members Tab Layout
+
+```
+┌────────────────────────────────────────────┐
+│  ● Requests  🔒 Privacy  ♟ Betting         │
+│  🎨 Customize  👥 Members                  │
+├────────────────────────────────────────────┤
+│  Group Members                             │
+│                                            │
+│  ┌──────────────┬──────────┬───────────┐   │
+│  │ Name         │ Role     │ Actions   │   │
+│  ├──────────────┼──────────┼───────────┤   │
+│  │ Alice        │ Owner    │           │   │
+│  ├──────────────┼──────────┼───────────┤   │
+│  │ Bob          │ Admin    │ [Remove]* │   │
+│  ├──────────────┼──────────┼───────────┤   │
+│  │ Carol        │ Member   │ [Remove]  │   │
+│  ├──────────────┼──────────┼───────────┤   │
+│  │ David        │ Member   │ [Remove]  │   │
+│  └──────────────┴──────────┴───────────┘   │
+│  * Remove button on admin rows only        │
+│    visible to group owner                  │
+└────────────────────────────────────────────┘
+```
+
+### Confirmation Dialog
+
+```
+┌──────────────────────────────────────────┐
+│  Remove Member                           │
+│                                          │
+│  Are you sure you want to remove Carol   │
+│  from the group? This cannot be undone.  │
+│                                          │
+│                    [Cancel]  [Remove]    │
+└──────────────────────────────────────────┘
+```
+
+**States:**
+- Removing: "Remove" button shows loading spinner, disabled
+- Success: Snackbar "Carol has been removed" (1000ms)
+- Error: Snackbar with error message (6000ms); row remains in list
+
+---
+
+## Files to Create / Modify
+
+| File | Change |
+|------|--------|
+| `app/actions/prode-group-actions.ts` | Add `removeGroupMemberAction` server action |
+| `app/components/friend-groups/group-members-admin.tsx` | **New** — member table with remove button + confirm dialog |
+| `app/components/friend-groups/admin-section-tabs.tsx` | Add 5th "Members" tab; update Props type |
+| `app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx` | Pass `ownerId` prop to AdminSectionTabs |
+| `locales/en/groups.json` | Add `adminSectionTabs.members` and `members` namespace |
+| `locales/es/groups.json` | Same for Spanish |
+| `docs/code-structure/actions.md` | Add `removeGroupMemberAction` entry |
+| `docs/code-structure/components/components-friend-groups.md` | Add `GroupMembersAdmin` entry; update `AdminSectionTabs` entry |
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+**Modified flows:**
+- **Flow 13 (Friend group management)** — `AdminSectionTabs` now renders `GroupMembersAdmin` (5th tab), which calls `removeGroupMemberAction` → `deleteParticipantFromGroup`
+
+**New flows:**
+- None (extends existing Flow 13)
+
+---
+
+### `app/actions/prode-group-actions.ts` *(modified)*
+
+**New functions:**
+
+- **`removeGroupMemberAction(groupId: string, memberId: string): Promise<void>`**
+  Server Action. Allows group owner or admin to remove a member from the group.
+  Authorization rules:
+  - Current user must be owner or admin of the group
+  - Cannot remove the group owner (throw)
+  - Admins cannot remove other admins (only owner can)
+  Calls: `getLoggedInUser`, `findProdeGroupById`, `findParticipantsInGroup`, `deleteParticipantFromGroup`
+  Tests:
+  - throws when caller is not authenticated
+  - throws when group does not exist
+  - throws when caller is not admin or owner
+  - throws when attempting to remove the group owner
+  - throws when admin attempts to remove another admin
+  - allows owner to remove an admin
+  - allows owner to remove a regular member
+  - allows admin to remove a regular member
+  - calls deleteParticipantFromGroup with correct groupId and memberId
+
+---
+
+### `app/components/friend-groups/group-members-admin.tsx` *(new)*
+
+**New component:**
+
+- **`GroupMembersAdmin`** (default export, Client Component)
+  Props: `{ groupId: string; members: { id: string; nombre: string; is_admin: boolean }[]; ownerId: string; isOwner: boolean; locale: Locale }`
+  Renders a MUI Table with one row per member. Owner row has no action; admin rows show Remove only if `isOwner`; member rows always show Remove. Clicking Remove opens a MUI Dialog for confirmation. On confirm, calls `removeGroupMemberAction` and on success removes the row from local state; on error shows snackbar.
+  Calls: `removeGroupMemberAction`
+  Tests:
+  - renders all members in the table
+  - does not show Remove button for the owner row
+  - shows Remove button for admin rows only when viewer is owner
+  - does not show Remove button for admin rows when viewer is non-owner admin
+  - shows Remove button for regular member rows for both owner and admin viewers
+  - opens confirmation dialog on Remove click
+  - calls removeGroupMemberAction with correct args on dialog confirm
+  - removes member row from list on successful removal
+  - closes dialog without removing member when user clicks Cancel
+  - renders no Remove buttons when viewer is a regular member (non-admin)
+  - shows error snackbar when removeGroupMemberAction throws
+  - (all tests use `testFactories.user()` and `testFactories.prodeGroup()` for test data)
+
+---
+
+### `app/components/friend-groups/admin-section-tabs.tsx` *(modified)*
+
+**Changed types:**
+
+- `Props.members`: was `{ id: string; nombre: string }[]`, now `{ id: string; nombre: string; is_admin: boolean }[]`
+- Add `Props.ownerId: string`
+- `AdminSectionTabValue`: add `'members'` to union type
+
+**UI changes:**
+- Import `GroupMembersAdmin` and `PeopleIcon` from `@mui/icons-material`
+- Add 5th Tab with `PeopleIcon` and `t('members')` label
+- Add 5th TabPanel rendering `<GroupMembersAdmin>`
+
+---
+
+### `app/[locale]/tournaments/[id]/friend-groups/[group_id]/page.tsx` *(modified)*
+
+**Changed calls:**
+- Pass `ownerId={prodeGroup.owner_user_id}` to `AdminSectionTabs`
+
+---
+
+## Translation Keys
+
+### `locales/en/groups.json` additions
+
+```json
+"adminSectionTabs": {
+  // existing keys...
+  "members": "Members"
+},
+"members": {
+  "title": "Group Members",
+  "tableHeaders": {
+    "name": "Name",
+    "role": "Role",
+    "actions": "Actions"
+  },
+  "roles": {
+    "owner": "Owner",
+    "admin": "Admin",
+    "member": "Member"
+  },
+  "removeButton": "Remove",
+  "confirmDialog": {
+    "title": "Remove Member",
+    "message": "Are you sure you want to remove {name} from the group? This cannot be undone.",
+    "confirm": "Remove",
+    "cancel": "Cancel"
+  },
+  "feedback": {
+    "removedSuccess": "{name} has been removed from the group",
+    "removeError": "Failed to remove member"
+  }
+}
+```
+
+### `locales/es/groups.json` additions (Spanish equivalents)
+```json
+"adminSectionTabs": {
+  // existing keys...
+  "members": "Miembros"
+},
+"members": {
+  "title": "Miembros del Grupo",
+  "tableHeaders": {
+    "name": "Nombre",
+    "role": "Rol",
+    "actions": "Acciones"
+  },
+  "roles": {
+    "owner": "Dueño",
+    "admin": "Admin",
+    "member": "Miembro"
+  },
+  "removeButton": "Eliminar",
+  "confirmDialog": {
+    "title": "Eliminar Miembro",
+    "message": "¿Estás seguro de que quieres eliminar a {name} del grupo? Esta acción no se puede deshacer.",
+    "confirm": "Eliminar",
+    "cancel": "Cancelar"
+  },
+  "feedback": {
+    "removedSuccess": "{name} ha sido eliminado del grupo",
+    "removeError": "Error al eliminar miembro"
+  }
+}
+```
+
+---
+
+## Implementation Steps
+
+1. **Server action** (`prode-group-actions.ts`): Add `removeGroupMemberAction` with auth/permission guards, calling `deleteParticipantFromGroup`
+2. **New component** (`group-members-admin.tsx`): Build `GroupMembersAdmin` with table, confirm dialog, snackbar — following the `GroupTournamentBettingAdmin` pattern
+3. **Update AdminSectionTabs**: Add Props (`ownerId`, updated `members` type), add "Members" tab + panel
+4. **Update page**: Pass `ownerId` prop
+5. **Translations**: Add keys to both `locales/en/groups.json` and `locales/es/groups.json`
+6. **CODE-STRUCTURE updates**: Update `actions.md` and `components-friend-groups.md`
+
+---
+
+## Testing Strategy
+
+### Unit Tests (new file: `__tests__/actions/prode-group-actions.remove-member.test.ts`)
+- 9 test cases covering all auth/permission branches of `removeGroupMemberAction` (listed in Mid-Level Design)
+
+### Component Tests (new file: `__tests__/components/friend-groups/group-members-admin.test.tsx`)
+- 9 test cases covering render, permission display, dialog flow, success/error states (listed in Mid-Level Design)
+
+### Manual verification
+1. Log in as group owner → Members tab appears → can remove regular members and admins
+2. Log in as group admin → Members tab appears → Remove button only on regular members, not on admins
+3. Log in as regular member → Admin tab is hidden entirely
+4. Confirm removal dialog shows member's name
+5. After removal, the removed user cannot access the group
+6. Test in both EN and ES locales
+
+---
+
+## Validation Considerations (SonarCloud)
+- No new security issues: Server Action validates authentication + authorization before mutation
+- Coverage: ≥80% on new code — covered by the 9 unit tests per new function/component
+- No `any` types — use proper TypeScript types throughout
+- No hardcoded colors — use MUI theme tokens only


### PR DESCRIPTION
## Plan: Group Admins Can Remove Members from a Group

Fixes #471

### Summary
Adds a "Members" admin tab to the group management interface that allows group owners and admins to remove members with role-based permissions:
- **Owners** can remove admins and regular members
- **Admins** can only remove regular members  
- **Owner** themselves cannot be removed

### Key Changes
- New `removeGroupMemberAction` server action with two-tier authorization
- New `GroupMembersAdmin` component (table + confirmation dialog + snackbar)
- 5th "Members" tab added to `AdminSectionTabs`
- EN + ES translations

### Plan File
See `plans/STORY-471-plan.md` for full technical design, mid-level design, and testing strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)