### PR TITLE
Plan: [Story] Quick score entry wizard for recently finished games #474

### DIFF
--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -769,5 +769,11 @@ Key flows:
       │     └── findTeamsByIds(uniqueTeamIds) → teamsMap
       └── saveAndPublishSingleGameResult(game, locale) [server action, per game]
             ├── getLoggedInUser (admin check)
-            └── saveGameResults([publishedGame]) → processGameResult → calculateGameScores
+            └── saveGamesAndRecalculate([publishedGame], tournamentId, locale)
+                  ├── saveGameResults([game]) → processGameResult
+                  ├── [group games only] findGamesInGroup(groupId, true, false) + findTeamsInGroup + findTournamentById
+                  ├── [group games only] calculateAndStoreGroupPosition → updateTournamentGroupTeams
+                  ├── [group games only] calculateAndSavePlayoffGamesForTournament → fills R16 bracket slots
+                  ├── [group games only] calculateAndStoreQualifiedTeamsScores
+                  └── calculateGameScores → recalculates all user prediction scores
 ```

--- a/CODE-STRUCTURE.md
+++ b/CODE-STRUCTURE.md
@@ -759,4 +759,15 @@ Key flows:
           when non-null → HistoryTab merges with displayNames from historyData.userHistories
                           → passes merged data to RankHistoryChart (replaces computed ranks)
           when null     → HistoryTab falls back to computed ranks from getScoreHistoryForGroup (existing behavior)
+
+35. Quick Score Wizard (Story #474)
+    UserActions [Client] (header) → QuickScoreWizardDialog [Client] (on "Fill Latest Scores" menu click)
+      ├── getRecentUnscoredGames(locale) [server action, on open]
+      │     ├── getLoggedInUser (admin check)
+      │     ├── findRecentUnscoredGames(24) → games with no published result in last 24h across all tournaments
+      │     ├── applyLocalization (per game and per team)
+      │     └── findTeamsByIds(uniqueTeamIds) → teamsMap
+      └── saveAndPublishSingleGameResult(game, locale) [server action, per game]
+            ├── getLoggedInUser (admin check)
+            └── saveGameResults([publishedGame]) → processGameResult → calculateGameScores
 ```

--- a/__tests__/actions/backoffice-actions.test.ts
+++ b/__tests__/actions/backoffice-actions.test.ts
@@ -17,6 +17,7 @@ import {
   updateTournamentPermissions,
   getRecentUnscoredGames,
   saveAndPublishSingleGameResult,
+  saveGamesAndRecalculate,
 } from '../../app/actions/backoffice-actions';
 import { GameResult, Tournament, TournamentUpdate } from '../../app/db/tables-definition';
 import { ExtendedGameData, ExtendedGroupData, ExtendedPlayoffRoundData } from '../../app/definitions';
@@ -276,6 +277,10 @@ vi.mock('../../app/actions/group-ranking-actions', () => ({
   recalculateGroupRankingsForUsers: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../../app/actions/qualified-teams-scoring-actions', () => ({
+  calculateAndStoreQualifiedTeamsScores: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Import mocked functions
 import * as tournamentRepository from '../../app/db/tournament-repository';
 import * as teamRepository from '../../app/db/team-repository';
@@ -299,6 +304,7 @@ import * as groupPositionCalculator from '../../app/utils/group-position-calcula
 import * as gameScoreCalculator from '../../app/utils/game-score-calculator';
 import * as objectUtils from '../../app/utils/ObjectUtils';
 import * as database from '../../app/db/database';
+import * as qualifiedTeamsScoringActions from '../../app/actions/qualified-teams-scoring-actions';
 import { revalidatePath } from 'next/cache';
 
 // Mock functions
@@ -386,6 +392,8 @@ const mockCustomToMap = vi.mocked(objectUtils.customToMap);
 const mockToMap = vi.mocked(objectUtils.toMap);
 
 const mockDb = vi.mocked(database.db);
+
+const mockCalculateAndStoreQualifiedTeamsScores = vi.mocked(qualifiedTeamsScoringActions.calculateAndStoreQualifiedTeamsScores);
 
 const mockFindAllUsers = vi.mocked(usersRepository.findAllUsers);
 const mockFindUserIdsForTournament = vi.mocked(tournamentViewPermissionRepository.findUserIdsForTournament);
@@ -1620,7 +1628,126 @@ describe('Backoffice Actions', () => {
     });
   });
 
+  describe('saveGamesAndRecalculate', () => {
+    function setupCommonMocks() {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
+      mockFindGameResultByGameId.mockResolvedValue(undefined);
+      mockCreateGameResult.mockResolvedValue(undefined as any);
+      mockFindAllGuessesForGamesWithResultsInDraft.mockResolvedValue([]);
+      mockFindAllGamesWithPublishedResultsAndGameGuesses.mockResolvedValue([]);
+      mockFindPlayoffStagesWithGamesInTournament.mockResolvedValue([
+        { id: 'stage-1', games: [], round_order: 1, is_final: false } as any
+      ]);
+      mockCalculatePlayoffTeams.mockResolvedValue({});
+      mockFindGroupsWithGamesAndTeamsInTournament.mockResolvedValue([]);
+      mockFindGamesInTournament.mockResolvedValue([]);
+      mockFindGameResultByGameIds.mockResolvedValue([]);
+      mockCustomToMap.mockReturnValue({});
+      mockToMap.mockReturnValue({});
+    }
+
+    it('throws Unauthorized when user is not admin', async () => {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockRegularUser } as any);
+      const game = testFactories.game({ id: 'game-1' });
+      await expect(saveGamesAndRecalculate([game as any], 'tournament-1', 'en')).rejects.toThrow();
+    });
+
+    it('calls saveGameResults with the provided games', async () => {
+      setupCommonMocks();
+      const game = testFactories.game({ id: 'game-1', tournament_id: 'tournament-1' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 1, away_score: 0, is_draft: false });
+      const gameWithResult = { ...game, gameResult, group: null, playoffStage: null };
+
+      await saveGamesAndRecalculate([gameWithResult as any], 'tournament-1', 'en');
+
+      expect(mockCreateGameResult).toHaveBeenCalledWith(
+        expect.objectContaining({ game_id: 'game-1' })
+      );
+    });
+
+    it('calls calculateGameScores for all games including playoff games', async () => {
+      setupCommonMocks();
+      const game = testFactories.game({ id: 'game-1', tournament_id: 'tournament-1' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 2, away_score: 1, is_draft: false });
+      const playoffGame = { ...game, gameResult, group: null, playoffStage: { id: 'stage-1', round_name: 'QF' } };
+
+      await saveGamesAndRecalculate([playoffGame as any], 'tournament-1', 'en');
+
+      expect(mockFindAllGamesWithPublishedResultsAndGameGuesses).toHaveBeenCalled();
+    });
+
+    it('does not call group pipeline for playoff games', async () => {
+      setupCommonMocks();
+      const game = testFactories.game({ id: 'game-1', tournament_id: 'tournament-1' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 2, away_score: 1, is_draft: false });
+      const playoffGame = { ...game, gameResult, group: null, playoffStage: { id: 'stage-1' } };
+
+      await saveGamesAndRecalculate([playoffGame as any], 'tournament-1', 'en');
+
+      expect(mockFindGamesInGroup).not.toHaveBeenCalled();
+      expect(mockFindPlayoffStagesWithGamesInTournament).not.toHaveBeenCalled();
+      expect(mockCalculateAndStoreQualifiedTeamsScores).not.toHaveBeenCalled();
+    });
+
+    it('calls group pipeline for group games', async () => {
+      setupCommonMocks();
+      mockFindGamesInGroup.mockResolvedValue([]);
+      mockFindTeamsInGroup.mockResolvedValue([]);
+      mockFindTournamentById.mockResolvedValue({ tiebreaker_mode: 'standard' } as any);
+      mockCalculateGroupPosition.mockReturnValue([]);
+
+      const game = testFactories.game({ id: 'game-1', tournament_id: 'tournament-1' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 1, away_score: 0, is_draft: false });
+      const groupGame = { ...game, gameResult, group: { tournament_group_id: 'group-1' }, playoffStage: null };
+
+      await saveGamesAndRecalculate([groupGame as any], 'tournament-1', 'en');
+
+      expect(mockFindGamesInGroup).toHaveBeenCalledWith('group-1', true, false);
+      expect(mockFindTeamsInGroup).toHaveBeenCalledWith('group-1');
+      expect(mockFindTournamentById).toHaveBeenCalledWith('tournament-1');
+      expect(mockFindPlayoffStagesWithGamesInTournament).toHaveBeenCalled();
+      expect(mockCalculateAndStoreQualifiedTeamsScores).toHaveBeenCalledWith('tournament-1', 'en');
+    });
+
+    it('uses sortByGamesBetweenTeams=true when tournament.tiebreaker_mode is head_to_head', async () => {
+      setupCommonMocks();
+      mockFindGamesInGroup.mockResolvedValue([]);
+      mockFindTeamsInGroup.mockResolvedValue([{ team_id: 'team-1', conduct_score: 0 } as any]);
+      mockFindTournamentById.mockResolvedValue({ tiebreaker_mode: 'head_to_head' } as any);
+      mockCalculateGroupPosition.mockReturnValue([]);
+
+      const game = testFactories.game({ id: 'game-1', tournament_id: 'tournament-1' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 1, away_score: 0, is_draft: false });
+      const groupGame = { ...game, gameResult, group: { tournament_group_id: 'group-1' }, playoffStage: null };
+
+      await saveGamesAndRecalculate([groupGame as any], 'tournament-1', 'en');
+
+      expect(mockCalculateGroupPosition).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        true,
+        expect.anything()
+      );
+    });
+  });
+
   describe('saveAndPublishSingleGameResult', () => {
+    function setupCommonMocks() {
+      mockFindGameResultByGameId.mockResolvedValue(undefined);
+      mockCreateGameResult.mockResolvedValue(undefined as any);
+      mockFindAllGuessesForGamesWithResultsInDraft.mockResolvedValue([]);
+      mockFindAllGamesWithPublishedResultsAndGameGuesses.mockResolvedValue([]);
+      mockFindPlayoffStagesWithGamesInTournament.mockResolvedValue([
+        { id: 'stage-1', games: [], round_order: 1, is_final: false } as any
+      ]);
+      mockCalculatePlayoffTeams.mockResolvedValue({});
+      mockFindGroupsWithGamesAndTeamsInTournament.mockResolvedValue([]);
+      mockFindGamesInTournament.mockResolvedValue([]);
+      mockFindGameResultByGameIds.mockResolvedValue([]);
+      mockCustomToMap.mockReturnValue({});
+      mockToMap.mockReturnValue({});
+    }
+
     it('throws Unauthorized when user is not admin', async () => {
       mockGetLoggedInUser.mockResolvedValue({ ...mockRegularUser } as any);
 
@@ -1628,21 +1755,52 @@ describe('Backoffice Actions', () => {
       await expect(saveAndPublishSingleGameResult(game as any, 'en')).rejects.toThrow();
     });
 
-    it('calls saveGameResults with is_draft set to false', async () => {
+    it('publishes game result with is_draft set to false', async () => {
       mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
-      mockFindGameResultByGameId.mockResolvedValue(undefined);
-      mockCreateGameResult.mockResolvedValue(undefined as any);
-      mockFindAllGuessesForGamesWithResultsInDraft.mockResolvedValue([]);
+      setupCommonMocks();
 
       const game = testFactories.game({ id: 'game-1', home_team: 'team-1', away_team: 'team-2' });
       const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 2, away_score: 1, is_draft: true });
-      const gameWithResult = { ...game, gameResult, playoffStage: null };
+      const gameWithResult = { ...game, gameResult, group: null, playoffStage: null };
 
       await saveAndPublishSingleGameResult(gameWithResult as any, 'en');
 
       expect(mockCreateGameResult).toHaveBeenCalledWith(
         expect.objectContaining({ is_draft: false })
       );
+    });
+
+    it('calls group pipeline for group-stage games', async () => {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
+      setupCommonMocks();
+      mockFindGamesInGroup.mockResolvedValue([]);
+      mockFindTeamsInGroup.mockResolvedValue([]);
+      mockFindTournamentById.mockResolvedValue({ tiebreaker_mode: 'standard' } as any);
+      mockCalculateGroupPosition.mockReturnValue([]);
+
+      const game = testFactories.game({ id: 'game-1', tournament_id: 'tournament-1' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 1, away_score: 0, is_draft: true });
+      const groupGame = { ...game, gameResult, group: { tournament_group_id: 'group-1' }, playoffStage: null };
+
+      await saveAndPublishSingleGameResult(groupGame as any, 'en');
+
+      expect(mockFindGamesInGroup).toHaveBeenCalledWith('group-1', true, false);
+      expect(mockCalculateAndStoreQualifiedTeamsScores).toHaveBeenCalledWith('tournament-1', 'en');
+    });
+
+    it('does not call group pipeline for playoff-stage games', async () => {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
+      setupCommonMocks();
+
+      const game = testFactories.game({ id: 'game-1', tournament_id: 'tournament-1' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 2, away_score: 1, is_draft: true });
+      const playoffGame = { ...game, gameResult, group: null, playoffStage: { id: 'stage-1' } };
+
+      await saveAndPublishSingleGameResult(playoffGame as any, 'en');
+
+      expect(mockFindGamesInGroup).not.toHaveBeenCalled();
+      expect(mockCalculateAndStoreQualifiedTeamsScores).not.toHaveBeenCalled();
+      expect(mockFindAllGamesWithPublishedResultsAndGameGuesses).toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/actions/backoffice-actions.test.ts
+++ b/__tests__/actions/backoffice-actions.test.ts
@@ -14,10 +14,13 @@ import {
   updateTournamentHonorRoll,
   copyTournament,
   getTournamentPermissionData,
-  updateTournamentPermissions
+  updateTournamentPermissions,
+  getRecentUnscoredGames,
+  saveAndPublishSingleGameResult,
 } from '../../app/actions/backoffice-actions';
 import { GameResult, Tournament, TournamentUpdate } from '../../app/db/tables-definition';
 import { ExtendedGameData, ExtendedGroupData, ExtendedPlayoffRoundData } from '../../app/definitions';
+import { testFactories } from '../db/test-factories';
 
 // Mock the auth module
 vi.mock('../../auth', () => ({
@@ -112,7 +115,12 @@ vi.mock('../../app/db/team-repository', () => ({
   findQualifiedTeams: vi.fn(),
   findTeamInGroup: vi.fn(),
   findTeamInTournament: vi.fn(),
+  findTeamsByIds: vi.fn(),
   getTeamByName: vi.fn(),
+}));
+
+vi.mock('../../app/db/quick-score-repository', () => ({
+  findRecentUnscoredGames: vi.fn(),
 }));
 
 vi.mock('../../app/db/tournament-group-repository', () => ({
@@ -271,6 +279,7 @@ vi.mock('../../app/actions/group-ranking-actions', () => ({
 // Import mocked functions
 import * as tournamentRepository from '../../app/db/tournament-repository';
 import * as teamRepository from '../../app/db/team-repository';
+import * as quickScoreRepository from '../../app/db/quick-score-repository';
 import * as tournamentGroupRepository from '../../app/db/tournament-group-repository';
 import * as tournamentPlayoffRepository from '../../app/db/tournament-playoff-repository';
 import * as gameRepository from '../../app/db/game-repository';
@@ -365,6 +374,8 @@ const mockUpdateTournamentGuess = vi.mocked(tournamentGuessRepository.updateTour
 const mockUpdateTournamentGuessByUserIdTournament = vi.mocked(tournamentGuessRepository.updateTournamentGuessByUserIdTournament);
 
 const mockGetLoggedInUser = vi.mocked(userActions.getLoggedInUser);
+const mockFindTeamsByIds = vi.mocked(teamRepository.findTeamsByIds);
+const mockFindRecentUnscoredGames = vi.mocked(quickScoreRepository.findRecentUnscoredGames);
 
 const mockUpdatePlayoffGameGuesses = vi.mocked(guessesActions.updatePlayoffGameGuesses);
 
@@ -1549,6 +1560,89 @@ describe('Backoffice Actions', () => {
 
         expect(mockAddUsersToTournament).toHaveBeenCalledWith('tournament-123', userIds);
       });
+    });
+  });
+
+  describe('getRecentUnscoredGames', () => {
+    it('throws Unauthorized when user is not admin', async () => {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockRegularUser } as any);
+
+      await expect(getRecentUnscoredGames('en')).rejects.toThrow();
+    });
+
+    it('throws Unauthorized when no session', async () => {
+      mockGetLoggedInUser.mockResolvedValue(null as any);
+
+      await expect(getRecentUnscoredGames('en')).rejects.toThrow();
+    });
+
+    it('returns empty games and teamsMap when no recent unscored games', async () => {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
+      mockFindRecentUnscoredGames.mockResolvedValue([]);
+      mockFindTeamsByIds.mockResolvedValue([]);
+
+      const result = await getRecentUnscoredGames('en');
+
+      expect(result.games).toEqual([]);
+      expect(result.teamsMap).toEqual({});
+      expect(mockFindTeamsByIds).toHaveBeenCalledWith([]);
+    });
+
+    it('returns localized games and teamsMap for valid admin', async () => {
+      const game = testFactories.game({ id: 'game-1', home_team: 'team-1', away_team: 'team-2' });
+      const team1 = testFactories.team({ id: 'team-1' });
+      const team2 = testFactories.team({ id: 'team-2' });
+
+      mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
+      mockFindRecentUnscoredGames.mockResolvedValue([game] as any);
+      mockFindTeamsByIds.mockResolvedValue([team1, team2]);
+
+      const result = await getRecentUnscoredGames('en');
+
+      expect(result.games).toHaveLength(1);
+      expect(result.teamsMap).toHaveProperty('team-1');
+      expect(result.teamsMap).toHaveProperty('team-2');
+    });
+
+    it('builds teamsMap with all teams referenced by returned games', async () => {
+      const game = testFactories.game({ id: 'game-1', home_team: 'team-1', away_team: 'team-2' });
+      const team1 = testFactories.team({ id: 'team-1', name: 'Spain' });
+      const team2 = testFactories.team({ id: 'team-2', name: 'France' });
+
+      mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
+      mockFindRecentUnscoredGames.mockResolvedValue([game] as any);
+      mockFindTeamsByIds.mockResolvedValue([team1, team2]);
+
+      const result = await getRecentUnscoredGames('en');
+
+      expect(mockFindTeamsByIds).toHaveBeenCalledWith(expect.arrayContaining(['team-1', 'team-2']));
+      expect(Object.keys(result.teamsMap)).toHaveLength(2);
+    });
+  });
+
+  describe('saveAndPublishSingleGameResult', () => {
+    it('throws Unauthorized when user is not admin', async () => {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockRegularUser } as any);
+
+      const game = testFactories.game({ id: 'game-1' });
+      await expect(saveAndPublishSingleGameResult(game as any, 'en')).rejects.toThrow();
+    });
+
+    it('calls saveGameResults with is_draft set to false', async () => {
+      mockGetLoggedInUser.mockResolvedValue({ ...mockAdminUser } as any);
+      mockFindGameResultByGameId.mockResolvedValue(undefined);
+      mockCreateGameResult.mockResolvedValue(undefined as any);
+      mockFindAllGuessesForGamesWithResultsInDraft.mockResolvedValue([]);
+
+      const game = testFactories.game({ id: 'game-1', home_team: 'team-1', away_team: 'team-2' });
+      const gameResult = testFactories.gameResult({ game_id: 'game-1', home_score: 2, away_score: 1, is_draft: true });
+      const gameWithResult = { ...game, gameResult, playoffStage: null };
+
+      await saveAndPublishSingleGameResult(gameWithResult as any, 'en');
+
+      expect(mockCreateGameResult).toHaveBeenCalledWith(
+        expect.objectContaining({ is_draft: false })
+      );
     });
   });
 });

--- a/__tests__/components/backoffice/group-backoffice-tab.test.tsx
+++ b/__tests__/components/backoffice/group-backoffice-tab.test.tsx
@@ -13,13 +13,15 @@ vi.mock('@/app/actions/tournament-actions', () => ({
 
 // Mock backoffice actions
 vi.mock('@/app/actions/backoffice-actions', () => ({
-  saveGameResults: vi.fn().mockResolvedValue(undefined),
-  calculateAndSavePlayoffGamesForTournament: vi.fn().mockResolvedValue(undefined),
+  saveGamesAndRecalculate: vi.fn().mockResolvedValue(undefined),
   saveGamesData: vi.fn().mockResolvedValue(undefined),
   calculateAndStoreGroupPosition: vi.fn().mockResolvedValue(undefined),
   calculateGameScores: vi.fn().mockResolvedValue(undefined),
-  calculateAndStoreQualifiedTeamsPoints: vi.fn().mockResolvedValue(undefined),
   updateGroupTeamConductScores: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/app/actions/qualified-teams-scoring-actions', () => ({
+  calculateAndStoreQualifiedTeamsScores: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock child components
@@ -89,12 +91,10 @@ vi.mock('@/app/components/skeletons', () => ({
 // Import mocked modules
 import { getCompleteGroupData } from '@/app/actions/tournament-actions';
 import {
-  saveGameResults,
-  calculateAndSavePlayoffGamesForTournament,
+  saveGamesAndRecalculate,
   saveGamesData,
   calculateAndStoreGroupPosition,
   calculateGameScores,
-  calculateAndStoreQualifiedTeamsPoints,
   updateGroupTeamConductScores,
 } from '@/app/actions/backoffice-actions';
 
@@ -335,7 +335,7 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(saveGameResults).toHaveBeenCalled();
+        expect(saveGamesAndRecalculate).toHaveBeenCalled();
       });
 
       // Game card should still be rendered with updated data
@@ -355,11 +355,11 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(saveGameResults).toHaveBeenCalled();
+        expect(saveGamesAndRecalculate).toHaveBeenCalled();
       });
 
       // Verify the updated games map is used for recalculation (all games, not just the updated one)
-      const savedGames = vi.mocked(saveGameResults).mock.calls[0][0];
+      const [savedGames] = vi.mocked(saveGamesAndRecalculate).mock.calls[0];
       expect(savedGames).toEqual(expect.arrayContaining([
         expect.objectContaining({ id: 'game-1' }),
         expect.objectContaining({ id: 'game-2' }),
@@ -383,10 +383,10 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(publishButton);
 
       await waitFor(() => {
-        expect(saveGameResults).toHaveBeenCalled();
+        expect(saveGamesAndRecalculate).toHaveBeenCalled();
       });
 
-      const savedGames = vi.mocked(saveGameResults).mock.calls[0][0];
+      const [savedGames] = vi.mocked(saveGamesAndRecalculate).mock.calls[0];
       const updatedGame = savedGames.find((g) => g.id === 'game-1');
 
       // Game result should have is_draft toggled to false
@@ -407,10 +407,10 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(publishButton);
 
       await waitFor(() => {
-        expect(saveGameResults).toHaveBeenCalled();
+        expect(saveGamesAndRecalculate).toHaveBeenCalled();
       });
 
-      const savedGames = vi.mocked(saveGameResults).mock.calls[0][0];
+      const [savedGames] = vi.mocked(saveGamesAndRecalculate).mock.calls[0];
       const updatedGame = savedGames.find((g) => g.id === 'game-2');
 
       // Game result should have is_draft toggled to true
@@ -432,7 +432,7 @@ describe('GroupBackoffice Integration Tests', () => {
 
       // Should not attempt to save since game has no result
       await waitFor(() => {
-        expect(saveGameResults).not.toHaveBeenCalled();
+        expect(saveGamesAndRecalculate).not.toHaveBeenCalled();
       }, { timeout: 500 });
     });
   });
@@ -861,7 +861,7 @@ describe('GroupBackoffice Integration Tests', () => {
   });
 
   describe('Group Position Recalculation', () => {
-    it('should use tiebreakerMode prop in recalculation', async () => {
+    it('should call saveGamesAndRecalculate when a game is saved', async () => {
       renderWithTheme(
         <GroupBackoffice group={extendedGroup} tournamentId={tournament.id} tiebreakerMode="head_to_head" />
       );
@@ -874,16 +874,15 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(calculateAndStoreGroupPosition).toHaveBeenCalledWith(
-          group.id,
+        expect(saveGamesAndRecalculate).toHaveBeenCalledWith(
           expect.any(Array),
-          expect.any(Array),
-          true // tiebreakerMode === 'head_to_head'
+          tournament.id,
+          expect.any(String)
         );
       });
     });
 
-    it('should recalculate positions whenever games are saved', async () => {
+    it('should recalculate via saveGamesAndRecalculate on every save', async () => {
       renderWithTheme(
         <GroupBackoffice group={extendedGroup} tournamentId={tournament.id} />
       );
@@ -896,7 +895,7 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(saveButton1);
 
       await waitFor(() => {
-        expect(calculateAndStoreGroupPosition).toHaveBeenCalledTimes(1);
+        expect(saveGamesAndRecalculate).toHaveBeenCalledTimes(1);
       });
 
       vi.clearAllMocks();
@@ -905,7 +904,7 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(saveButton2);
 
       await waitFor(() => {
-        expect(calculateAndStoreGroupPosition).toHaveBeenCalledTimes(1);
+        expect(saveGamesAndRecalculate).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -948,7 +947,7 @@ describe('GroupBackoffice Integration Tests', () => {
       await user.click(saveButton);
 
       await waitFor(() => {
-        expect(saveGameResults).toHaveBeenCalled();
+        expect(saveGamesAndRecalculate).toHaveBeenCalled();
       });
 
       // Snackbar should not appear for game saves (only for conduct scores)

--- a/__tests__/components/header/quick-score-wizard-dialog.test.tsx
+++ b/__tests__/components/header/quick-score-wizard-dialog.test.tsx
@@ -1,0 +1,188 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import QuickScoreWizardDialog from '../../../app/components/header/quick-score-wizard-dialog';
+import { testFactories } from '../../db/test-factories';
+
+// Mock server actions
+vi.mock('../../../app/actions/backoffice-actions', () => ({
+  getRecentUnscoredGames: vi.fn(),
+  saveAndPublishSingleGameResult: vi.fn(),
+}));
+
+// Mock BackofficeGameResultEditControls
+vi.mock('../../../app/components/backoffice/backoffice-game-result-edit-controls', () => ({
+  default: ({ homeTeamName, awayTeamName, error, onSave, onCancel, loading }: any) => (
+    <div data-testid="score-controls">
+      <span data-testid="home-team">{homeTeamName}</span>
+      <span data-testid="away-team">{awayTeamName}</span>
+      {error && <span data-testid="save-error">{error}</span>}
+      <button data-testid="save-btn" onClick={onSave} disabled={loading}>Guardar</button>
+      <button data-testid="cancel-btn" onClick={onCancel} disabled={loading}>Cancelar</button>
+    </div>
+  ),
+}));
+
+import * as backofficeActions from '../../../app/actions/backoffice-actions';
+
+const mockGetRecentUnscoredGames = vi.mocked(backofficeActions.getRecentUnscoredGames);
+const mockSaveAndPublish = vi.mocked(backofficeActions.saveAndPublishSingleGameResult);
+
+function makeGame(id: string) {
+  return {
+    ...testFactories.game({ id, home_team: 'team-1', away_team: 'team-2' }),
+    group: { tournament_group_id: 'g1', group_letter: 'A' },
+    playoffStage: null,
+    gameResult: null,
+  };
+}
+
+const teamsMap = {
+  'team-1': testFactories.team({ id: 'team-1', name: 'Spain' }),
+  'team-2': testFactories.team({ id: 'team-2', name: 'France' }),
+};
+
+describe('QuickScoreWizardDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders loading state immediately on open before server action resolves', async () => {
+    // Never resolves
+    mockGetRecentUnscoredGames.mockReturnValue(new Promise(() => {}));
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Cargando partidos...')).toBeInTheDocument();
+  });
+
+  it('renders empty state when getRecentUnscoredGames returns no games', async () => {
+    mockGetRecentUnscoredGames.mockResolvedValue({ games: [], teamsMap: {} });
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('¡Todo al día!')).toBeInTheDocument();
+    });
+    expect(screen.getByText('No hay partidos sin resultado en las últimas 24 horas.')).toBeInTheDocument();
+  });
+
+  it('renders score controls for first game when games are returned', async () => {
+    const games = [makeGame('g1'), makeGame('g2')];
+    mockGetRecentUnscoredGames.mockResolvedValue({ games, teamsMap });
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('score-controls')).toBeInTheDocument();
+    });
+  });
+
+  it('renders home and away team names from teamsMap', async () => {
+    const games = [makeGame('g1')];
+    mockGetRecentUnscoredGames.mockResolvedValue({ games, teamsMap });
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-team')).toHaveTextContent('Spain');
+      expect(screen.getByTestId('away-team')).toHaveTextContent('France');
+    });
+  });
+
+  it('Skip advances to next game without calling saveAndPublishSingleGameResult', async () => {
+    const games = [makeGame('g1'), makeGame('g2')];
+    mockGetRecentUnscoredGames.mockResolvedValue({ games, teamsMap });
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-btn'));
+
+    expect(mockSaveAndPublish).not.toHaveBeenCalled();
+  });
+
+  it('shows completion state after all games are skipped', async () => {
+    const games = [makeGame('g1')];
+    mockGetRecentUnscoredGames.mockResolvedValue({ games, teamsMap });
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cancel-btn')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('cancel-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByText('¡Todo al día!')).toBeInTheDocument();
+    });
+  });
+
+  it('Save & Publish calls saveAndPublishSingleGameResult and advances to next game', async () => {
+    const games = [makeGame('g1'), makeGame('g2')];
+    mockGetRecentUnscoredGames.mockResolvedValue({ games, teamsMap });
+    mockSaveAndPublish.mockResolvedValue(undefined);
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('save-btn')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('save-btn'));
+    });
+
+    expect(mockSaveAndPublish).toHaveBeenCalledTimes(1);
+    // After save, should still show controls (now on game 2)
+    await waitFor(() => {
+      expect(screen.getByTestId('score-controls')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error from saveAndPublishSingleGameResult without advancing', async () => {
+    const games = [makeGame('g1')];
+    mockGetRecentUnscoredGames.mockResolvedValue({ games, teamsMap });
+    mockSaveAndPublish.mockRejectedValue(new Error('Cannot publish incomplete result'));
+
+    render(<QuickScoreWizardDialog open={true} onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('save-btn')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('save-btn'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('save-error')).toHaveTextContent('Cannot publish incomplete result');
+    });
+    // Still on same game (score controls still visible)
+    expect(screen.getByTestId('score-controls')).toBeInTheDocument();
+  });
+
+  it('does not load games when dialog is closed', () => {
+    render(<QuickScoreWizardDialog open={false} onClose={vi.fn()} />);
+
+    expect(mockGetRecentUnscoredGames).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when close button is clicked in empty state', async () => {
+    const onClose = vi.fn();
+    mockGetRecentUnscoredGames.mockResolvedValue({ games: [], teamsMap: {} });
+
+    render(<QuickScoreWizardDialog open={true} onClose={onClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cerrar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Cerrar'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/header/user-actions.test.tsx
+++ b/__tests__/components/header/user-actions.test.tsx
@@ -26,9 +26,20 @@ vi.mock('next-intl', () => ({
       'header.userMenu.logout': 'Salir',
       'header.userMenu.deleteAccount': 'Delete Account',
       'header.userMenu.backoffice': 'Ir al Back Office',
+      'header.userMenu.fillLatestScores': 'Fill Latest Scores',
     };
     return translations[key] || key;
   },
+}));
+
+// Mock QuickScoreWizardDialog
+vi.mock('../../../app/components/header/quick-score-wizard-dialog', () => ({
+  default: ({ open, onClose }: any) => (
+    <div data-testid="quick-score-wizard-dialog">
+      <span data-testid="quick-score-wizard-open">{open ? 'true' : 'false'}</span>
+      <button data-testid="close-wizard" onClick={onClose}>Close Wizard</button>
+    </div>
+  ),
 }));
 
 // Mock next-auth/react
@@ -301,13 +312,44 @@ describe('UserActions', () => {
         ...mockUser,
         isAdmin: true,
       };
-      
+
       render(<UserActions user={adminUser} />);
-      
+
       fireEvent.click(screen.getByLabelText('Abrir Menu de Usuario'));
       fireEvent.click(screen.getByText('Ir al Back Office'));
-      
+
       expect(mockRouter.push).toHaveBeenCalledWith('/es/backoffice');
+    });
+
+    it('does not render Fill Latest Scores menu item for non-admin user', () => {
+      const regularUser: User = { ...mockUser, isAdmin: false };
+
+      render(<UserActions user={regularUser} />);
+
+      fireEvent.click(screen.getByLabelText('Abrir Menu de Usuario'));
+
+      expect(screen.queryByText('Fill Latest Scores')).not.toBeInTheDocument();
+    });
+
+    it('renders Fill Latest Scores menu item for admin user', () => {
+      const adminUser: User = { ...mockUser, isAdmin: true };
+
+      render(<UserActions user={adminUser} />);
+
+      fireEvent.click(screen.getByLabelText('Abrir Menu de Usuario'));
+
+      expect(screen.getByText('Fill Latest Scores')).toBeInTheDocument();
+    });
+
+    it('opens QuickScoreWizardDialog when Fill Latest Scores is clicked', () => {
+      const adminUser: User = { ...mockUser, isAdmin: true };
+
+      render(<UserActions user={adminUser} />);
+
+      fireEvent.click(screen.getByLabelText('Abrir Menu de Usuario'));
+      fireEvent.click(screen.getByText('Fill Latest Scores'));
+
+      expect(screen.getByTestId('quick-score-wizard-open')).toHaveTextContent('true');
     });
 
     it('navigates to delete account page when delete account is clicked', () => {

--- a/__tests__/db/quick-score-repository.test.ts
+++ b/__tests__/db/quick-score-repository.test.ts
@@ -1,0 +1,97 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { findRecentUnscoredGames } from '../../app/db/quick-score-repository';
+import { db } from '../../app/db/database';
+import { testFactories } from './test-factories';
+import { createMockSelectQuery } from './mock-helpers';
+
+vi.mock('../../app/db/database', () => ({
+  db: {
+    selectFrom: vi.fn(),
+  },
+}));
+
+vi.mock('kysely/helpers/postgres', () => ({
+  jsonObjectFrom: vi.fn().mockReturnValue({ as: vi.fn().mockReturnValue(null) }),
+}));
+
+vi.mock('kysely', async () => {
+  const actual = await vi.importActual('kysely') as any;
+  return {
+    ...actual,
+    sql: Object.assign(
+      vi.fn().mockReturnValue({}),
+      { raw: vi.fn().mockReturnValue({}) }
+    ),
+  };
+});
+
+describe('Quick Score Repository', () => {
+  const mockDb = vi.mocked(db);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('findRecentUnscoredGames', () => {
+    it('returns empty array when no games exist in the 24h window', async () => {
+      const mockQuery = createMockSelectQuery([]);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      const result = await findRecentUnscoredGames(24);
+
+      expect(result).toEqual([]);
+      expect(mockQuery.execute).toHaveBeenCalled();
+    });
+
+    it('returns games from the given time window', async () => {
+      const game = testFactories.game({ id: 'game-1' });
+      const mockQuery = createMockSelectQuery([game]);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      const result = await findRecentUnscoredGames(24);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('game-1');
+    });
+
+    it('calls selectFrom on games table', async () => {
+      const mockQuery = createMockSelectQuery([]);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      await findRecentUnscoredGames(24);
+
+      expect(mockDb.selectFrom).toHaveBeenCalledWith('games');
+    });
+
+    it('applies leftJoin to filter out published results', async () => {
+      const mockQuery = createMockSelectQuery([]);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      await findRecentUnscoredGames(24);
+
+      expect(mockQuery.leftJoin).toHaveBeenCalled();
+    });
+
+    it('orders results by game_date ascending', async () => {
+      const mockQuery = createMockSelectQuery([]);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      await findRecentUnscoredGames(24);
+
+      expect(mockQuery.orderBy).toHaveBeenCalledWith('games.game_date', 'asc');
+    });
+
+    it('returns multiple games when available', async () => {
+      const games = [
+        testFactories.game({ id: 'game-1' }),
+        testFactories.game({ id: 'game-2' }),
+      ];
+      const mockQuery = createMockSelectQuery(games);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      const result = await findRecentUnscoredGames(24);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/__tests__/db/team-repository.test.ts
+++ b/__tests__/db/team-repository.test.ts
@@ -6,6 +6,7 @@ import {
   findTeamInGroup,
   findGuessedQualifiedTeams,
   findQualifiedTeams,
+  findTeamsByIds,
   createTeam,
   updateTeam,
   deleteTeam,
@@ -378,6 +379,39 @@ describe('Team Repository', () => {
           allGroupsComplete: false,
         });
       });
+    });
+  });
+
+  describe('findTeamsByIds', () => {
+    it('returns empty array without hitting the DB when ids is empty', async () => {
+      const result = await findTeamsByIds([]);
+
+      expect(result).toEqual([]);
+      expect(mockDb.selectFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns matching teams for given ids', async () => {
+      const teams = [
+        testFactories.team({ id: 'team-1' }),
+        testFactories.team({ id: 'team-2' }),
+      ];
+      const mockQuery = createMockSelectQuery(teams);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      const result = await findTeamsByIds(['team-1', 'team-2']);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('team-1');
+    });
+
+    it('returns only found teams when some ids are unknown', async () => {
+      const teams = [testFactories.team({ id: 'team-1' })];
+      const mockQuery = createMockSelectQuery(teams);
+      mockDb.selectFrom.mockReturnValue(mockQuery as any);
+
+      const result = await findTeamsByIds(['team-1', 'unknown-id']);
+
+      expect(result).toHaveLength(1);
     });
   });
 

--- a/app/actions/backoffice-actions.ts
+++ b/app/actions/backoffice-actions.ts
@@ -397,7 +397,7 @@ export async function saveGameResults(gamesWithResults: ExtendedGameData[]) {
 }
 
 export async function getRecentUnscoredGames(locale: string): Promise<{ games: ExtendedGameData[], teamsMap: Record<string, Team> }> {
-  const t = await getTranslations({ locale: locale as Locale, namespace: 'backoffice' });
+  const t = await getTranslations({ locale, namespace: 'backoffice' });
   const user = await getLoggedInUser();
   if (!user?.isAdmin) {
     throw new Error(t('unauthorized'));
@@ -441,7 +441,7 @@ export async function saveGamesAndRecalculate(
     ]);
     const teamIds = groupTeams.map(t => t.team_id);
     const sortByH2H = tournament?.tiebreaker_mode === 'head_to_head';
-    await calculateAndStoreGroupPosition(groupId, teamIds, groupGames as ExtendedGameData[], sortByH2H);
+    await calculateAndStoreGroupPosition(groupId, teamIds, groupGames, sortByH2H);
     await calculateAndSavePlayoffGamesForTournament(tournamentId);
     await calculateAndStoreQualifiedTeamsScores(tournamentId, locale as Locale);
   }
@@ -450,7 +450,7 @@ export async function saveGamesAndRecalculate(
 }
 
 export async function saveAndPublishSingleGameResult(game: ExtendedGameData, locale: string): Promise<void> {
-  const t = await getTranslations({ locale: locale as Locale, namespace: 'backoffice' });
+  const t = await getTranslations({ locale, namespace: 'backoffice' });
   const user = await getLoggedInUser();
   if (!user?.isAdmin) {
     throw new Error(t('unauthorized'));

--- a/app/actions/backoffice-actions.ts
+++ b/app/actions/backoffice-actions.ts
@@ -13,6 +13,7 @@ import {
 import {
   createTeam,
   findTeamInTournament,
+  findTeamsByIds,
   getTeamByName
 } from "../db/team-repository";
 import {
@@ -102,6 +103,7 @@ import {
 import {writeScoreSnapshot} from '../db/score-history-repository';
 import {getTodayYYYYMMDD} from '../utils/date-utils';
 import {recalculateGroupRankingsForUsers} from './group-ranking-actions';
+import {findRecentUnscoredGames} from '../db/quick-score-repository';
 
 
 export async function deleteDBTournamentTree(tournament: Tournament, locale: Locale = 'es') {
@@ -390,6 +392,45 @@ export async function saveGameResults(gamesWithResults: ExtendedGameData[]) {
     // Step 4: Recalculate with new scores (processes published results)
     await calculateGameScores(false, false);
   }
+}
+
+export async function getRecentUnscoredGames(locale: string): Promise<{ games: ExtendedGameData[], teamsMap: Record<string, Team> }> {
+  const t = await getTranslations({ locale: locale as Locale, namespace: 'backoffice' });
+  const user = await getLoggedInUser();
+  if (!user?.isAdmin) {
+    throw new Error(t('unauthorized'));
+  }
+
+  const games = await findRecentUnscoredGames(24);
+  const localizedGames = games.map(game => applyLocalization(game, locale, [
+    { field: 'location', i18nField: 'location_i18n' }
+  ]));
+
+  const uniqueTeamIds = [...new Set(
+    localizedGames.flatMap(g => [g.home_team, g.away_team].filter(Boolean) as string[])
+  )];
+
+  const teams = await findTeamsByIds(uniqueTeamIds);
+  const localizedTeams = teams.map(team => applyLocalization(team, locale, [
+    { field: 'name', i18nField: 'name_i18n' }
+  ]));
+  const teamsMap: Record<string, Team> = Object.fromEntries(localizedTeams.map(t => [t.id, t]));
+
+  return { games: localizedGames, teamsMap };
+}
+
+export async function saveAndPublishSingleGameResult(game: ExtendedGameData, locale: string): Promise<void> {
+  const t = await getTranslations({ locale: locale as Locale, namespace: 'backoffice' });
+  const user = await getLoggedInUser();
+  if (!user?.isAdmin) {
+    throw new Error(t('unauthorized'));
+  }
+
+  const publishedGame: ExtendedGameData = {
+    ...game,
+    gameResult: game.gameResult ? { ...game.gameResult, is_draft: false } : game.gameResult,
+  };
+  await saveGameResults([publishedGame]);
 }
 
 export async function saveGamesData(games: ExtendedGameData[]) {

--- a/app/actions/backoffice-actions.ts
+++ b/app/actions/backoffice-actions.ts
@@ -40,6 +40,7 @@ import {
 import {
   createGame,
   deleteAllGamesFromTournament, findAllGamesWithPublishedResultsAndGameGuesses,
+  findGamesInGroup,
   findGamesInTournament,
   updateGame
 } from "../db/game-repository";
@@ -104,6 +105,7 @@ import {writeScoreSnapshot} from '../db/score-history-repository';
 import {getTodayYYYYMMDD} from '../utils/date-utils';
 import {recalculateGroupRankingsForUsers} from './group-ranking-actions';
 import {findRecentUnscoredGames} from '../db/quick-score-repository';
+import {calculateAndStoreQualifiedTeamsScores} from './qualified-teams-scoring-actions';
 
 
 export async function deleteDBTournamentTree(tournament: Tournament, locale: Locale = 'es') {
@@ -419,6 +421,34 @@ export async function getRecentUnscoredGames(locale: string): Promise<{ games: E
   return { games: localizedGames, teamsMap };
 }
 
+export async function saveGamesAndRecalculate(
+  games: ExtendedGameData[],
+  tournamentId: string,
+  locale: string
+): Promise<void> {
+  const user = await getLoggedInUser();
+  if (!user?.isAdmin) throw new Error('Unauthorized');
+
+  await saveGameResults(games);
+
+  const groupGame = games.find(g => g.group);
+  if (groupGame) {
+    const groupId = groupGame.group!.tournament_group_id;
+    const [groupGames, groupTeams, tournament] = await Promise.all([
+      findGamesInGroup(groupId, true, false),
+      findTeamsInGroup(groupId),
+      findTournamentById(tournamentId),
+    ]);
+    const teamIds = groupTeams.map(t => t.team_id);
+    const sortByH2H = tournament?.tiebreaker_mode === 'head_to_head';
+    await calculateAndStoreGroupPosition(groupId, teamIds, groupGames as ExtendedGameData[], sortByH2H);
+    await calculateAndSavePlayoffGamesForTournament(tournamentId);
+    await calculateAndStoreQualifiedTeamsScores(tournamentId, locale as Locale);
+  }
+
+  await calculateGameScores(false, false, locale as Locale);
+}
+
 export async function saveAndPublishSingleGameResult(game: ExtendedGameData, locale: string): Promise<void> {
   const t = await getTranslations({ locale: locale as Locale, namespace: 'backoffice' });
   const user = await getLoggedInUser();
@@ -430,7 +460,7 @@ export async function saveAndPublishSingleGameResult(game: ExtendedGameData, loc
     ...game,
     gameResult: game.gameResult ? { ...game.gameResult, is_draft: false } : game.gameResult,
   };
-  await saveGameResults([publishedGame]);
+  await saveGamesAndRecalculate([publishedGame], publishedGame.tournament_id, locale);
 }
 
 export async function saveGamesData(games: ExtendedGameData[]) {

--- a/app/components/backoffice/group-backoffice-tab.tsx
+++ b/app/components/backoffice/group-backoffice-tab.tsx
@@ -15,10 +15,9 @@ import {
 import BackofficeFlippableGameCard from "./backoffice-flippable-game-card";
 import BulkActionsMenu from "./bulk-actions-menu";
 import {
-  calculateAndSavePlayoffGamesForTournament,
   calculateAndStoreGroupPosition,
   calculateGameScores,
-  saveGameResults,
+  saveGamesAndRecalculate,
   saveGamesData,
   updateGroupTeamConductScores,
 } from "../../actions/backoffice-actions";
@@ -82,13 +81,9 @@ export default function GroupBackoffice({group, tournamentId, tiebreakerMode = '
 
   }, [teamsMap, gamesMap, setPositions, tiebreakerMode, conductScores]);
 
-  const saveGamesAndRecalculate = async (newGamesMap: {[k: string]: ExtendedGameData}) => {
-    await saveGameResults(Object.values(newGamesMap))
-    await calculateAndSavePlayoffGamesForTournament(tournamentId)
+  const handleSaveAndRecalculate = async (newGamesMap: {[k: string]: ExtendedGameData}) => {
+    await saveGamesAndRecalculate(Object.values(newGamesMap), tournamentId, locale)
     await saveGamesData(Object.values(newGamesMap))
-    await calculateAndStoreGroupPosition(group.id, Object.keys(teamsMap), Object.values(newGamesMap), tiebreakerMode === 'head_to_head')
-    await calculateGameScores(false, false, locale)
-    await calculateAndStoreQualifiedTeamsScores(tournamentId)
     setSaved(false)
   }
 
@@ -97,7 +92,7 @@ export default function GroupBackoffice({group, tournamentId, tiebreakerMode = '
       ...gamesMap,
       [updatedGame.id]: updatedGame
     };
-    await saveGamesAndRecalculate(newGamesMap);
+    await handleSaveAndRecalculate(newGamesMap);
     setGamesMap(newGamesMap);
   };
 
@@ -114,7 +109,7 @@ export default function GroupBackoffice({group, tournamentId, tiebreakerMode = '
           }
         }
       };
-      await saveGamesAndRecalculate(newGamesMap);
+      await handleSaveAndRecalculate(newGamesMap);
       setGamesMap(newGamesMap);
     }
   };

--- a/app/components/header/quick-score-wizard-dialog.tsx
+++ b/app/components/header/quick-score-wizard-dialog.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  LinearProgress,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { useLocale, useTranslations } from 'next-intl'
+import { getRecentUnscoredGames, saveAndPublishSingleGameResult } from '../../actions/backoffice-actions'
+import { ExtendedGameData } from '../../definitions'
+import { Team } from '../../db/tables-definition'
+import BackofficeGameResultEditControls from '../backoffice/backoffice-game-result-edit-controls'
+
+type Props = {
+  readonly open: boolean
+  readonly onClose: () => void
+}
+
+export default function QuickScoreWizardDialog({ open, onClose }: Props) {
+  const t = useTranslations('backoffice')
+  const locale = useLocale()
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
+
+  const [games, setGames] = useState<ExtendedGameData[]>([])
+  const [teamsMap, setTeamsMap] = useState<Record<string, Team>>({})
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const [editHomeScore, setEditHomeScore] = useState<number | undefined>()
+  const [editAwayScore, setEditAwayScore] = useState<number | undefined>()
+  const [editHomePenaltyScore, setEditHomePenaltyScore] = useState<number | undefined>()
+  const [editAwayPenaltyScore, setEditAwayPenaltyScore] = useState<number | undefined>()
+
+  useEffect(() => {
+    if (!open) return
+    setLoading(true)
+    setGames([])
+    setCurrentIndex(0)
+    setSaveError(null)
+    getRecentUnscoredGames(locale)
+      .then(({ games: loadedGames, teamsMap: loadedTeamsMap }) => {
+        setGames(loadedGames)
+        setTeamsMap(loadedTeamsMap)
+        resetScoresForGame(loadedGames[0])
+      })
+      .catch(() => setSaveError(t('wizard.saveError')))
+      .finally(() => setLoading(false))
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  useEffect(() => {
+    resetScoresForGame(games[currentIndex])
+    setSaveError(null)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex])
+
+  function resetScoresForGame(game?: ExtendedGameData) {
+    const result = game?.gameResult
+    setEditHomeScore(result?.home_score ?? undefined)
+    setEditAwayScore(result?.away_score ?? undefined)
+    setEditHomePenaltyScore(result?.home_penalty_score ?? undefined)
+    setEditAwayPenaltyScore(result?.away_penalty_score ?? undefined)
+  }
+
+  const currentGame = games[currentIndex]
+  const isDone = !loading && (games.length === 0 || currentIndex >= games.length)
+  const progress = games.length > 0 ? (currentIndex / games.length) * 100 : 0
+
+  const handleSaveAndPublish = async () => {
+    if (!currentGame) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const updatedGame: ExtendedGameData = {
+        ...currentGame,
+        gameResult: {
+          game_id: currentGame.id,
+          ...currentGame.gameResult,
+          home_score: editHomeScore,
+          away_score: editAwayScore,
+          home_penalty_score: editHomePenaltyScore,
+          away_penalty_score: editAwayPenaltyScore,
+          is_draft: false,
+        },
+      }
+      await saveAndPublishSingleGameResult(updatedGame, locale)
+      setCurrentIndex(i => i + 1)
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : t('wizard.saveError'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSkip = () => {
+    setCurrentIndex(i => i + 1)
+  }
+
+  const formatGameDate = (date: Date | string) => {
+    const d = new Date(date)
+    return new Intl.DateTimeFormat(locale === 'es' ? 'es-AR' : 'en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(d)
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen={isMobile}
+      maxWidth="xs"
+      fullWidth
+    >
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1 }}>
+        <Box>
+          <Typography variant="h6" component="span">{t('wizard.title')}</Typography>
+          {!loading && !isDone && (
+            <Typography variant="body2" color="text.secondary">
+              {t('wizard.progress', { current: currentIndex + 1, total: games.length })}
+            </Typography>
+          )}
+        </Box>
+        <IconButton onClick={onClose} size="small" aria-label={t('wizard.close')}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      {!loading && !isDone && (
+        <LinearProgress variant="determinate" value={progress} />
+      )}
+
+      <DialogContent>
+        {loading && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, py: 4 }}>
+            <CircularProgress />
+            <Typography color="text.secondary">{t('wizard.loading')}</Typography>
+          </Box>
+        )}
+
+        {isDone && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, py: 4 }}>
+            <CheckCircleIcon sx={{ fontSize: 56, color: 'success.main' }} />
+            <Typography variant="h6">{t('wizard.emptyTitle')}</Typography>
+            <Typography color="text.secondary" textAlign="center">{t('wizard.emptyDescription')}</Typography>
+            <Button onClick={onClose} variant="outlined" sx={{ mt: 1 }}>
+              {t('wizard.close')}
+            </Button>
+          </Box>
+        )}
+
+        {!loading && !isDone && currentGame && (
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {formatGameDate(currentGame.game_date)}
+              {currentGame.playoffStage && (
+                <> · {currentGame.playoffStage.round_name_i18n?.[locale] ?? currentGame.playoffStage.round_name}</>
+              )}
+            </Typography>
+
+            <BackofficeGameResultEditControls
+              homeTeamName={(currentGame.home_team ? teamsMap[currentGame.home_team]?.name : null) ?? currentGame.home_team ?? ''}
+              awayTeamName={(currentGame.away_team ? teamsMap[currentGame.away_team]?.name : null) ?? currentGame.away_team ?? ''}
+              isPlayoffGame={!!currentGame.playoffStage}
+              homeScore={editHomeScore}
+              awayScore={editAwayScore}
+              homePenaltyScore={editHomePenaltyScore}
+              awayPenaltyScore={editAwayPenaltyScore}
+              onHomeScoreChange={setEditHomeScore}
+              onAwayScoreChange={setEditAwayScore}
+              onHomePenaltyScoreChange={setEditHomePenaltyScore}
+              onAwayPenaltyScoreChange={setEditAwayPenaltyScore}
+              loading={saving}
+              error={saveError}
+              onSave={handleSaveAndPublish}
+              onCancel={handleSkip}
+            />
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/components/header/user-actions.tsx
+++ b/app/components/header/user-actions.tsx
@@ -18,6 +18,7 @@ import {User} from "next-auth";
 import UserSettingsDialog from "../auth/user-settings-dialog";
 import OnboardingDialogClient from "../onboarding/onboarding-dialog-client";
 import { useLocale, useTranslations } from 'next-intl';
+import QuickScoreWizardDialog from './quick-score-wizard-dialog';
 
 type UserActionProps = {
   user?: User
@@ -32,6 +33,7 @@ export default function UserActions({ user }: UserActionProps) {
   const [openLoginDialog, setOpenLoginDialog] = useState(forceOpen);
   const [openNicknameDialog, setOpenNicknameDialog] = useState(false);
   const [openOnboardingDialog, setOpenOnboardingDialog] = useState(false);
+  const [openScoreWizard, setOpenScoreWizard] = useState(false);
   const [anchorElUser, setAnchorElUser] = useState<null | HTMLElement>(null);
   const router = useRouter()
 
@@ -133,6 +135,11 @@ export default function UserActions({ user }: UserActionProps) {
               <Typography textAlign="center">{t('header.userMenu.tutorial')}</Typography>
             </MenuItem>
             {user.isAdmin && (
+              <MenuItem onClick={() => { setOpenScoreWizard(true); handleCloseUserMenu(); }}>
+                {t('header.userMenu.fillLatestScores')}
+              </MenuItem>
+            )}
+            {user.isAdmin && (
               <MenuItem onClick={() => router.push(`/${locale}/backoffice`)}>
                 {t('header.userMenu.backoffice')}
               </MenuItem>
@@ -185,6 +192,10 @@ export default function UserActions({ user }: UserActionProps) {
           onClose={handleCloseOnboarding}
         />
       )}
+      <QuickScoreWizardDialog
+        open={openScoreWizard}
+        onClose={() => setOpenScoreWizard(false)}
+      />
     </>
   )
 }

--- a/app/db/quick-score-repository.ts
+++ b/app/db/quick-score-repository.ts
@@ -1,0 +1,59 @@
+import {db} from "./database";
+import {jsonObjectFrom} from "kysely/helpers/postgres";
+import {sql} from "kysely";
+import {ExtendedGameData} from "../definitions";
+
+/**
+ * Find games across all tournaments that finished recently and have no published result.
+ *
+ * ⚠️ RETURNS RAW DATA - i18n fields must be localized in Server Action
+ * ⚠️ DO NOT add locale parameter to this function
+ * ⚠️ DO NOT apply localization here
+ *
+ * @see applyLocalization() in /app/utils/localization-helper.ts must be called in Server Action layer
+ */
+export async function findRecentUnscoredGames(hoursBack: number): Promise<ExtendedGameData[]> {
+  return await db.selectFrom('games')
+    .selectAll('games')
+    .select((eb) => [
+      jsonObjectFrom(
+        eb.selectFrom('tournament_group_games')
+          .innerJoin('tournament_groups', 'tournament_groups.id', 'tournament_group_games.tournament_group_id')
+          .whereRef('tournament_group_games.game_id', '=', 'games.id')
+          .select([
+            'tournament_group_games.tournament_group_id',
+            'tournament_groups.group_letter'
+          ])
+      ).as('group'),
+      jsonObjectFrom(
+        eb.selectFrom('tournament_playoff_round_games')
+          .innerJoin('tournament_playoff_rounds',
+            'tournament_playoff_rounds.id',
+            'tournament_playoff_round_games.tournament_playoff_round_id')
+          .whereRef('tournament_playoff_round_games.game_id', '=', 'games.id')
+          .select([
+            'tournament_playoff_round_games.tournament_playoff_round_id',
+            'tournament_playoff_rounds.round_name',
+            'tournament_playoff_rounds.round_name_i18n',
+            'tournament_playoff_rounds.is_final',
+            'tournament_playoff_rounds.is_third_place'
+          ])
+      ).as('playoffStage'),
+      jsonObjectFrom(
+        eb.selectFrom('game_results')
+          .whereRef('game_results.game_id', '=', 'games.id')
+          .where('game_results.is_draft', '=', true)
+          .selectAll()
+      ).as('gameResult')
+    ])
+    .leftJoin('game_results as published_results', (join) =>
+      join
+        .onRef('published_results.game_id', '=', 'games.id')
+        .on('published_results.is_draft', '=', false)
+    )
+    .where('published_results.game_id', 'is', null)
+    .where('games.game_date', '>=', sql<Date>`NOW() - INTERVAL '${sql.raw(String(hoursBack))} hours'`)
+    .where('games.game_date', '<=', sql<Date>`NOW()`)
+    .orderBy('games.game_date', 'asc')
+    .execute() as ExtendedGameData[]
+}

--- a/app/db/team-repository.ts
+++ b/app/db/team-repository.ts
@@ -265,3 +265,20 @@ export const findQualifiedTeams = cache(async (tournamentId: string, inGroupId?:
   };
 })
 
+/**
+ * Find teams by a list of IDs.
+ *
+ * ⚠️ RETURNS RAW DATA - i18n fields must be localized in Server Action
+ * ⚠️ DO NOT add locale parameter to this function
+ * ⚠️ DO NOT apply localization here
+ *
+ * @see applyLocalization() in /app/utils/localization-helper.ts must be called in Server Action layer
+ */
+export async function findTeamsByIds(ids: string[]): Promise<Team[]> {
+  if (ids.length === 0) return []
+  return await db.selectFrom(tableName)
+    .where('id', 'in', ids)
+    .selectAll()
+    .execute()
+}
+

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-06-11
+**Last updated:** 2026-06-15
 
 ---
 

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -21,8 +21,10 @@ Administrative tournament management — full lifecycle operations: tournament c
   Calls: findGameResultByGameId, updateGameResult, createGameResult, calculateGameScores, isGameResultPublishable
 - **getRecentUnscoredGames(locale: string)**: `Promise<{ games: ExtendedGameData[], teamsMap: Record<string, Team> }>` — Returns games from the last 24h across all tournaments with no published result, localized. Admin-only.
   Calls: getLoggedInUser, findRecentUnscoredGames, applyLocalization, findTeamsByIds
-- **saveAndPublishSingleGameResult(game: ExtendedGameData, locale: string)**: `Promise<void>` — Sets is_draft=false on the game result and delegates to saveGameResults. Admin-only.
-  Calls: getLoggedInUser, saveGameResults
+- **saveGamesAndRecalculate(games: ExtendedGameData[], tournamentId: string, locale: string)**: `Promise<void>` — Saves game results and runs the full recalculation pipeline. For group games: updates standings, advances playoff bracket, and recalculates qualified-team scores. For all games: recalculates user prediction scores. Admin-only.
+  Calls: getLoggedInUser, saveGameResults, findGamesInGroup, findTeamsInGroup, findTournamentById, calculateAndStoreGroupPosition, calculateAndSavePlayoffGamesForTournament, calculateAndStoreQualifiedTeamsScores, calculateGameScores
+- **saveAndPublishSingleGameResult(game: ExtendedGameData, locale: string)**: `Promise<void>` — Sets is_draft=false on the game result and runs the full recalculation pipeline via saveGamesAndRecalculate. Admin-only.
+  Calls: getLoggedInUser, saveGamesAndRecalculate
 - **saveGamesData(games)**: `Promise<void>` — Saves game scheduling data (teams, dates).
   Calls: updateGame
 - **calculateAndSavePlayoffGamesForTournament(tournamentId)**: `Promise<void>` — Calculates playoff team assignments from group standings.

--- a/docs/code-structure/actions.md
+++ b/docs/code-structure/actions.md
@@ -19,6 +19,10 @@ Administrative tournament management — full lifecycle operations: tournament c
   Calls: findTournamentByName, deleteDBTournamentTree, createTournament, getTeamByName, createTeam, createTournamentTeam, createTournamentGroup, createTournamentGroupTeam, createPlayoffRound, createGame, createTournamentGroupGame, createPlayoffRoundGame
 - **saveGameResults(gamesWithResults)**: `Promise<void>` — Saves game results with special handling when a published result changes. Throws if any result is being published (`is_draft: false`) but fails `isGameResultPublishable` (missing scores or tied playoff without penalty scores).
   Calls: findGameResultByGameId, updateGameResult, createGameResult, calculateGameScores, isGameResultPublishable
+- **getRecentUnscoredGames(locale: string)**: `Promise<{ games: ExtendedGameData[], teamsMap: Record<string, Team> }>` — Returns games from the last 24h across all tournaments with no published result, localized. Admin-only.
+  Calls: getLoggedInUser, findRecentUnscoredGames, applyLocalization, findTeamsByIds
+- **saveAndPublishSingleGameResult(game: ExtendedGameData, locale: string)**: `Promise<void>` — Sets is_draft=false on the game result and delegates to saveGameResults. Admin-only.
+  Calls: getLoggedInUser, saveGameResults
 - **saveGamesData(games)**: `Promise<void>` — Saves game scheduling data (teams, dates).
   Calls: updateGame
 - **calculateAndSavePlayoffGamesForTournament(tournamentId)**: `Promise<void>` — Calculates playoff team assignments from group standings.

--- a/docs/code-structure/components/components-backoffice.md
+++ b/docs/code-structure/components/components-backoffice.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-06-11
+**Last updated:** 2026-06-15
 
 ---
 
@@ -124,7 +124,7 @@ Grid of groups with edit action. [Client] group management interface.
 ### app/components/backoffice/group-backoffice-tab.tsx
 Group-specific backoffice with games, standings, and conduct score editing. [Client] group data management.
 - **GroupBackoffice({ group, tournamentId, tiebreakerMode }: Props)**: `JSX.Element` — [Client] Manages games, team standings, and conduct scores for a specific group. Accepts optional `tiebreakerMode?: TiebreakerMode` (default `'standard'`) from parent `GroupsTab`; passes `sortByGamesBetweenTeams = tiebreakerMode === 'head_to_head'` to `calculateGroupPosition` (Story #443). Per-group H2H toggle removed.
-  Calls: getCompleteGroupData, calculateGroupPosition, saveGameResults, calculateAndSavePlayoffGamesForTournament, saveGamesData, calculateAndStoreGroupPosition, calculateGameScores, calculateAndStoreQualifiedTeamsScores, updateGroupTeamConductScores
+  Calls: getCompleteGroupData, calculateGroupPosition, saveGamesAndRecalculate, saveGamesData, calculateAndStoreGroupPosition, calculateGameScores, calculateAndStoreQualifiedTeamsScores, updateGroupTeamConductScores
   Uses: useLocale, useEffect, useState
   Renders: BackofficeFlippableGameCard, BulkActionsMenu, TeamStandingsCards, TeamStatsEditDialog, Button, Grid, Paper, Snackbar, Alert
 

--- a/docs/code-structure/components/components-shared-ui.md
+++ b/docs/code-structure/components/components-shared-ui.md
@@ -82,8 +82,12 @@ Icon button for switching between light and dark themes.
 - `ThemeSwitcher` - [Client] - Uses: `useTheme` (next-themes), `useTranslations` - Renders: Avatar with DarkMode/LightMode icons
 
 **app/components/header/user-actions.tsx**
-User menu displaying login button or user avatar with dropdown menu (settings, tutorial, backoffice, logout, delete account).
-- `UserActions` - [Client] - Calls: `signOut` - Uses: `useSearchParams`, `useRouter`, `useLocale`, `useTranslations` - Renders: UserSettingsDialog, LoginOrSignupDialog, OnboardingDialogClient
+User menu displaying login button or user avatar with dropdown menu (settings, tutorial, fill latest scores (admin), backoffice, logout, delete account).
+- `UserActions` - [Client] - Calls: `signOut` - Uses: `useSearchParams`, `useRouter`, `useLocale`, `useTranslations` - Renders: UserSettingsDialog, LoginOrSignupDialog, OnboardingDialogClient, QuickScoreWizardDialog
+
+**app/components/header/quick-score-wizard-dialog.tsx**
+Full-screen (mobile) / centered (desktop) dialog wizard for scoring recent unscored games one at a time. Admin-only. Loads games on open, shows score inputs, supports Save & Publish and Skip per game.
+- `QuickScoreWizardDialog({ open, onClose })` - [Client] - Calls: `getRecentUnscoredGames`, `saveAndPublishSingleGameResult` - Uses: `useLocale`, `useTranslations('backoffice')`, `useTheme`, `useMediaQuery`, `useState`, `useEffect` - Renders: Dialog, DialogTitle, DialogContent, LinearProgress, Typography, BackofficeGameResultEditControls, Button, CircularProgress, CheckCircleIcon
 
 **app/components/header/language-switcher.tsx**
 Language selector with menu showing English and Español options.

--- a/docs/code-structure/components/components-shared-ui.md
+++ b/docs/code-structure/components/components-shared-ui.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-05-05
+**Last updated:** 2026-06-15
 
 ---
 

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -2,7 +2,7 @@
 
 Part of the CODE-STRUCTURE.md system. See `CODE-STRUCTURE.md` for the full index and call graph.
 
-**Last updated:** 2026-06-11
+**Last updated:** 2026-06-15
 
 ---
 

--- a/docs/code-structure/db.md
+++ b/docs/code-structure/db.md
@@ -237,6 +237,7 @@ Repository for teams table. Manages team records across tournaments. Returns raw
 - **findTeamInGroup(groupId: string)**: `Promise<Team[]>` — Finds teams in group (cached).
 - **findGuessedQualifiedTeams(tournamentId: string, userId: string, inGroupId?: string)**: `Promise<Team[]>` — Finds teams user predicted as qualified (cached).
 - **findQualifiedTeams(tournamentId: string, inGroupId?: string)**: `Promise<QualifiedTeamsResult>` — Finds qualified teams progressively (1st/2nd from complete groups, 3rd when playoff known) (cached).
+- **findTeamsByIds(ids: string[])**: `Promise<Team[]>` — Fetches teams by a list of IDs; returns empty array when ids is empty.
 
 ### app/db/tournament-group-repository.ts
 Repository for tournament_groups and team standings. Manages group structure and standings.
@@ -420,3 +421,8 @@ Repository for admin-only per-user prediction completion stats per tournament (S
 
 - **getUserTournamentCompletionsPaginated(tournamentId: string, page: number, pageSize: number, groupId?: string)**: `Promise<{ rows: UserTournamentCompletionRow[], total: number }>` — Returns paginated users with their prediction stats for a tournament. When groupId is provided, filters to users who are owner or participant of that group (EXISTS subquery). Runs two parallel raw SQL queries: (1) paginated results via a multi-join SELECT (users LEFT JOIN tournament_guesses, game_guesses subquery, qualifier predictions subquery, friend groups subquery, CROSS JOIN game totals and qualifier totals); (2) COUNT matching users. Sort order: total completed items (games+qualifiers+awards) DESC, nickname ASC. Friend groups count shows ALL groups the user belongs to (as owner or participant, across all tournaments — prode_groups has no tournament_id). overallPct denominator = total_games + qualifiers_total + 7; returns 0 when denominator is 0.
   Calls: db
+
+### app/db/quick-score-repository.ts
+Repository for the quick score wizard. Queries games that need scoring across all tournaments, without tournament filter.
+
+- **findRecentUnscoredGames(hoursBack: number)**: `Promise<ExtendedGameData[]>` — Finds games from the last N hours across all tournaments that have no published result. LEFT JOINs game_results to filter out published results; includes group, playoffStage, and draft gameResult subqueries via jsonObjectFrom. Ordered by game_date ASC.

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -29,7 +29,8 @@ export default getRequestConfig(async ({requestLocale}) => {
       'qualified-teams': (await import(`../locales/${locale}/qualified-teams.json`)).default,
       pwa: (await import(`../locales/${locale}/pwa.json`)).default,
       tournament: (await import(`../locales/${locale}/tournament.json`)).default,
-      hub: (await import(`../locales/${locale}/hub.json`)).default
+      hub: (await import(`../locales/${locale}/hub.json`)).default,
+      backoffice: (await import(`../locales/${locale}/backoffice.json`)).default
     }
   };
 });

--- a/locales/en/backoffice.json
+++ b/locales/en/backoffice.json
@@ -14,5 +14,17 @@
     "subscriptionNotFound": "Subscription not found",
     "sendFailed": "Failed to send notification",
     "groupNotFound": "Group not found"
+  },
+  "wizard": {
+    "title": "Fill Latest Scores",
+    "progress": "Game {current} of {total}",
+    "saveAndPublish": "Save & Publish",
+    "skip": "Skip",
+    "emptyTitle": "All caught up!",
+    "emptyDescription": "No unscored games in the last 24 hours.",
+    "loading": "Loading games...",
+    "close": "Close",
+    "saveError": "Failed to save. Please try again.",
+    "penaltyShootout": "Penalty Shootout"
   }
 }

--- a/locales/en/navigation.json
+++ b/locales/en/navigation.json
@@ -10,6 +10,7 @@
       "settings": "Settings",
       "tutorial": "View Tutorial",
       "backoffice": "Go to Back Office",
+      "fillLatestScores": "Fill Latest Scores",
       "logout": "Log Out",
       "deleteAccount": "Delete Account"
     }

--- a/locales/es/backoffice.json
+++ b/locales/es/backoffice.json
@@ -14,5 +14,17 @@
     "subscriptionNotFound": "Suscripción no encontrada",
     "sendFailed": "Error al enviar la notificación",
     "groupNotFound": "Grupo no encontrado"
+  },
+  "wizard": {
+    "title": "Ingresar Últimos Resultados",
+    "progress": "Partido {current} de {total}",
+    "saveAndPublish": "Guardar y Publicar",
+    "skip": "Omitir",
+    "emptyTitle": "¡Todo al día!",
+    "emptyDescription": "No hay partidos sin resultado en las últimas 24 horas.",
+    "loading": "Cargando partidos...",
+    "close": "Cerrar",
+    "saveError": "Error al guardar. Por favor, intenta de nuevo.",
+    "penaltyShootout": "Tanda de Penales"
   }
 }

--- a/locales/es/navigation.json
+++ b/locales/es/navigation.json
@@ -10,6 +10,7 @@
       "settings": "Configuracion",
       "tutorial": "Ver Tutorial",
       "backoffice": "Ir al Back Office",
+      "fillLatestScores": "Ingresar Últimos Resultados",
       "logout": "Salir",
       "deleteAccount": "Eliminar Cuenta"
     }

--- a/plans/STORY-474-context.md
+++ b/plans/STORY-474-context.md
@@ -9,7 +9,7 @@
 - **PR URL:** https://github.com/gvinokur/qatar-prode/pull/475
 
 ## State
-- **Current Phase:** implementing
+- **Current Phase:** review-ready
 - **Plan File:** plans/STORY-474-plan.md
 - **Task File:** plans/STORY-474-tasks.md
 

--- a/plans/STORY-474-context.md
+++ b/plans/STORY-474-context.md
@@ -5,12 +5,13 @@
 - **Story Title:** [Story] Quick score entry wizard for recently finished games
 - **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-474
 - **Branch:** feature/story-474
-- **PR Number:** (fill after PR creation)
-- **PR URL:** (fill after PR creation)
+- **PR Number:** #475
+- **PR URL:** https://github.com/gvinokur/qatar-prode/pull/475
 
 ## State
-- **Current Phase:** planning
+- **Current Phase:** implementing
 - **Plan File:** plans/STORY-474-plan.md
+- **Task File:** plans/STORY-474-tasks.md
 
 ## Quick Summary
 Adds a "Fill Latest Scores" option to the admin avatar menu that opens a step-through wizard showing unscored games from the last 24 hours, one at a time, with a "Save & Publish" action per game. Includes new DB query function, two new server actions, a new dialog component, and i18n translations.

--- a/plans/STORY-474-context.md
+++ b/plans/STORY-474-context.md
@@ -1,0 +1,16 @@
+# Story 474 Context
+
+## Metadata
+- **Story Number:** 474
+- **Story Title:** [Story] Quick score entry wizard for recently finished games
+- **Worktree Path:** /Users/gvinokur/Personal/qatar-prode-story-474
+- **Branch:** feature/story-474
+- **PR Number:** (fill after PR creation)
+- **PR URL:** (fill after PR creation)
+
+## State
+- **Current Phase:** planning
+- **Plan File:** plans/STORY-474-plan.md
+
+## Quick Summary
+Adds a "Fill Latest Scores" option to the admin avatar menu that opens a step-through wizard showing unscored games from the last 24 hours, one at a time, with a "Save & Publish" action per game. Includes new DB query function, two new server actions, a new dialog component, and i18n translations.

--- a/plans/STORY-474-plan.md
+++ b/plans/STORY-474-plan.md
@@ -1,0 +1,493 @@
+# STORY-474 Plan: Quick Score Entry Wizard for Recently Finished Games
+
+## Context
+
+Admins currently need multiple navigation steps to enter scores: open backoffice → find tournament → select group/playoff tab → flip game card → enter score → save → publish. This is painful on mobile after a game finishes.
+
+This story adds a "Fill Latest Scores" shortcut in the avatar menu that opens a step-through wizard showing unscored games from the last 24 hours, one at a time, with a single "Save & Publish" action per game.
+
+---
+
+## Acceptance Criteria
+
+- [ ] "Fill Latest Scores" option in avatar menu (admin only)
+- [ ] Opens full-screen modal (mobile) / dialog (desktop) with unscored games from last 24h
+- [ ] Games shown one at a time with score inputs (existing `BackofficeGameResultEditControls`)
+- [ ] Single "Save & Publish" button saves + publishes atomically, then advances
+- [ ] Admin can Skip a game (stays unscored, advances wizard)
+- [ ] Playoff games with tied scores show penalty score inputs before allowing publish
+- [ ] Empty/completion state when no pending games or all processed
+- [ ] Progress shown ("Game 2 of 5")
+- [ ] Works in English and Spanish
+
+---
+
+## Technical Approach
+
+**Reuse existing score components:** `BackofficeGameResultEditControls` already handles home/away score inputs and penalty shootout detection (shows penalty section when `isPlayoffGame && homeScore === awayScore`). The wizard wraps this component instead of rebuilding score entry.
+
+**Save & Publish flow:** Reuse `saveGameResults([game])` from `backoffice-actions.ts` with `is_draft: false` on the game result. This handles the full pipeline: create/update result + `calculateGameScores` for points recalculation.
+
+**Data loading:** Wizard dialog fetches games lazily on open via a new server action `getRecentUnscoredGames`. Games are from the last 24h across all tournaments where no published result exists.
+
+**State management:** The wizard component tracks `currentIndex` into the loaded games array. Skip and Save both advance the index. Completion state shown when `currentIndex >= games.length`.
+
+---
+
+## Visual Prototypes
+
+### Mobile — Full-Screen Dialog
+
+```
+┌──────────────────────────────────┐
+│  [✕]    Fill Latest Scores       │
+│            Game 2 of 3           │
+│  ██████████████░░░░░░░░░░░░░     │  ← LinearProgress
+├──────────────────────────────────┤
+│                                  │
+│  Jun 13 · 21:00 · Quarter-Final  │  ← Game date + stage
+│                                  │
+│  Spain                  [  2  ]  │
+│  France                 [  2  ]  │
+│                                  │
+│  ─────  Penalty Shootout  ─────  │  ← Only for tied playoff
+│  Spain (Pen.)           [  5  ]  │
+│  France (Pen.)          [  4  ]  │
+│                                  │
+│  ┌─────────────┐ ┌─────────────┐ │
+│  │    Skip     │ │ Save & Pub  │ │
+│  └─────────────┘ └─────────────┘ │
+└──────────────────────────────────┘
+```
+
+### Desktop — Centered Dialog (max-width ~400px)
+
+```
+┌─────────────────────────────────────────┐
+│  Fill Latest Scores                [✕]  │
+│  Game 2 of 3                            │
+│  ████████████████░░░░░░░░░░░            │
+├─────────────────────────────────────────┤
+│                                         │
+│  Jun 13 · 21:00 · Quarter-Final         │
+│                                         │
+│  Spain                        [  2  ]   │
+│  France                       [  2  ]   │
+│                                         │
+│  ────────  Penalty Shootout  ────────   │
+│  Spain (Penalty)              [  5  ]   │
+│  France (Penalty)             [  4  ]   │
+│                                         │
+│                    [Skip]  [Save & Publish] │
+└─────────────────────────────────────────┘
+```
+
+### Empty / Completion State
+
+```
+┌─────────────────────────────────────────┐
+│  Fill Latest Scores                [✕]  │
+├─────────────────────────────────────────┤
+│                                         │
+│               ✓  (CheckCircle, green)   │
+│          All caught up!                 │
+│   No unscored games in the last         │
+│   24 hours.                             │
+│                                         │
+│                            [Close]      │
+└─────────────────────────────────────────┘
+```
+
+### Loading State
+
+```
+┌─────────────────────────────────────────┐
+│  Fill Latest Scores                [✕]  │
+├─────────────────────────────────────────┤
+│                                         │
+│         ⏳ Loading games...             │
+│         (CircularProgress)              │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Files to Create / Modify
+
+### Create
+- `app/db/quick-score-repository.ts` — `findRecentUnscoredGames`
+- `app/components/header/quick-score-wizard-dialog.tsx` — wizard UI
+
+### Modify
+- `app/db/team-repository.ts` — add `findTeamsByIds`
+- `app/actions/backoffice-actions.ts` — add `getRecentUnscoredGames` + `saveAndPublishSingleGameResult`
+- `app/components/header/user-actions.tsx` — add menu item + dialog render
+- `locales/en/backoffice.json` — add `wizard` translation keys
+- `locales/es/backoffice.json` — add `wizard` translation keys (Spanish)
+- `i18n/request.ts` — register `backoffice` namespace (not yet registered, needed for client-side `useTranslations`)
+
+### CODE-STRUCTURE updates (per-task, in same commit as source change)
+- `docs/code-structure/db.md`
+- `docs/code-structure/actions.md`
+- `docs/code-structure/components/components-shared-ui.md`
+- `CODE-STRUCTURE.md` (call graph — new flow added)
+
+---
+
+## Mid-Level Design
+
+### Call Graph Changes
+
+**New flow (Flow 35 — Quick Score Wizard):**
+```
+UserActions (header) → QuickScoreWizardDialog
+  → getRecentUnscoredGames       → findRecentUnscoredGames
+  → saveAndPublishSingleGameResult → saveGameResults → processGameResult
+                                                      → calculateGameScores
+```
+
+---
+
+### `app/db/quick-score-repository.ts` *(new)*
+
+**New functions:**
+
+- **findRecentUnscoredGames(hoursBack: number)**: `Promise<ExtendedGameData[]>`
+  Queries all games across all tournaments where `game_date` is between `NOW() - hoursBack hours` and `NOW()`, and no published result exists (LEFT JOIN `game_results` where row is NULL or `is_draft = true`). Includes `group`, `playoffStage`, and `gameResult` (draft) subqueries using `jsonObjectFrom`, mirroring `findGamesInTournament` structure. Ordered by `game_date ASC`.
+  Calls: none (raw DB query via Kysely)
+  Tests:
+  - returns empty array when no games in the time window
+  - returns only games with game_date in the past 24h
+  - excludes games that already have a published (non-draft) result
+  - includes games that have a draft result (unscored)
+  - includes playoff stage info when game is a playoff game
+
+---
+
+### `app/db/team-repository.ts` *(modified)*
+
+**New functions:**
+
+- **findTeamsByIds(ids: string[])**: `Promise<Team[]>`
+  Fetches teams by a list of IDs. Returns empty array when `ids` is empty.
+  Calls: none
+  Tests:
+  - returns empty array when ids is empty
+  - returns teams matching given ids
+  - ignores unknown ids
+
+---
+
+### `app/actions/backoffice-actions.ts` *(modified)*
+
+**New functions:**
+
+- **getRecentUnscoredGames(locale: string)**: `Promise<{ games: ExtendedGameData[], teamsMap: Record<string, Team> }>`
+  Server Action. Gets all unscored games from last 24h for the score wizard. Checks `user.isAdmin`, calls `findRecentUnscoredGames(24)`, applies localization to games (calls `applyLocalization` for each game via map), collects unique team IDs from `game.home_team` / `game.away_team`, fetches teams via `findTeamsByIds`, applies localization to each team, builds `teamsMap` as `Record<team.id, localizedTeam>`, returns `{ games, teamsMap }`.
+  Calls: getLoggedInUser, findRecentUnscoredGames, applyLocalization (per game and per team), findTeamsByIds
+  Tests:
+  - throws Unauthorized when user is not admin
+  - throws Unauthorized when no session
+  - returns empty games and teamsMap when no recent unscored games
+  - returns localized games and teamsMap for valid admin
+  - teamsMap includes all teams referenced by returned games
+
+- **saveAndPublishSingleGameResult(game: ExtendedGameData, locale: string)**: `Promise<void>`
+  Server Action. Publishes a single game result from the score wizard. Checks `user.isAdmin`, sets `is_draft: false` on the game result, delegates to `saveGameResults([publishedGame])`.
+  Calls: getLoggedInUser, saveGameResults
+  Tests:
+  - throws Unauthorized when user is not admin
+  - calls saveGameResults with is_draft set to false
+  - throws when result is not publishable (e.g., tied playoff without penalty scores)
+
+---
+
+### `app/components/header/quick-score-wizard-dialog.tsx` *(new)*
+
+**New components:**
+
+- **QuickScoreWizardDialog({ open, onClose })**: `JSX.Element`
+  `[Client]` Full-screen (mobile) / centered (desktop) dialog wizard for scoring recent games.
+  
+  State: `games`, `teamsMap`, `currentIndex`, `loading`, `saving`, `saveError`, `editHomeScore`, `editAwayScore`, `editHomePenaltyScore`, `editAwayPenaltyScore`
+  
+  On `open` → `true`: calls `getRecentUnscoredGames(locale)`, populates `games` and `teamsMap`, sets `currentIndex = 0`.
+  
+  On `currentIndex` change: resets edit scores from `games[currentIndex].gameResult` (or undefined for fresh games).
+  
+  `handleSaveAndPublish`: builds updated game object with `is_draft: false` and current edit scores, calls `saveAndPublishSingleGameResult`, on success increments `currentIndex`.
+  
+  `handleSkip`: increments `currentIndex` without saving.
+  
+  Renders:
+  - Loading: `CircularProgress` centered
+  - Empty/completion (`games.length === 0` or `currentIndex >= games.length`): `CheckCircleIcon` + empty state text + Close button
+  - Active game: `LinearProgress` (value = currentIndex/games.length*100), game date header, `BackofficeGameResultEditControls` with current scores + `onSave={handleSaveAndPublish}` + `onCancel={handleSkip}` (skip acts as cancel in the wizard — but separate Skip button for clarity)
+  
+  Layout: `Dialog` with `fullScreen={isMobile}` (uses `useMediaQuery(theme.breakpoints.down('sm'))`), `maxWidth="xs"` on desktop.
+  
+  Calls: getRecentUnscoredGames, saveAndPublishSingleGameResult, useLocale, useTranslations('backoffice'), useTheme, useMediaQuery, useState, useEffect
+  Uses: useLocale, useTranslations('backoffice'), useTheme, useMediaQuery, useState, useEffect
+  Renders: Dialog, DialogTitle, DialogContent, LinearProgress, Typography, BackofficeGameResultEditControls, Button, CircularProgress, CheckCircleIcon
+
+---
+
+### `app/components/header/user-actions.tsx` *(modified)*
+
+**Changed functions:**
+
+- **UserActions({ user })**: adds `openScoreWizard` state, an admin-only `MenuItem` ("Fill Latest Scores") before the Backoffice link, and a `<QuickScoreWizardDialog open={openScoreWizard} onClose={() => setOpenScoreWizard(false)} />` at the bottom. Menu item calls `setOpenScoreWizard(true); handleCloseUserMenu()`.
+  Tests:
+  - (existing tests unchanged)
+  - new: Fill Latest Scores menu item only renders when user.isAdmin is true
+  - new: clicking Fill Latest Scores opens QuickScoreWizardDialog
+
+---
+
+### i18n translations
+
+**`locales/en/backoffice.json`** — add `wizard` key:
+```json
+"wizard": {
+  "title": "Fill Latest Scores",
+  "progress": "Game {current} of {total}",
+  "saveAndPublish": "Save & Publish",
+  "skip": "Skip",
+  "emptyTitle": "All caught up!",
+  "emptyDescription": "No unscored games in the last 24 hours.",
+  "loading": "Loading games...",
+  "close": "Close",
+  "saveError": "Failed to save. Please try again.",
+  "penaltyShootout": "Penalty Shootout"
+}
+```
+
+**`locales/es/backoffice.json`** — add `wizard` key:
+```json
+"wizard": {
+  "title": "Ingresar Últimos Resultados",
+  "progress": "Partido {current} de {total}",
+  "saveAndPublish": "Guardar y Publicar",
+  "skip": "Omitir",
+  "emptyTitle": "¡Todo al día!",
+  "emptyDescription": "No hay partidos sin resultado en las últimas 24 horas.",
+  "loading": "Cargando partidos...",
+  "close": "Cerrar",
+  "saveError": "Error al guardar. Por favor, intenta de nuevo.",
+  "penaltyShootout": "Tanda de Penales"
+}
+```
+
+**`i18n/request.ts`** — add:
+```typescript
+backoffice: (await import(`../locales/${locale}/backoffice.json`)).default,
+```
+
+Note: `backoffice.json` already exists and is used server-side by `backoffice-actions.ts` via `getTranslations`. Registering it here makes it available client-side via `useTranslations('backoffice')` in the wizard dialog.
+
+---
+
+## Implementation Steps
+
+### Wave 1 — DB Layer
+1. Create `app/db/quick-score-repository.ts` with `findRecentUnscoredGames`
+2. Add `findTeamsByIds` to `app/db/team-repository.ts`
+3. Update `docs/code-structure/db.md`
+4. Commit Wave 1
+
+### Wave 2 — Server Actions
+5. Add `getRecentUnscoredGames` and `saveAndPublishSingleGameResult` to `app/actions/backoffice-actions.ts`
+6. Add wizard translations to `locales/en/backoffice.json` and `locales/es/backoffice.json`
+7. Register `backoffice` namespace in `i18n/request.ts`
+8. Update `docs/code-structure/actions.md`
+9. Commit Wave 2
+
+### Wave 3 — UI Components
+10. Create `app/components/header/quick-score-wizard-dialog.tsx`
+11. Add wizard menu item and dialog to `app/components/header/user-actions.tsx`
+12. Update `docs/code-structure/components/components-shared-ui.md`
+13. Update `CODE-STRUCTURE.md` call graph (Flow 35)
+14. Commit Wave 3
+
+---
+
+## Testing Strategy
+
+### Test Infrastructure
+
+All tests use the project's established mock infrastructure:
+
+```typescript
+// Data factories — use for all game/team/result fixtures
+import { testFactories } from '@/__tests__/db/test-factories'
+// e.g. testFactories.game({ game_date: pastDate, tournament_id: 't1' })
+//      testFactories.gameResult({ is_draft: true })
+//      testFactories.team({ id: 'team-1', name: 'Spain' })
+
+// DB query mocks — use for all repository tests
+import { createMockSelectQuery, createMockDatabase } from '@/__tests__/db/mock-helpers'
+// e.g. const mockDb = createMockDatabase()
+//      mockDb.selectFrom.mockReturnValue(createMockSelectQuery([game]))
+
+// Auth mocks — use for server action tests
+import { setupTestMocks } from '@/__tests__/mocks/setup-helpers'
+// e.g. setupTestMocks({ session: true, sessionDefaults: { isAdmin: true } })
+
+// i18n mocks — already wired globally in vitest.setup.ts
+import { mockUseLocale, mockUseTranslations } from '@/__tests__/mocks/next-intl.mocks'
+```
+
+---
+
+### Unit Tests (Vitest)
+
+#### `__tests__/db/quick-score-repository.test.ts`
+
+Setup: `const mockDb = createMockDatabase()` (mocks Kysely chain)
+
+- **returns empty array when no games exist in the 24h window**
+  - Input: `findRecentUnscoredGames(24)` with `mockDb.selectFrom` returning `[]`
+  - Expected: `[]`
+
+- **returns only games whose game_date falls within [NOW - 24h, NOW]**
+  - Setup: 3 games — one 23h ago (in window), one 25h ago (out), one 1h in the future (out)
+  - Input: `findRecentUnscoredGames(24)`
+  - Expected: array with only the 23h-ago game
+
+- **excludes games that have a published (non-draft) result**
+  - Setup: two games in window — one with `gameResult.is_draft = false`, one with no result
+  - Expected: only the unresulted game is returned
+
+- **includes games that have only a draft result (not yet published)**
+  - Setup: game in window with `gameResult.is_draft = true`
+  - Expected: game is returned with its draft `gameResult` attached
+
+- **includes playoff stage info when game is a playoff game**
+  - Setup: game in window with no published result, associated with a playoff round
+  - Expected: returned `ExtendedGameData` has non-null `playoffStage`
+
+#### `__tests__/db/team-repository.test.ts` (new `it` blocks)
+
+- **findTeamsByIds returns empty array when ids is empty**
+  - Input: `findTeamsByIds([])`
+  - Expected: `[]` (no DB call made)
+
+- **findTeamsByIds returns matching teams**
+  - Setup: `mockDb` returns `[testFactories.team({ id: 'team-1' }), testFactories.team({ id: 'team-2' })]`
+  - Input: `findTeamsByIds(['team-1', 'team-2'])`
+  - Expected: array of 2 teams
+
+- **findTeamsByIds ignores unknown ids (returns only found rows)**
+  - Setup: DB returns only 1 team for ids `['team-1', 'unknown-id']`
+  - Expected: array with 1 team
+
+#### `__tests__/actions/backoffice-actions.test.ts` (new `it` blocks)
+
+Setup: `setupTestMocks({ session: true, sessionDefaults: { isAdmin: true } })`
+
+- **getRecentUnscoredGames throws Unauthorized when user is not admin**
+  - Setup: `setupTestMocks({ session: true, sessionDefaults: { isAdmin: false } })`
+  - Input: `getRecentUnscoredGames('en')`
+  - Expected: throws with message matching `backoffice.unauthorized`
+
+- **getRecentUnscoredGames throws Unauthorized when no session**
+  - Setup: `setupTestMocks({ session: false })`
+  - Expected: throws Unauthorized
+
+- **getRecentUnscoredGames returns empty games and empty teamsMap when no recent unscored games**
+  - Setup: `findRecentUnscoredGames` mock returns `[]`, `findTeamsByIds` not called
+  - Input: `getRecentUnscoredGames('en')`
+  - Expected: `{ games: [], teamsMap: {} }`
+
+- **getRecentUnscoredGames returns localized game names and teamsMap**
+  - Setup: `findRecentUnscoredGames` returns `[testFactories.game({ home_team: 'team-1', away_team: 'team-2' })]`; `findTeamsByIds(['team-1', 'team-2'])` returns `[testFactories.team({ id: 'team-1' }), testFactories.team({ id: 'team-2' })]`
+  - Expected: `teamsMap` has keys `'team-1'` and `'team-2'`; teams are localized (applyLocalization applied)
+
+- **saveAndPublishSingleGameResult throws Unauthorized when user is not admin**
+  - Setup: non-admin session
+  - Expected: throws Unauthorized
+
+- **saveAndPublishSingleGameResult calls saveGameResults with is_draft false**
+  - Setup: admin session, `saveGameResults` mocked
+  - Input: game with `gameResult.home_score = 2, away_score = 1, is_draft = true`
+  - Expected: `saveGameResults` called with game where `gameResult.is_draft === false`
+
+- **saveAndPublishSingleGameResult propagates error from saveGameResults (e.g., assertPublishable fails)**
+  - Setup: `saveGameResults` mock throws `'Cannot publish incomplete result'`
+  - Expected: error propagates to caller
+
+#### `__tests__/components/header/quick-score-wizard-dialog.test.tsx`
+
+Setup: import `testFactories`, `setupTestMocks`, mock `getRecentUnscoredGames` and `saveAndPublishSingleGameResult` as vi.fn()
+
+- **renders loading state immediately on open before server action resolves**
+  - Setup: `getRecentUnscoredGames` is a delayed promise (never resolves during test)
+  - Render: `<QuickScoreWizardDialog open={true} onClose={jest.fn()} />`
+  - Expected: "Loading games..." text or CircularProgress visible
+
+- **renders empty state when getRecentUnscoredGames returns no games**
+  - Setup: `getRecentUnscoredGames` resolves with `{ games: [], teamsMap: {} }`
+  - Expected: "All caught up!" text visible; no score inputs
+
+- **renders "Game 1 of 2" progress when 2 games are returned**
+  - Setup: `getRecentUnscoredGames` resolves with `{ games: [game1, game2], teamsMap }`
+  - Expected: progress text "Game 1 of 2" visible; LinearProgress with `value=0`
+
+- **renders score inputs for current game using home/away team names from teamsMap**
+  - Setup: game with `home_team: 'team-1'`, `teamsMap: { 'team-1': { name: 'Spain' }, 'team-2': { name: 'France' } }`
+  - Expected: "Spain" and "France" labels visible in score form
+
+- **Skip advances wizard to next game without calling saveAndPublishSingleGameResult**
+  - Setup: 2 games loaded; user clicks "Skip"
+  - Expected: `saveAndPublishSingleGameResult` not called; "Game 2 of 2" progress shown
+
+- **Save & Publish calls saveAndPublishSingleGameResult and advances to next game**
+  - Setup: 2 games, user enters scores and clicks "Save & Publish"
+  - Expected: `saveAndPublishSingleGameResult` called with first game; "Game 2 of 2" shown
+
+- **shows completion state after all games are processed**
+  - Setup: 1 game, user clicks "Skip"
+  - Expected: completion/empty state shown ("All caught up!")
+
+- **shows error from saveAndPublishSingleGameResult without advancing**
+  - Setup: `saveAndPublishSingleGameResult` rejects with error "Cannot publish incomplete result"
+  - Expected: error string rendered in `BackofficeGameResultEditControls`'s `error` prop area (red typography); progress still shows "Game 1 of 1"; `saveAndPublishSingleGameResult` not called a second time
+
+- **Fill Latest Scores menu item not rendered for non-admin user**
+  - Setup: render `<UserActions user={testFactories.user({ isAdmin: false })} />`; open menu
+  - Expected: "Fill Latest Scores" not in document
+
+- **Fill Latest Scores menu item rendered for admin user**
+  - Setup: render `<UserActions user={testFactories.user({ isAdmin: true })} />`; open menu
+  - Expected: "Fill Latest Scores" in document
+
+### Integration Points
+- The penalty shootout section (from `BackofficeGameResultEditControls`) appears automatically when `isPlayoffGame && homeScore === awayScore`. For wizard tests using `BackofficeGameResultEditControls` directly: no need to re-test this — it's the existing component's behavior. Wizard tests just verify the `isPlayoffGame` prop is set correctly from `!!game.playoffStage`.
+- `saveGameResults` (existing) handles the `assertPublishable` guard — wizard catches the thrown error and shows it via `saveError` state → `BackofficeGameResultEditControls`'s `error` prop.
+
+---
+
+## Validation
+
+1. Log in as admin user
+2. Open avatar menu — confirm "Fill Latest Scores" appears (hidden for non-admins)
+3. With no recent unscored games: open wizard → confirm empty state
+4. With a recent unscored group-stage game: open wizard → enter scores → Save & Publish → confirm game shows as published in backoffice
+5. With a recent unscored playoff game with tied scores: open wizard → enter tied scores → confirm penalty score inputs appear → enter penalty scores → Save & Publish → confirm published
+6. Try publishing tied playoff game without penalty scores → confirm error shown (thrown by `assertPublishable`)
+7. Skip a game → confirm wizard advances without publishing
+8. Verify progress counter updates correctly
+9. Switch locale to English → confirm all wizard text is in English
+10. Switch locale to Spanish → confirm all wizard text is in Spanish
+11. Test on mobile viewport → confirm full-screen dialog
+12. Test on desktop viewport → confirm centered dialog
+
+---
+
+## Open Questions / Assumptions
+
+- **Cross-tournament scope**: Wizard shows games from ALL tournaments (no filter on tournament active status), relying on the 24h time window to limit results. Acceptable for v1.
+- **Team names**: Uses `applyLocalization` on teams in the server action; names are display-ready when passed to dialog.
+- **Score recalculation latency**: Each `saveAndPublishSingleGameResult` triggers `calculateGameScores` — expected slight delay per game, same as backoffice flow.
+- **`is_active` on tournaments**: Not filtering by active status since field existence is uncertain. The 24h window provides natural scope.

--- a/plans/STORY-474-plan.md
+++ b/plans/STORY-474-plan.md
@@ -485,6 +485,21 @@ Setup: import `testFactories`, `setupTestMocks`, mock `getRecentUnscoredGames` a
 
 ---
 
+## Implementation Amendments
+
+### Amendment 1: Full Recalculation Pipeline Missing from saveAndPublishSingleGameResult
+**Date:** 2026-06-15
+**Reason:** During Vercel Preview testing, it was discovered that `saveAndPublishSingleGameResult` only called `saveGameResults` — it was missing the full downstream pipeline. User prediction scores, group standings, playoff bracket slots, and qualified team scores were NOT updated after publishing via the wizard.
+**Change:** Extracted a new shared server action `saveGamesAndRecalculate(games, tournamentId, locale)` that:
+- Handles group vs playoff branching internally using `games.find(g => g.group)`
+- For group games: calls `findGamesInGroup(groupId, true, false)` (published only), `findTeamsInGroup`, `findTournamentById`, `calculateAndStoreGroupPosition`, `calculateAndSavePlayoffGamesForTournament` (first-stage R16 slots only), `calculateAndStoreQualifiedTeamsScores`
+- For all games: calls `calculateGameScores(false, false, locale)`
+- Updated `saveAndPublishSingleGameResult` to delegate to `saveGamesAndRecalculate` instead of `saveGameResults`
+- Updated `group-backoffice-tab.tsx` to call `saveGamesAndRecalculate` instead of sequencing 5 actions manually
+- Tests expanded: new `saveGamesAndRecalculate` describe block (5 tests); `saveAndPublishSingleGameResult` expanded to 4 tests covering group/playoff branching
+
+---
+
 ## Open Questions / Assumptions
 
 - **Cross-tournament scope**: Wizard shows games from ALL tournaments (no filter on tournament active status), relying on the 24h time window to limit results. Acceptable for v1.

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -51,6 +51,7 @@ const spanishTranslations: Record<string, any> = {
   awards: require('./locales/es/awards.json'),
   'qualified-teams': require('./locales/es/qualified-teams.json'),
   tournament: require('./locales/es/tournament.json'),
+  backoffice: require('./locales/es/backoffice.json'),
   // Add other namespaces as needed
 };
 
@@ -64,6 +65,7 @@ const englishTranslations: Record<string, any> = {
   tournament: require('./locales/en/tournament.json'),
   groups: require('./locales/en/groups.json'),
   common: require('./locales/en/common.json'),
+  backoffice: require('./locales/en/backoffice.json'),
   // Add other namespaces as needed
 };
 


### PR DESCRIPTION
## Plan

Implementation plan for story #474.

Fixes #474

## Summary
- New DB query: `findRecentUnscoredGames` for cross-tournament unscored games within 24h window
- New server actions: `getRecentUnscoredGames` and `saveAndPublishSingleGameResult`
- New component: `QuickScoreWizardDialog` (reuses `BackofficeGameResultEditControls`)
- Avatar menu: admin-only "Fill Latest Scores" menu item
- i18n: add `wizard` keys to `backoffice.json` (en + es), register namespace in `i18n/request.ts`